### PR TITLE
Cleanup test assertions descriptions.

### DIFF
--- a/Tests/Unit/InstallationUnitTests.m
+++ b/Tests/Unit/InstallationUnitTests.m
@@ -27,24 +27,18 @@
     PFInstallation *installation = [PFInstallation currentInstallation];
     installation.deviceToken = @"11433856eed2f1285fb3aa11136718c1198ed5647875096952c66bf8cb976306";
 
-    PFAssertThrowsInvalidArgumentException(installation[@"deviceType"] = @"android",
-                                           @"Should throw an exception for trying to change deviceType.");
-    PFAssertThrowsInvalidArgumentException(installation[@"installationId"] = @"a"
-                                           @"Should throw an exception for trying to change installationId.");
-    PFAssertThrowsInvalidArgumentException(installation[@"localeIdentifier"] = @"a"
-                                           @"Should throw an exception for trying to change installationId.");
+    PFAssertThrowsInvalidArgumentException(installation[@"deviceType"] = @"android");
+    PFAssertThrowsInvalidArgumentException(installation[@"installationId"] = @"a");
+    PFAssertThrowsInvalidArgumentException(installation[@"localeIdentifier"] = @"a");
 }
 
 - (void)testInstallationImmutableFieldsCannotBeDeleted {
     PFInstallation *installation = [PFInstallation currentInstallation];
     installation.deviceToken = @"11433856eed2f1285fb3aa11136718c1198ed5647875096952c66bf8cb976306";
 
-    PFAssertThrowsInvalidArgumentException([installation removeObjectForKey:@"deviceType"],
-                                           @"Should throw an exception for trying to delete deviceType.");
-    PFAssertThrowsInvalidArgumentException([installation removeObjectForKey:@"installationId"],
-                                           @"Should throw an exception for trying to delete installationId.");
-    PFAssertThrowsInvalidArgumentException([installation removeObjectForKey:@"localeIdentifier"],
-                                           @"Should throw an exception for trying to delete installationId.");
+    PFAssertThrowsInvalidArgumentException([installation removeObjectForKey:@"deviceType"]);
+    PFAssertThrowsInvalidArgumentException([installation removeObjectForKey:@"installationId"]);
+    PFAssertThrowsInvalidArgumentException([installation removeObjectForKey:@"localeIdentifier"]);
 }
 
 @end

--- a/Tests/Unit/ObjectSubclassTests.m
+++ b/Tests/Unit/ObjectSubclassTests.m
@@ -147,12 +147,12 @@
 
 - (void)testSubclassConstructor {
     PFObject *theFlash = [PFObject objectWithClassName:@"Person"];
-    XCTAssertFalse([theFlash isKindOfClass:[TheFlash class]], @"We're living the past.");
+    XCTAssertFalse([theFlash isKindOfClass:[TheFlash class]]);
 
     [TheFlash registerSubclass];
     theFlash = [PFObject objectWithClassName:@"Person"];
-    XCTAssertTrue([theFlash isKindOfClass:[TheFlash class]], @"In the future, everyone is the Flash.");
-    XCTAssertEqualObjects(@"The Flash", [(TheFlash*)theFlash flashName], @"The Flash's name should be The Flash, duh.");
+    XCTAssertTrue([theFlash isKindOfClass:[TheFlash class]]);
+    XCTAssertEqualObjects(@"The Flash", [(TheFlash*)theFlash flashName]);
 }
 
 - (void)testSubclassesMustHaveTheirParentsParseClassName {
@@ -162,8 +162,7 @@
 
 - (void)testDirtyPointerDetection {
     [ClassWithDirtyingConstructor registerSubclass];
-    XCTAssertThrows([ClassWithDirtyingConstructor objectWithoutDataWithObjectId:@"NotUsed"],
-                    @"ClassWithDirtyingConstructor has an invalid init method");
+    XCTAssertThrows([ClassWithDirtyingConstructor objectWithoutDataWithObjectId:@"NotUsed"]);
     [PFObject unregisterSubclass:[ClassWithDirtyingConstructor class]];
 }
 

--- a/Tests/Unit/ObjectUnitTests.m
+++ b/Tests/Unit/ObjectUnitTests.m
@@ -69,20 +69,19 @@
                                        @"object" : object };
     PFObject *object2 = [PFObject objectWithClassName:@"Test" dictionary:validDictionary];
     XCTAssertNotNil(object2);
