### PR TITLE
Cleaned up usages of exceptions and asserts.

### DIFF
--- a/Parse/Internal/Commands/PFRESTCommand.m
+++ b/Parse/Internal/Commands/PFRESTCommand.m
@@ -10,6 +10,7 @@
 #import "PFRESTCommand.h"
 #import "PFRESTCommand_Private.h"
 
+#import "PFAssert.h"
 #import "PFCoreManager.h"
 #import "PFFieldOperation.h"
 #import "PFHTTPRequest.h"
@@ -159,10 +160,8 @@ static const int PFRESTCommandCacheKeyVersion = 1;
             }
         }
 
-        if ([self.httpMethod isEqualToString:PFHTTPRequestMethodDELETE] && !objectId) {
-            [NSException raise:NSInternalInconsistencyException
-                        format:@"Attempt to delete non-existent object."];
-        }
+        PFConsistencyAssert(![self.httpMethod isEqualToString:PFHTTPRequestMethodDELETE] || objectId,
+                            @"Attempt to delete non-existent object.");
     }
 }
 

--- a/Parse/Internal/Commands/PFRESTQueryCommand.m
+++ b/Parse/Internal/Commands/PFRESTQueryCommand.m
@@ -9,6 +9,7 @@
 
 #import "PFRESTQueryCommand.h"
 
+#import "PFAssert.h"
 #import "PFEncoder.h"
 #import "PFHTTPRequest.h"
 #import "PFQueryPrivate.h"
@@ -133,30 +134,11 @@
                 NSMutableArray *newArray = [NSMutableArray array];
                 for (PFQuery *subquery in array) {
                     // TODO: (nlutsenko) Move this validation into PFQuery/PFQueryState.
-                    if (subquery.state.limit >= 0) {
-                        [NSException raise:NSInvalidArgumentException
-                                    format:@"OR queries do not support sub queries with limits"];
-                    }
-
-                    if (subquery.state.skip > 0) {
-                        [NSException raise:NSInvalidArgumentException
-                                    format:@"OR queries do not support sub queries with skip"];
-                    }
-
-                    if ([subquery.state.sortKeys count]) {
-                        [NSException raise:NSInvalidArgumentException
-                                    format:@"OR queries do not support sub queries with order"];
-                    }
-
-                    if ([subquery.state.includedKeys count] > 0) {
-                        [NSException raise:NSInvalidArgumentException
-                                    format:@"OR queries do not support sub-queries with includes"];
-                    }
-
-                    if (subquery.state.selectedKeys) {
-                        [NSException raise:NSInvalidArgumentException
-                                    format:@"OR queries do not support sub-queries with selectKeys"];
-                    }
+                    PFParameterAssert(subquery.state.limit < 0, @"OR queries do not support sub queries with limits");
+                    PFParameterAssert(subquery.state.skip == 0, @"OR queries do not support sub queries with skip");
+                    PFParameterAssert(subquery.state.sortKeys.count == 0, @"OR queries do not support sub queries with order");
+                    PFParameterAssert(subquery.state.includedKeys.count == 0, @"OR queries do not support sub-queries with includes");
+                    PFParameterAssert(subquery.state.selectedKeys == nil, @"OR queries do not support sub-queries with selectKeys");
 
                     NSDictionary *queryDict = [self findCommandParametersWithOrder:subquery.state.sortOrderString
                                                                         conditions:subquery.state.conditions

--- a/Parse/Internal/FieldOperation/PFFieldOperation.m
+++ b/Parse/Internal/FieldOperation/PFFieldOperation.m
@@ -152,11 +152,9 @@
         NSNumber *newAmount = [PFInternalUtils addNumber:self.amount
                                               withNumber:((PFIncrementOperation *)previous).amount];
         return [PFIncrementOperation incrementWithAmount:newAmount];
-    } else {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Operation is invalid after previous operation."
-                                     userInfo:nil];
     }
