### PR TITLE
Explicitly import Bolts/BFTask to eliminate the need for explicit Bolts import in Swift projects.

### DIFF
--- a/Parse/PFAnalytics.h
+++ b/Parse/PFAnalytics.h
@@ -9,11 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFConstants.h>
 
 PF_ASSUME_NONNULL_BEGIN
-
-@class BFTask;
 
 /*!
  `PFAnalytics` provides an interface to Parse's logging and analytics backend.

--- a/Parse/PFAnonymousUtils.h
+++ b/Parse/PFAnonymousUtils.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFConstants.h>
 #import <Parse/PFUser.h>
 

--- a/Parse/PFCloud.h
+++ b/Parse/PFCloud.h
@@ -9,11 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFConstants.h>
 
 PF_ASSUME_NONNULL_BEGIN
-
-@class BFTask;
 
 /*!
  The `PFCloud` class provides methods for interacting with Parse Cloud Functions.

--- a/Parse/PFConfig.h
+++ b/Parse/PFConfig.h
@@ -9,11 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFNullability.h>
 
 PF_ASSUME_NONNULL_BEGIN
 
-@class BFTask;
 @class PFConfig;
 
 typedef void(^PFConfigResultBlock)(PFConfig *PF_NULLABLE_S config, NSError *PF_NULLABLE_S error);

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -9,11 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFConstants.h>
 
 PF_ASSUME_NONNULL_BEGIN
-
-@class BFTask;
 
 /*!
  `PFFile` representes a file of binary data stored on the Parse servers.

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -9,13 +9,14 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFACL.h>
 #import <Parse/PFConstants.h>
 
 PF_ASSUME_NONNULL_BEGIN
 
 @protocol PFSubclassing;
-@class BFTask;
 @class PFRelation;
 
 /*!

--- a/Parse/PFProduct.h
+++ b/Parse/PFProduct.h
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import <Foundation/Foundation.h>
+
 #import <Parse/PFFile.h>
 #import <Parse/PFNullability.h>
 #import <Parse/PFObject.h>

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -9,9 +9,10 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFConstants.h>
 
-@class BFTask;
 @class PFQuery;
 
 /*!

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -9,14 +9,14 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFConstants.h>
 #import <Parse/PFGeoPoint.h>
 #import <Parse/PFObject.h>
 #import <Parse/PFUser.h>
 
 PF_ASSUME_NONNULL_BEGIN
-
-@class BFTask;
 
 /*!
  The `PFQuery` class defines a query that is used to query for <PFObject>s.

--- a/Parse/PFSession.h
+++ b/Parse/PFSession.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFObject.h>
 #import <Parse/PFSubclassing.h>
 

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bolts/BFTask.h>
+
 #import <Parse/PFConstants.h>
 #import <Parse/PFObject.h>
 #import <Parse/PFSubclassing.h>

--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
@@ -9,7 +9,6 @@
 
 import Cocoa
 
-import Bolts
 import Parse
 
 @NSApplicationMain

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
@@ -9,7 +9,6 @@
 
 import UIKit
 
-import Bolts
 import Parse
 
 // If you want to use any of the UI components, uncomment this line


### PR DESCRIPTION
This is needed to eliminate the need for explicit import of Bolts in Swift projects.
As soon as we import BFTask in our headers - all the APIs that return a BFTask magically become visible to Swift projects without the need for importing Bolts.