### PR TITLE
Fixed PFAlertView cancel button handling logic.

### DIFF
--- a/Parse/Internal/PFAlertView.m
+++ b/Parse/Internal/PFAlertView.m
@@ -35,8 +35,12 @@
 
         void (^alertActionHandler)(UIAlertAction *) = [^(UIAlertAction *action){
             // This block intentionally retains alertController, and releases it afterwards.
-            NSUInteger index = [alertController.actions indexOfObject:action];
-            completion(index - 1);
+            if (action.style == UIAlertActionStyleCancel) {
+                completion(NSNotFound);
+            } else {
+                NSUInteger index = [alertController.actions indexOfObject:action];
+                completion(index - 1);
+            }
             alertController = nil;
         } copy];
 
@@ -85,7 +89,11 @@
 
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
     if (self.completion) {
-        self.completion(buttonIndex - alertView.firstOtherButtonIndex);
+        if (buttonIndex == alertView.cancelButtonIndex) {
+            self.completion(NSNotFound);
+        } else {
+            self.completion(buttonIndex - 1);
+        }
     }
 }
 

--- a/Tests/Unit/AlertViewTests.m
+++ b/Tests/Unit/AlertViewTests.m
@@ -102,7 +102,7 @@
                   cancelButtonTitle:@"Cancel"
                   otherButtonTitles:@[ @"Yes", @"No" ]
                          completion:^(NSUInteger selectedOtherButtonIndex) {
-                             XCTAssertEqual(selectedOtherButtonIndex, -1);
+                             XCTAssertEqual(selectedOtherButtonIndex, NSNotFound);
 
                              [expectation fulfill];
                          }];
@@ -147,7 +147,7 @@
             [delegate alertView:self clickedButtonAtIndex:0];
         });
 
-        OCMStub([mockedAlertView firstOtherButtonIndex]).andReturn(1);
+        OCMStub([mockedAlertView cancelButtonIndex]).andReturn(0);
 
         XCTestExpectation *expectation = [self currentSelectorTestExpectation];
         [PFAlertView showAlertWithTitle:@"Title"
@@ -155,7 +155,7 @@
                       cancelButtonTitle:@"Cancel"
                       otherButtonTitles:@[ @"Yes", @"No" ]
                              completion:^(NSUInteger selectedOtherButtonIndex) {
-                                 XCTAssertEqual(selectedOtherButtonIndex, -1);
+                                 XCTAssertEqual(selectedOtherButtonIndex, NSNotFound);
 
                                  [expectation fulfill];
                              }];


### PR DESCRIPTION
This logic doesn't handle 32/64 bit conversions, so just hard-code it to use style and cancelButtonIndex.
It's goping to be waaay safer this way.