### PR TITLE
Implemented In-App-Purchase validation using App Store Receipt instead of Transaction Receipt.

### DIFF
--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -342,7 +342,8 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
     dispatch_sync(_controllerAccessQueue, ^{
         if (!_purchaseController) {
             _purchaseController = [PFPurchaseController controllerWithCommandRunner:self.commandRunner
-                                                                        fileManager:self.fileManager];
+                                                                        fileManager:self.fileManager
+                                                                             bundle:[NSBundle mainBundle]];
         }
         controller = _purchaseController;
     });

--- a/Parse/Internal/Purchase/Controller/PFPurchaseController.h
+++ b/Parse/Internal/Purchase/Controller/PFPurchaseController.h
@@ -22,6 +22,7 @@
 
 @property (nonatomic, strong, readonly) id<PFCommandRunning> commandRunner;
 @property (nonatomic, strong, readonly) PFFileManager *fileManager;
+@property (nonatomic, strong, readonly) NSBundle *bundle;
 
 @property (nonatomic, strong) SKPaymentQueue *paymentQueue;
 @property (nonatomic, strong, readonly) PFPaymentTransactionObserver *transactionObserver;
@@ -34,10 +35,12 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithCommandRunner:(id<PFCommandRunning>)commandRunner
-                          fileManager:(PFFileManager *)fileManager NS_DESIGNATED_INITIALIZER;
+                          fileManager:(PFFileManager *)fileManager
+                               bundle:(NSBundle *)bundle NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)controllerWithCommandRunner:(id<PFCommandRunning>)commandRunner
-                                fileManager:(PFFileManager *)fileManager;
+                                fileManager:(PFFileManager *)fileManager
+                                     bundle:(NSBundle *)bundle;
 
 ///--------------------------------------
 /// @name Products

--- a/Tests/Unit/PurchaseUnitTests.m
+++ b/Tests/Unit/PurchaseUnitTests.m
@@ -34,9 +34,11 @@
 - (PFPurchaseController *)mockedPurchaseController {
     id<PFCommandRunning> commandRunner = PFStrictProtocolMock(@protocol(PFCommandRunning));
     PFFileManager *fileManager = PFStrictClassMock([PFFileManager class]);
+    id bundle = PFStrictClassMock([NSBundle class]);
 
     PFPurchaseController *purchaseController = PFPartialMock([[PFPurchaseController alloc] initWithCommandRunner:commandRunner
-                                                                                                      fileManager:fileManager]);
+                                                                                                     fileManager:fileManager
+                                                                                                          bundle:bundle]);
 
     SKPaymentQueue *paymentQueue = PFClassMock([SKPaymentQueue class]);
     purchaseController.paymentQueue = paymentQueue;


### PR DESCRIPTION
Start using `appStoreReceiptURL` instead of transaction receipts, that are deprecated in iOS 9.