### PR TITLE
Add automatic management of Network Activity Indicator on iOS.

### DIFF
--- a/Parse/PFNetworkActivityIndicatorManager.m
+++ b/Parse/PFNetworkActivityIndicatorManager.m
@@ -10,6 +10,7 @@
 #import "PFNetworkActivityIndicatorManager.h"
 
 #import "PFApplication.h"
+#import "PFCommandRunningConstants.h"
 
 static NSTimeInterval const PFNetworkActivityIndicatorVisibilityDelay = 0.17;
 
@@ -49,10 +50,20 @@ static NSTimeInterval const PFNetworkActivityIndicatorVisibilityDelay = 0.17;
     _networkActivityAccessQueue = dispatch_queue_create("com.parse.networkActivityIndicatorManager",
                                                         DISPATCH_QUEUE_SERIAL);
 
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_handleWillSendURLRequestNotification:)
+                                                 name:PFCommandRunnerWillSendURLRequestNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_handleDidReceiveURLResponseNotification:)
+                                                 name:PFCommandRunnerDidReceiveURLResponseNotification
+                                               object:nil];
+
     return self;
 }
 
 - (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     [_activityIndicatorVisibilityTimer invalidate];
 }
 
@@ -135,6 +146,18 @@ static NSTimeInterval const PFNetworkActivityIndicatorVisibilityDelay = 0.17;
     if (![PFApplication currentApplication].extensionEnvironment) {
         [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:self.networkActivityIndicatorVisible];
     }
+}
+
+///--------------------------------------
+#pragma mark - Command Running
+///--------------------------------------
+
+- (void)_handleWillSendURLRequestNotification:(NSNotification *)notification {
+    [self incrementActivityCount];
+}
+
+- (void)_handleDidReceiveURLResponseNotification:(NSNotification *)notification {
+    [self decrementActivityCount];
 }
 
 @end


### PR DESCRIPTION
Fixes #74 
Depends on #82 

Just subscribe it to the network indicator.