### PR TITLE
Add better subclassing support to PFGeoPoint.

### DIFF
--- a/Parse/Internal/PFGeoPointPrivate.h
+++ b/Parse/Internal/PFGeoPointPrivate.h
@@ -28,6 +28,6 @@ extern const double EARTH_RADIUS_KILOMETERS;
 /*!
  Creates an GeoPoint from its encoded format.
  */
-+ (PFGeoPoint *)geoPointWithDictionary:(NSDictionary *)dictionary;
++ (instancetype)geoPointWithDictionary:(NSDictionary *)dictionary;
 
 @end

--- a/Parse/PFGeoPoint.h
+++ b/Parse/PFGeoPoint.h
@@ -35,7 +35,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *PF_NULLABLE_S geoPoint, NSError
 
  @returns Returns a new `PFGeoPoint`.
  */
-+ (PFGeoPoint *)geoPoint;
++ (instancetype)geoPoint;
 
 /*!
  @abstract Creates a new `PFGeoPoint` object for the given `CLLocation`, set to the location's coordinates.
@@ -44,7 +44,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *PF_NULLABLE_S geoPoint, NSError
 
  @returns Returns a new PFGeoPoint at specified location.
  */
-+ (PFGeoPoint *)geoPointWithLocation:(PF_NULLABLE CLLocation *)location;
++ (instancetype)geoPointWithLocation:(PF_NULLABLE CLLocation *)location;
 
 /*!
  @abstract Create a new `PFGeoPoint` object with the specified latitude and longitude.
@@ -54,7 +54,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *PF_NULLABLE_S geoPoint, NSError
 
  @returns New point object with specified latitude and longitude.
  */
-+ (PFGeoPoint *)geoPointWithLatitude:(double)latitude longitude:(double)longitude;
++ (instancetype)geoPointWithLatitude:(double)latitude longitude:(double)longitude;
 
 /*!
  @abstract Fetches the current device location and executes a block with a new `PFGeoPoint` object.

--- a/Parse/PFGeoPoint.m
+++ b/Parse/PFGeoPoint.m
@@ -26,17 +26,17 @@ const double EARTH_RADIUS_KILOMETERS = 6371.0;
 #pragma mark - Init
 ///--------------------------------------
 
-+ (PFGeoPoint *)geoPoint {
++ (instancetype)geoPoint {
     return [[self alloc] init];
 }
 
-+ (PFGeoPoint *)geoPointWithLocation:(CLLocation *)location {
++ (instancetype)geoPointWithLocation:(CLLocation *)location {
     return [self geoPointWithLatitude:location.coordinate.latitude
                             longitude:location.coordinate.longitude];
 }
 
-+ (PFGeoPoint *)geoPointWithLatitude:(double)latitude longitude:(double)longitude {
-    PFGeoPoint *gpt = [PFGeoPoint geoPoint];
++ (instancetype)geoPointWithLatitude:(double)latitude longitude:(double)longitude {
+    PFGeoPoint *gpt = [self geoPoint];
     gpt.latitude = latitude;
     gpt.longitude = longitude;
     return gpt;
@@ -111,7 +111,7 @@ static NSString *const PFGeoPointCodingLongitudeKey = @"longitude";
              };
 }
 
-+ (PFGeoPoint *)geoPointWithDictionary:(NSDictionary *)dictionary {
++ (instancetype)geoPointWithDictionary:(NSDictionary *)dictionary {
     return [[self alloc] initWithEncodedDictionary:dictionary];
 }
 


### PR DESCRIPTION
Use `instancetype` instead of returning PFGeoPoint.