### PR TITLE
Added NSNotifications being posted on every network request being sent/finished.

### DIFF
--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.h
@@ -33,3 +33,27 @@ extern NSString *const PFCommandHeaderNameSessionToken;
 ///--------------------------------------
 
 extern NSString *const PFCommandParameterNameMethodOverride;
+
+///--------------------------------------
+/// @name Notifications
+///--------------------------------------
+
+/*!
+ @abstract The name of the notification that is going to be sent before any URL request is sent.
+ */
+extern NSString *const PFCommandRunnerWillSendURLRequestNotification;
+
+/*!
+ @abstract The name of the notification that is going to be sent after any URL response is received.
+ */
+extern NSString *const PFCommandRunnerDidReceiveURLResponseNotification;
+
+/*!
+ @abstract The key of request(NSURLRequest) in the userInfo dictionary of a notification.
+ */
+extern NSString *const PFCommandRunnerNotificationURLRequestUserInfoKey;
+
+/*!
+ @abstract The key of response(NSHTTPURLResponse) in the userInfo dictionary of a notification.
+ */
+extern NSString *const PFCommandRunnerNotificationURLResponseUserInfoKey;

--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.m
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.m
@@ -21,3 +21,12 @@ NSString *const PFCommandHeaderNameOSVersion = @"X-Parse-OS-Version";
 NSString *const PFCommandHeaderNameSessionToken = @"X-Parse-Session-Token";
 
 NSString *const PFCommandParameterNameMethodOverride = @"_method";
+
+///--------------------------------------
+#pragma mark - Notifications
+///--------------------------------------
+
+NSString *const PFCommandRunnerWillSendURLRequestNotification = @"PFCommandRunnerWillSendURLRequestNotification";
+NSString *const PFCommandRunnerDidReceiveURLResponseNotification = @"PFCommandRunnerDidReceiveURLResponseNotification";
+NSString *const PFCommandRunnerNotificationURLRequestUserInfoKey = @"PFCommandRunnerNotificationURLRequestUserInfoKey";
+NSString *const PFCommandRunnerNotificationURLResponseUserInfoKey = @"PFCommandRunnerNotificationURLResponseUserInfoKey";

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner_Private.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner_Private.h
@@ -21,7 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                            session:(PFURLSession *)session
-                requestConstructor:(PFCommandURLRequestConstructor *)requestConstructor NS_DESIGNATED_INITIALIZER;
+                requestConstructor:(PFCommandURLRequestConstructor *)requestConstructor
+                notificationCenter:(NSNotificationCenter *)notificationCenter NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
@@ -17,15 +17,29 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class PFURLSession;
+
+@protocol PFURLSessionDelegate <NSObject>
+
+- (void)urlSession:(PFURLSession *)session willPerformURLRequest:(NSURLRequest *)request;
+- (void)urlSession:(PFURLSession *)session didPerformURLRequest:(NSURLRequest *)request withURLResponse:(nullable NSURLResponse *)response;
+
+@end
+
 @interface PFURLSession : NSObject
+
+@property (nonatomic, weak, readonly) id<PFURLSessionDelegate> delegate;
 
 ///--------------------------------------
 /// @name Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
-+ (instancetype)sessionWithConfiguration:(NSURLSessionConfiguration *)configuration;
+- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
+                             delegate:(id<PFURLSessionDelegate>)delegate NS_DESIGNATED_INITIALIZER;
+
++ (instancetype)sessionWithConfiguration:(NSURLSessionConfiguration *)configuration
+                                delegate:(id<PFURLSessionDelegate>)delegate;
 
 ///--------------------------------------
 /// @name Teardown
@@ -51,7 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
                                   toFileAtPath:(NSString *)filePath
                          withCancellationToken:(nullable BFCancellationToken *)cancellationToken
                                  progressBlock:(nullable PFProgressBlock)progressBlock;
-
 
 @end
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession_Private.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession_Private.h
@@ -13,9 +13,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PFURLSession ()
 
-- (instancetype)initWithURLSession:(NSURLSession *)session NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithURLSession:(NSURLSession *)session
+                          delegate:(id<PFURLSessionDelegate>)delegate NS_DESIGNATED_INITIALIZER;
 
-+ (instancetype)sessionWithURLSession:(NSURLSession *)session;
++ (instancetype)sessionWithURLSession:(NSURLSession *)session
+                             delegate:(id<PFURLSessionDelegate>)delegate;
 
 @end
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSURLSessionDataTask *dataTask;
 @property (nonatomic, strong, readonly) BFTask *resultTask;
 
+@property (nonatomic, strong, readonly) NSHTTPURLResponse *response;
+
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initForDataTask:(NSURLSessionDataTask *)dataTask
           withCancellationToken:(nullable BFCancellationToken *)cancellationToken NS_DESIGNATED_INITIALIZER;

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate_Private.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate_Private.h
@@ -13,8 +13,6 @@
 
 @property (nonatomic, strong, readonly) dispatch_queue_t dataQueue;
 
-@property (nonatomic, strong, readonly) NSHTTPURLResponse *response;
-
 /*!
  @abstract Defaults to to-memory output stream if not overwritten.
  */

--- a/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -54,6 +54,7 @@
     id mockedDataSource = PFStrictProtocolMock(@protocol(PFInstallationIdentifierStoreProvider));
     id mockedSession = PFStrictClassMock([PFURLSession class]);
     id mockedRequestConstructor = PFStrictClassMock([PFCommandURLRequestConstructor class]);
