### PR TITLE
Properly specify bundle executable in OS X framework Info.plist.

### DIFF
--- a/Parse/Resources/FrameworkOSX.plist
+++ b/Parse/Resources/FrameworkOSX.plist
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>ParseOSX</string>
+	<string>Parse</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.parse.ParseOSX</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
This will cause the code signature to fail, since apparently it looks for executable first, then for entire folder.
Fixes #98 