+    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    return nil;
 }
 
 - (id)applyToValue:(id)oldValue forKey:(NSString *)key {
@@ -210,19 +208,16 @@
             NSArray *newArray = [oldArray arrayByAddingObjectsFromArray:self.objects];
             return [PFSetOperation setWithValue:newArray];
         } else {
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                           reason:@"You can't add an item to a non-array."
-                                         userInfo:nil];
+            [NSException raise:NSInternalInconsistencyException format:@"You can't add an item to a non-array."];
+            return nil;
         }
     } else if ([previous isKindOfClass:[PFAddOperation class]]) {
         NSMutableArray *newObjects = [((PFAddOperation *)previous).objects mutableCopy];
         [newObjects addObjectsFromArray:self.objects];
         return [[self class] addWithObjects:newObjects];
-    } else {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Operation is invalid after previous operation."
-                                     userInfo:nil];
     }
+    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    return nil;
 }
 
 - (id)applyToValue:(id)oldValue forKey:(NSString *)key {
@@ -230,11 +225,9 @@
         return [self.objects mutableCopy];
     } else if ([oldValue isKindOfClass:[NSArray class]]) {
         return [((NSArray *)oldValue)arrayByAddingObjectsFromArray:self.objects];
-    } else {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Operation is invalid after previous operation."
-                                     userInfo:nil];
     }
+    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    return nil;
 }
 
 @end
@@ -274,18 +267,15 @@
             NSArray *oldArray = (((PFSetOperation *)previous).value);
             return [PFSetOperation setWithValue:[self applyToValue:oldArray forKey:nil]];
         } else {
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                           reason:@"You can't add an item to a non-array."
-                                         userInfo:nil];
+            [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+            return nil;
         }
     } else if ([previous isKindOfClass:[PFAddUniqueOperation class]]) {
         NSArray *previousObjects = ((PFAddUniqueOperation *)previous).objects;
         return [[self class] addUniqueWithObjects:[self applyToValue:previousObjects forKey:nil]];
-    } else {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Operation is invalid after previous operation."
-                                     userInfo:nil];
     }
+    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    return nil;
 }
 
 - (id)applyToValue:(id)oldValue forKey:(NSString *)key {
@@ -311,11 +301,9 @@
             }
         }
         return newValue;
-    } else {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Operation is invalid after previous operation."
-                                     userInfo:nil];
     }
+    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    return nil;
 }
 
 @end
@@ -348,26 +336,23 @@
     if (!previous) {
         return self;
     } else if ([previous isKindOfClass:[PFDeleteOperation class]]) {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"You can't remove items from a deleted array."
-                                     userInfo:nil];
+        [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+        return nil;
     } else if ([previous isKindOfClass:[PFSetOperation class]]) {
         if ([((PFSetOperation *)previous).value isKindOfClass:[NSArray class]]) {
             NSArray *oldArray = ((PFSetOperation *)previous).value;
             return [PFSetOperation setWithValue:[self applyToValue:oldArray forKey:nil]];
         } else {
-            @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                           reason:@"You can't add an item to a non-array."
-                                         userInfo:nil];
+            [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+            return nil;
         }
     } else if ([previous isKindOfClass:[PFRemoveOperation class]]) {
         NSArray *newObjects = [((PFRemoveOperation *)previous).objects arrayByAddingObjectsFromArray:self.objects];
         return [PFRemoveOperation removeWithObjects:newObjects];
-    } else {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Operation is invalid after previous operation."
-                                     userInfo:nil];
     }
+
+    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    return nil;
 }
 
 - (id)applyToValue:(id)oldValue forKey:(NSString *)key {
@@ -393,11 +378,9 @@
             }
         }
         return newValue;
-    } else {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Operation is invalid after previous operation."
-                                     userInfo:nil];
     }
+    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    return nil;
 }
 
 @end
@@ -426,10 +409,8 @@
     }
 
     for (PFObject *target in targets) {
-        if (![[target parseClassName] isEqualToString:op.targetClass]) {
-            [NSException raise:NSInvalidArgumentException
-                        format:@"All objects in a relation must be of the same class."];
-        }
+        PFParameterAssert([target.parseClassName isEqualToString:op.targetClass],
+                          @"All objects in a relation must be of the same class.");
         [op.relationsToAdd addObject:target];
     }
 
