### PR TITLE
Fix a crash when receiving a push notification with null sound

### DIFF
--- a/Parse/PFPush.m
+++ b/Parse/PFPush.m
@@ -415,7 +415,7 @@ static Class _pushInternalUtilClass = nil;
 
     NSString *soundName = aps[@"sound"];
 
-    if (soundName.length == 0 || [soundName isEqualToString:@"default"]) {
+    if ((id)soundName == [NSNull null] || soundName.length == 0 || [soundName isEqualToString:@"default"]) {
         [[self pushInternalUtilClass] playVibrate];
     } else {
         [[self pushInternalUtilClass] playAudioWithName:soundName];

--- a/Tests/Unit/PushMobileTests.m
+++ b/Tests/Unit/PushMobileTests.m
@@ -54,4 +54,21 @@
     OCMVerifyAll(mockedUtils);
 }
 
+- (void)testHandlePushWithNullSound {
+    id mockedUtils = PFStrictProtocolMock(@protocol(PFPushInternalUtils));
+    OCMExpect([mockedUtils showAlertViewWithTitle:[OCMArg isNil] message:@"hello"]);
+    OCMExpect([mockedUtils playVibrate]);
+
+    // NOTE: Async parse preload step may call this selector.
+    // Don't epxect it because it doesn't ALWAYs get to this point before returning from the method.
+    OCMStub([mockedUtils getDeviceTokenFromKeychain]).andReturn(nil);
+
+    [PFPush setPushInternalUtilClass:mockedUtils];
+    [PFPush handlePush:@{ @"aps" : @{@"alert" : @"hello", @"sound": [NSNull null]} }];
+
+    OCMVerifyAll(mockedUtils);
+
+    [PFPush setPushInternalUtilClass:nil];
+}
+
 @end


### PR DESCRIPTION
Previously there was a crash when receiving a push notification which had its sound set to `null`. This resulted in `soundName` being `NSNull` and crashed when checking for its length.