-    XCTAssertEqualObjects(string, object2[@"string"], @"'string' should be set via constructor");
-    XCTAssertEqualObjects(number, object2[@"number"], @"'number' should be set via constructor");
-    XCTAssertEqualObjects(date, object2[@"date"], @"'date' should be set via constructor");
-    XCTAssertEqualObjects(object, object2[@"object"], @"'object' should be set via constructor");
-    XCTAssertEqualObjects(null, object2[@"null"], @"'null' should be set via constructor");
-    XCTAssertEqualObjects(data, object2[@"data"], @"'data' should be set via constructor");
+    XCTAssertEqualObjects(string, object2[@"string"]);
+    XCTAssertEqualObjects(number, object2[@"number"]);
+    XCTAssertEqualObjects(date, object2[@"date"]);
+    XCTAssertEqualObjects(object, object2[@"object"]);
+    XCTAssertEqualObjects(null, object2[@"null"]);
+    XCTAssertEqualObjects(data, object2[@"data"]);
 
     validDictionary = @{ @"array" : @[ object, object2 ],
                          @"dictionary" : @{@"bar" : date, @"score" : number} };
     PFObject *object3 = [PFObject objectWithClassName:@"Stuff" dictionary:validDictionary];
     XCTAssertNotNil(object3);
-    XCTAssertEqualObjects(validDictionary[@"array"], object3[@"array"], @"'array' should be set via constructor");
-    XCTAssertEqualObjects(validDictionary[@"dictionary"], object3[@"dictionary"],
-                         @"'dictionary' should be set via constructor");
+    XCTAssertEqualObjects(validDictionary[@"array"], object3[@"array"]);
+    XCTAssertEqualObjects(validDictionary[@"dictionary"], object3[@"dictionary"]);
 
     // Dictionary constructor relise on constraints enforced by PFObject -setObject:forKey:
     NSDictionary *invalidDictionary = @{ @"1" : @"2",

--- a/Tests/Unit/ParseModuleUnitTests.m
+++ b/Tests/Unit/ParseModuleUnitTests.m
@@ -41,7 +41,7 @@
     // Spin the run loop, as the delegate messages are being called on the main thread
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
 
-    XCTAssertTrue(module.didInitializeCalled, @"Did initialize method should be called on a module.");
+    XCTAssertTrue(module.didInitializeCalled);
 }
 
 - (void)testWeakModuleReference {
@@ -53,7 +53,7 @@
     }
 
     [collection parseDidInitializeWithApplicationId:nil clientKey:nil];
-    XCTAssertEqual([collection modulesCount], 0, @"Module should be removed from the collection.");
+    XCTAssertEqual([collection modulesCount], 0);
 }
 
 - (void)testModuleRemove {
@@ -69,7 +69,7 @@
 
     XCTAssertTrue([collection containsModule:moduleB]);
     XCTAssertFalse([collection containsModule:moduleA]);
-    XCTAssertEqual([collection modulesCount], 1, @"Module should be removed from the collection");
+    XCTAssertEqual([collection modulesCount], 1);
 }
 
 - (void)testNilModule {

--- a/Tests/Unit/UserUnitTests.m
+++ b/Tests/Unit/UserUnitTests.m
@@ -21,8 +21,7 @@
 ///--------------------------------------
 
 - (void)testConstructorsClassNameValidation {
-    PFAssertThrowsInvalidArgumentException([[PFUser alloc] initWithClassName:@"notuserclass"],
-                                           @"Should throw an exception for invalid classname");
+    PFAssertThrowsInvalidArgumentException([[PFUser alloc] initWithClassName:@"notuserclass"]);
 }
 
 - (void)testImmutableFieldsCannotBeChanged {


### PR DESCRIPTION
Most of these have low signal, compared to simply looking at the log from the assertion or re-running the test, so remove them.
InstallationUnitTests ones had wrong descriptions there.