@@ -443,10 +424,8 @@
     }
 
     for (PFObject *target in targets) {
-        if (![[target parseClassName] isEqualToString:operation.targetClass]) {
-            [NSException raise:NSInvalidArgumentException
-                        format:@"All objects in a relation must be of the same class."];
-        }
+        PFParameterAssert([target.parseClassName isEqualToString:operation.targetClass],
+                          @"All objects in a relation must be of the same class.");
         [operation.relationsToRemove addObject:target];
     }
 
@@ -496,57 +475,48 @@
         return removeDict;
     }
 
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"A PFRelationOperation was created without any data."
-                                 userInfo:nil];
+    [NSException raise:NSInternalInconsistencyException format:@"A PFRelationOperation was created without any data."];
+    return nil;
 }
 
 - (PFFieldOperation *)mergeWithPrevious:(PFFieldOperation *)previous {
     if (!previous) {
         return self;
-    } else if ([previous isKindOfClass:[PFDeleteOperation class]]) {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"You can't modify a relation after deleting it."
-                                     userInfo:nil];
-    } else if ([previous isKindOfClass:[PFRelationOperation class]]) {
-        PFRelationOperation *previousOperation = (PFRelationOperation *)previous;
-        if (previousOperation.targetClass &&
-            ![previousOperation.targetClass isEqualToString:self.targetClass]) {
-            [NSException raise:NSInvalidArgumentException
-                        format:@"Related object object must be of class %@, but %@ was passed in",
-             previousOperation.targetClass,
-             self.targetClass];
-        } else {
-            //TODO: (nlutsenko) This logic seems to be messed up. We should return a new operation here, also merging logic seems funky.
-            NSSet *newRelationsToAdd = [self.relationsToAdd copy];
-            NSSet *newRelationsToRemove = [self.relationsToRemove copy];
-            [self.relationsToAdd removeAllObjects];
-            [self.relationsToRemove removeAllObjects];
-
-            for (NSString *objectId in previousOperation.relationsToAdd) {
-                [self.relationsToRemove removeObject:objectId];
-                [self.relationsToAdd addObject:objectId];
-            }
-            for (NSString *objectId in previousOperation.relationsToRemove) {
-                [self.relationsToRemove removeObject:objectId];
-                [self.relationsToRemove addObject:objectId];
-            }
-
-            for (NSString *objectId in newRelationsToAdd) {
-                [self.relationsToRemove removeObject:objectId];
-                [self.relationsToAdd addObject:objectId];
-            }
-            for (NSString *objectId in newRelationsToRemove) {
-                [self.relationsToRemove removeObject:objectId];
-                [self.relationsToRemove addObject:objectId];
-            }
-        }
-        return self;
-    } else {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Operation is invalid after previous operation."
-                                     userInfo:nil];
     }
