### PR TITLE
Fixed too agressive deallocation for PFObject when fetch/delete is in  progress.

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -1561,11 +1561,9 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
 
 - (BFTask *)fetchAsync:(BFTask *)toAwait {
     PFCurrentUserController *controller = [[self class] currentUserController];
-    @weakify(self);
     return [[controller getCurrentUserSessionTokenAsync] continueWithBlock:^id(BFTask *task) {
         NSString *sessionToken = task.result;
         return [toAwait continueAsyncWithBlock:^id(BFTask *task) {
-            @strongify(self);
             return [[[self class] objectController] fetchObjectAsync:self withSessionToken:sessionToken];
         }];
     }];
@@ -1575,11 +1573,9 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
     [self checkDeleteParams];
 
     PFCurrentUserController *controller = [[self class] currentUserController];
-    @weakify(self);
     return [[controller getCurrentUserSessionTokenAsync] continueWithBlock:^id(BFTask *task) {
         NSString *sessionToken = task.result;
         return [toAwait continueAsyncWithBlock:^id(BFTask *task) {
-            @strongify(self);
             return [[[self class] objectController] deleteObjectAsync:self withSessionToken:sessionToken];
         }];
     }];


### PR DESCRIPTION
If there are no other references to `self` (aka PFObject instance) - evicting this object too early here will actually cause the object
to be gone from memory and then inside the last continuation - it will be `nil`.
This is reproducible by calling `delete/fetchInBackground` on an instance of PFObject and never referencing that instance again.
Fixes #100