### PR TITLE
Store original network error under NSUnderlyingError key.

### DIFF
--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionFileDownloadTaskDelegate.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionFileDownloadTaskDelegate.m
@@ -82,6 +82,7 @@
         errorDictionary[@"code"] = @(kPFErrorConnectionFailed);
         errorDictionary[@"error"] = [self.error localizedDescription];
         errorDictionary[@"originalError"] = self.error;
+        errorDictionary[NSUnderlyingErrorKey] = self.error;
         errorDictionary[@"temporary"] = @(self.response.statusCode >= 500 || self.response.statusCode < 400);
         self.error = [PFErrorUtilities errorFromResult:errorDictionary];
     }

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionJSONDataTaskDelegate.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionJSONDataTaskDelegate.m
@@ -54,6 +54,7 @@
         errorDictionary[@"code"] = @(kPFErrorConnectionFailed);
         errorDictionary[@"error"] = [self.error localizedDescription];
         errorDictionary[@"originalError"] = self.error;
+        errorDictionary[NSUnderlyingErrorKey] = self.error;
         errorDictionary[@"temporary"] = @(self.response.statusCode >= 500 || self.response.statusCode < 400);
         self.error = [PFErrorUtilities errorFromResult:errorDictionary];
         [super _taskDidFinish];

--- a/Tests/Unit/URLSessionDataTaskDelegateTests.m
+++ b/Tests/Unit/URLSessionDataTaskDelegateTests.m
@@ -130,6 +130,7 @@ totalBytesExpectedToSend:5];
     [delegate URLSession:mockedSession task:mockedTask didCompleteWithError:expectedError];
 
     XCTAssertEqualObjects(delegate.resultTask.error.userInfo[@"originalError"], expectedError);
+    XCTAssertEqualObjects(delegate.resultTask.error.userInfo[NSUnderlyingErrorKey], expectedError);
 }
 
 - (void)testJSONError {

--- a/Tests/Unit/URLSessionTests.m
+++ b/Tests/Unit/URLSessionTests.m
@@ -244,6 +244,7 @@
     [[session performDataURLRequestAsync:mockedURLRequest forCommand:mockedCommand cancellationToken:nil]
      continueWithBlock:^id(BFTask *task) {
          XCTAssertEqualObjects(expectedError, task.error.userInfo[@"originalError"]);
+         XCTAssertEqualObjects(expectedError, task.error.userInfo[NSUnderlyingErrorKey]);
          [expectation fulfill];
          return nil;
      }];

--- a/Tests/Unit/URLSessionUploadTaskDelegateTests.m
+++ b/Tests/Unit/URLSessionUploadTaskDelegateTests.m
@@ -205,6 +205,7 @@ totalBytesExpectedToSend:5];
     [delegate URLSession:mockedSession task:mockedTask didCompleteWithError:expectedError];
 
     XCTAssertEqualObjects(delegate.resultTask.error.userInfo[@"originalError"], expectedError);
+    XCTAssertEqualObjects(delegate.resultTask.error.userInfo[NSUnderlyingErrorKey], expectedError);
 }
 
 - (void)testJSONError {


### PR DESCRIPTION
Still store in `originalError`, but add it to `NSUnderlyingErrorKey` as well.