+
+    PFConsistencyAssert(![previous isKindOfClass:[PFDeleteOperation class]], @"You can't modify a relation after deleting it");
+    PFConsistencyAssert([previous isKindOfClass:[PFRelationOperation class]], @"Operation is invalid after previous operation");
+
+    PFRelationOperation *previousOperation = (PFRelationOperation *)previous;
+
+    PFParameterAssert(!previousOperation.targetClass || [previousOperation.targetClass isEqualToString:self.targetClass],
+                      @"Related object object must be of class %@, but %@ was passed in",
+                      previousOperation.targetClass, self.targetClass);
+
+    //TODO: (nlutsenko) This logic seems to be messed up. We should return a new operation here, also merging logic seems funky.
+    NSSet *newRelationsToAdd = [self.relationsToAdd copy];
+    NSSet *newRelationsToRemove = [self.relationsToRemove copy];
+    [self.relationsToAdd removeAllObjects];
+    [self.relationsToRemove removeAllObjects];
+
+    for (NSString *objectId in previousOperation.relationsToAdd) {
+        [self.relationsToRemove removeObject:objectId];
+        [self.relationsToAdd addObject:objectId];
+    }
+    for (NSString *objectId in previousOperation.relationsToRemove) {
+        [self.relationsToRemove removeObject:objectId];
+        [self.relationsToRemove addObject:objectId];
+    }
+
+    for (NSString *objectId in newRelationsToAdd) {
+        [self.relationsToRemove removeObject:objectId];
+        [self.relationsToAdd addObject:objectId];
+    }
+    for (NSString *objectId in newRelationsToRemove) {
+        [self.relationsToRemove removeObject:objectId];
+        [self.relationsToRemove addObject:objectId];
+    }
+    return self;
 }
 
 - (id)applyToValue:(id)oldValue forKey:(NSString *)key {
@@ -557,20 +527,16 @@
         relation = oldValue;
         if (self.targetClass) {
             if (relation.targetClass) {
-                if (![relation.targetClass isEqualToString:targetClass]) {
-                    [NSException raise:NSInvalidArgumentException
-                                format:@"Related object object must be of class %@, but %@ was passed in",
-                     relation.targetClass,
-                     self.targetClass];
-                }
+                PFParameterAssert([relation.targetClass isEqualToString:targetClass],
+                                  @"Related object object must be of class %@, but %@ was passed in",
+                                  relation.targetClass, self.targetClass);
             } else {
                 relation.targetClass = self.targetClass;
             }
         }
     } else {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"Operation is invalid after previous operation."
-                                     userInfo:nil];
+        [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+        return nil;
     }
 
     for (PFObject *object in self.relationsToAdd) {

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -944,10 +944,8 @@ int const PFOfflineStoreMaximumSQLVariablesCount = 999;
                     oldObjectId:(NSString *)oldObjectId
                     newObjectId:(NSString *)newObjectId {
     if (oldObjectId != nil) {
-        if ([oldObjectId isEqualToString:newObjectId]) {
-            return;
-        }
-        [NSException raise:NSInternalInconsistencyException format:@"objectIds cannot be changed in offline mode."];
+        PFConsistencyAssert([oldObjectId isEqualToString:newObjectId], @"objectIds cannot be changed in offline mode.");
+        return;
     }
 
     NSString *className = object.parseClassName;

--- a/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
+++ b/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
@@ -140,10 +140,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
  * Grabs one entry in the local id map off the disk.
  */
 - (PFObjectLocalIdStoreMapEntry *)getMapEntry:(NSString *)localId {
-    if (![[self class] isLocalId:localId]) {
-        [NSException raise:NSInternalInconsistencyException
-                    format:@"Tried to get invalid local id: \"%@\".", localId];
-    }
+    PFConsistencyAssert([[self class] isLocalId:localId], @"Tried to get invalid local id: \"%@\".", localId);
 
     PFObjectLocalIdStoreMapEntry *entry = nil;
 
@@ -173,10 +170,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
  * Writes one entry to the local id map on disk.
  */
 - (void)putMapEntry:(PFObjectLocalIdStoreMapEntry *)entry forLocalId:(NSString *)localId {
-    if (![[self class] isLocalId:localId]) {
-        [NSException raise:NSInternalInconsistencyException
-                    format:@"Tried to get invalid local id: \"%@\".", localId];
-    }
+    PFConsistencyAssert([[self class] isLocalId:localId], @"Tried to get invalid local id: \"%@\".", localId);
 
     NSString *file = [_diskPath stringByAppendingPathComponent:localId];
     [entry writeToFile:file];
@@ -186,10 +180,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
  * Removes an entry from the local id map on disk.
  */
 - (void)removeMapEntry:(NSString *)localId {
-    if (![[self class] isLocalId:localId]) {
-        [NSException raise:NSInternalInconsistencyException
-                    format:@"Tried to get invalid local id: \"%@\".", localId];
-    }
+    PFConsistencyAssert([[self class] isLocalId:localId], @"Tried to get invalid local id: \"%@\".", localId);
 
     NSString *file = [_diskPath stringByAppendingPathComponent:localId];
     [[NSFileManager defaultManager] removeItemAtPath:file error:nil];
@@ -207,10 +198,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
         uint64_t localIdNumber = (((uint64_t)arc4random()) << 32) | ((uint64_t)arc4random());
         NSString *localId = [NSString stringWithFormat:@"local_%016llx", localIdNumber];
 
-        if (![[self class] isLocalId:localId]) {
-            [NSException raise:NSInternalInconsistencyException
-                        format:@"Generated an invalid local id: \"%@\".", localId];
-        }
+        PFConsistencyAssert([[self class] isLocalId:localId], @"Generated an invalid local id: \"%@\".", localId);
 
         return localId;
     }

--- a/Parse/Internal/PFJSONSerialization.m
+++ b/Parse/Internal/PFJSONSerialization.m
@@ -9,6 +9,7 @@
 
 #import "PFJSONSerialization.h"
 
+#import "PFAssert.h"
 #import "PFLogging.h"
 
 @implementation PFJSONSerialization
@@ -16,10 +17,8 @@
 + (NSData *)dataFromJSONObject:(id)object {
     NSError *error = nil;
     NSData *data = [NSJSONSerialization dataWithJSONObject:object options:0 error:&error];
-    if (!data || error != nil) {
-        [NSException raise:NSInvalidArgumentException
-                    format:@"PFObject values must be serializable to JSON"];
-    }
+    PFParameterAssert(data && !error, @"PFObject values must be serializable to JSON");
+
     return data;
 }
 

--- a/Parse/Internal/Query/Utilities/PFQueryUtilities.m
+++ b/Parse/Internal/Query/Utilities/PFQueryUtilities.m
@@ -9,6 +9,7 @@
 
 #import "PFQueryUtilities.h"
 
+#import "PFAssert.h"
 #import "PFConstants.h"
 #import "PFErrorUtilities.h"
 
@@ -195,20 +196,15 @@
                        NSComparisonPredicate *between = (NSComparisonPredicate *)predicate;
                        NSExpression *rhs = between.rightExpression;
 
-                       if (rhs.expressionType != NSConstantValueExpressionType &&
-                           rhs.expressionType != NSAggregateExpressionType) {
-                           [NSException raise:NSInternalInconsistencyException
-                                       format:@"The right-hand side of a BETWEEN operation must be a value or literal."];
-                       }
-                       if (![rhs.constantValue isKindOfClass:[NSArray class]]) {
-                           [NSException raise:NSInternalInconsistencyException
-                                       format:@"The right-hand side of a BETWEEN operation must be an array."];
-                       }
+                       PFConsistencyAssert(rhs.expressionType == NSConstantValueExpressionType ||
+                                           rhs.expressionType == NSAggregateExpressionType,
+                                           @"The right-hand side of a BETWEEN operation must be a value or literal.");
+
+                       PFConsistencyAssert([rhs.constantValue isKindOfClass:[NSArray class]],
+                                           @"The right-hand side of a BETWEEN operation must be an array.");
+
                        NSArray *array = rhs.constantValue;
-                       if (array.count != 2) {
-                           [NSException raise:NSInternalInconsistencyException
-                                       format:@"The right-hand side of a BETWEEN operation must have 2 items."];
-                       }
+                       PFConsistencyAssert(array.count == 2, @"The right-hand side of a BETWEEN operation must have 2 items.");
 
                        id minValue = array[0];
                        id maxValue = array[1];
@@ -406,11 +402,9 @@
     [self _mapPredicate:predicate
           compoundBlock:nil
         comparisonBlock:^NSPredicate *(NSComparisonPredicate *comparison) {
-            if (comparison.comparisonPredicateModifier != NSDirectPredicateModifier) {
-                [NSException raise:NSInternalInconsistencyException
-                            format:@"Unsupported comparison predicate modifier %zd.",
-                 comparison.comparisonPredicateModifier];
-            }
+            PFConsistencyAssert(comparison.comparisonPredicateModifier == NSDirectPredicateModifier,
+                                @"Unsupported comparison predicate modifier %zd.",
+                                comparison.comparisonPredicateModifier);
             return comparison;
         }];
 }


### PR DESCRIPTION
We no longer do `@throw [NSException exceptionWith...]` anywhere in the code base, replaced usages of `if (conditon) [NSException raise:...` with PFParamter/ConsistencyAssert where appropriate.

This is related to #6.