+    id mockedNotificationCenter = PFStrictClassMock([NSNotificationCenter class]);
 
     id mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     id mockedCommandResult = PFStrictClassMock([PFCommandResult class]);
@@ -71,7 +72,8 @@
 
     PFURLSessionCommandRunner *commandRunner = [[PFURLSessionCommandRunner alloc] initWithDataSource:mockedDataSource
                                                                                              session:mockedSession
-                                                                                  requestConstructor:mockedRequestConstructor];
+                                                                                  requestConstructor:mockedRequestConstructor
+                                                                                  notificationCenter:mockedNotificationCenter];
 
     XCTestExpectation *expecatation = [self currentSelectorTestExpectation];
     [[commandRunner runCommandAsync:mockedCommand withOptions:0] continueWithBlock:^id(BFTask *task) {
@@ -89,6 +91,7 @@
     id mockedDataSource = PFStrictProtocolMock(@protocol(PFInstallationIdentifierStoreProvider));
     id mockedSession = PFStrictClassMock([PFURLSession class]);
     id mockedRequestConstructor = PFStrictClassMock([PFCommandURLRequestConstructor class]);
+    id mockedNotificationCenter = PFStrictClassMock([NSNotificationCenter class]);
 
     id mockedCommand = PFStrictClassMock([PFRESTCommand class]);
 
@@ -96,7 +99,8 @@
 
     PFURLSessionCommandRunner *commandRunner = [[PFURLSessionCommandRunner alloc] initWithDataSource:mockedDataSource
                                                                                              session:mockedSession
-                                                                                  requestConstructor:mockedRequestConstructor];
+                                                                                  requestConstructor:mockedRequestConstructor
+                                                                                  notificationCenter:mockedNotificationCenter];
 
     BFCancellationTokenSource *cancellationToken = [BFCancellationTokenSource cancellationTokenSource];
     [cancellationToken cancel];
@@ -117,6 +121,7 @@
     id mockedDataSource = PFStrictProtocolMock(@protocol(PFInstallationIdentifierStoreProvider));
     id mockedSession = PFStrictClassMock([PFURLSession class]);
     id mockedRequestConstructor = PFStrictClassMock([PFCommandURLRequestConstructor class]);
+    id mockedNotificationCenter = PFStrictClassMock([NSNotificationCenter class]);
 
     id mockedCommand = PFStrictClassMock([PFRESTCommand class]);
 
@@ -140,7 +145,8 @@
 
     PFURLSessionCommandRunner *commandRunner = [[PFURLSessionCommandRunner alloc] initWithDataSource:mockedDataSource
                                                                                              session:mockedSession
-                                                                                  requestConstructor:mockedRequestConstructor];
+                                                                                  requestConstructor:mockedRequestConstructor
+                                                                                  notificationCenter:mockedNotificationCenter];
     commandRunner.initialRetryDelay = DBL_MIN; // Lets not needlessly sleep here.
 
     XCTestExpectation *expecatation = [self currentSelectorTestExpectation];
@@ -162,6 +168,7 @@
     id mockedDataSource = PFStrictProtocolMock(@protocol(PFInstallationIdentifierStoreProvider));
     id mockedSession = PFStrictClassMock([PFURLSession class]);
     id mockedRequestConstructor = PFStrictClassMock([PFCommandURLRequestConstructor class]);
+    id mockedNotificationCenter = PFStrictClassMock([NSNotificationCenter class]);
 
     id mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     id mockedCommandResult = PFStrictClassMock([PFCommandResult class]);
@@ -191,7 +198,8 @@
 
     PFURLSessionCommandRunner *commandRunner = [[PFURLSessionCommandRunner alloc] initWithDataSource:mockedDataSource
                                                                                              session:mockedSession
-                                                                                  requestConstructor:mockedRequestConstructor];
+                                                                                  requestConstructor:mockedRequestConstructor
+                                                                                  notificationCenter:mockedNotificationCenter];
 
     XCTestExpectation *expecatation = [self currentSelectorTestExpectation];
     [[commandRunner runFileUploadCommandAsync:mockedCommand
@@ -213,6 +221,7 @@
     id mockedDataSource = PFStrictProtocolMock(@protocol(PFInstallationIdentifierStoreProvider));
     id mockedSession = PFStrictClassMock([PFURLSession class]);
     id mockedRequestConstructor = PFStrictClassMock([PFCommandURLRequestConstructor class]);
+    id mockedNotificationCenter = PFStrictClassMock([NSNotificationCenter class]);
 
     id mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     id mockedCommandResult = PFStrictClassMock([PFCommandResult class]);
@@ -230,7 +239,8 @@
 
     PFURLSessionCommandRunner *commandRunner = [[PFURLSessionCommandRunner alloc] initWithDataSource:mockedDataSource
                                                                                              session:mockedSession
-                                                                                  requestConstructor:mockedRequestConstructor];
+                                                                                  requestConstructor:mockedRequestConstructor
+                                                                                  notificationCenter:mockedNotificationCenter];
 
     XCTestExpectation *expecatation = [self currentSelectorTestExpectation];
     [[commandRunner runCommandAsync:mockedCommand withOptions:0] continueWithBlock:^id(BFTask *task) {


### PR DESCRIPTION
This is required #74
- Added delegate to PFURLSession
- Updated Tests
- Added NSNotification posting whenever the request will be sent/finished.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/parseplatform/parse-sdk-ios-osx/82)
<!-- Reviewable:end -->
