### PR TITLE
Fix potential infinite recursion on resolving PFObject subclass properties.

### DIFF
--- a/Parse/Internal/PropertyInfo/PFPropertyInfo.m
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo.m
@@ -74,7 +74,7 @@ static inline NSString *stringByCapitalizingFirstCharacter(NSString *string) {
             _ivar = class_getInstanceVariable(superClass, [safeStringWithPropertyAttributeValue(superProperty, "V") UTF8String]);
             if (_ivar) break;
 
-            superClass = class_getSuperclass(kls);
+            superClass = class_getSuperclass(superClass);
         }
 
         if (_ivar) break;


### PR DESCRIPTION
We get into in infinite recursion if there are 2 subclasses of PFObject and the property is implemented on the superclass doesn't have an instance variable.
This fixes the problem. Looks like a typo in the first place.

@richardjrossiii Would be awesome to have tests on this.