### PR TITLE
Fixed presentation of PFAlertView when rootViewController has presentedViewController.

### DIFF
--- a/Parse/Internal/PFAlertView.m
+++ b/Parse/Internal/PFAlertView.m
@@ -52,6 +52,9 @@
 
         UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
         UIViewController *viewController = keyWindow.rootViewController;
+        while (viewController.presentedViewController) {
+            viewController = viewController.presentedViewController;
+        }
 
         [viewController presentViewController:alertController animated:YES completion:nil];
     } else {

--- a/Tests/Unit/AlertViewTests.m
+++ b/Tests/Unit/AlertViewTests.m
@@ -44,6 +44,7 @@
     id mockedApplication = PFStrictClassMock([UIApplication class]);
     UIWindow *mockedWindow = PFStrictClassMock([UIWindow class]);
     UIViewController *mockedViewController = PFStrictClassMock([UIViewController class]);
+    OCMStub(mockedViewController.presentedViewController).andReturn(nil);
 
     // Using .andReturn() here will result in a retain cycle, which will cause our mocked shared application to
     // persist across tests.


### PR DESCRIPTION
Fixes #71
Whenever a rootViewController has presented view controller - we fail to acknowledge it and present our UIAlertController on the wrong view controller, which usually leads to no presentation at all.