### PR TITLE
Make sure we compile for App Extensions from source.

### DIFF
--- a/Parse/Internal/PFAlertView.h
+++ b/Parse/Internal/PFAlertView.h
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 typedef void(^PFAlertViewCompletion)(NSUInteger selectedOtherButtonIndex);
@@ -17,6 +18,6 @@ typedef void(^PFAlertViewCompletion)(NSUInteger selectedOtherButtonIndex);
                    message:(NSString *)message
          cancelButtonTitle:(NSString *)cancelButtonTitle
          otherButtonTitles:(NSArray *)otherButtonTitles
-                completion:(PFAlertViewCompletion)completion;
+                completion:(PFAlertViewCompletion)completion NS_EXTENSION_UNAVAILABLE_IOS("");
 
 @end

--- a/Parse/Internal/PFApplication.h
+++ b/Parse/Internal/PFApplication.h
@@ -9,11 +9,20 @@
 
 #import <Foundation/Foundation.h>
 
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#else
+#import <AppKit/AppKit.h>
+@compatibility_alias UIApplication NSApplication;
+#endif
+
 /*!
  `PFApplication` class provides a centralized way to get the information about the current application,
  or the environment it's running in. Please note, that all device specific things - should go to <PFDevice>.
  */
 @interface PFApplication : NSObject
+
+@property (nonatomic, strong, readonly) UIApplication *systemApplication;
 
 @property (nonatomic, assign, readonly, getter=isAppStoreEnvironment) BOOL appStoreEnvironment;
 @property (nonatomic, assign, readonly, getter=isExtensionEnvironment) BOOL extensionEnvironment;

--- a/Parse/Internal/PFApplication.m
+++ b/Parse/Internal/PFApplication.m
@@ -48,7 +48,7 @@
 
 - (NSInteger)iconBadgeNumber {
 #if TARGET_OS_IPHONE
-    return [UIApplication sharedApplication].applicationIconBadgeNumber;
+    return self.systemApplication.applicationIconBadgeNumber;
 #else
     // Make sure not to use `NSApp` here, because it doesn't work sometimes,
     // `NSApplication +sharedApplication` does though.
@@ -72,11 +72,16 @@
 - (void)setIconBadgeNumber:(NSInteger)iconBadgeNumber {
     if (self.iconBadgeNumber != iconBadgeNumber) {
 #if TARGET_OS_IPHONE
-        [UIApplication sharedApplication].applicationIconBadgeNumber = iconBadgeNumber;
+        self.systemApplication.applicationIconBadgeNumber = iconBadgeNumber;
 #else
         [[NSApplication sharedApplication] dockTile].badgeLabel = [@(iconBadgeNumber) stringValue];
 #endif
     }
+}
+
+- (UIApplication *)systemApplication {
+    // Workaround to make `sharedApplication` still be called even if compiling for App Extensions or WatchKit apps.
+    return [UIApplication performSelector:@selector(sharedApplication)];
 }
 
 @end

--- a/Parse/Internal/PFLocationManager.m
+++ b/Parse/Internal/PFLocationManager.m
@@ -13,13 +13,7 @@
 
 #import "PFConstants.h"
 #import "PFGeoPoint.h"
-
-#if !TARGET_OS_IPHONE
-
-// To let us compile for OSX.
-@compatibility_alias UIApplication NSApplication;
-
-#endif
+#import "PFApplication.h"
 
 @interface PFLocationManager () <CLLocationManagerDelegate>
 
@@ -66,7 +60,7 @@
 
 - (instancetype)initWithSystemLocationManager:(CLLocationManager *)manager {
     return [self initWithSystemLocationManager:manager
-                                   application:[UIApplication sharedApplication]
+                                   application:[PFApplication currentApplication].systemApplication
                                         bundle:[NSBundle mainBundle]];
 }
 

--- a/Parse/Internal/Push/PFPushPrivate.h
+++ b/Parse/Internal/Push/PFPushPrivate.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if TARGET_OS_IPHONE
 
-+ (void)showAlertViewWithTitle:(nullable NSString *)title message:(nullable NSString *)message;
++ (void)showAlertViewWithTitle:(nullable NSString *)title message:(nullable NSString *)message NS_EXTENSION_UNAVAILABLE_IOS("");
 + (void)playVibrate;
 + (void)playAudioWithName:(nullable NSString *)audioName;
 

--- a/Parse/PFNetworkActivityIndicatorManager.m
+++ b/Parse/PFNetworkActivityIndicatorManager.m
@@ -142,7 +142,7 @@ static NSTimeInterval const PFNetworkActivityIndicatorVisibilityDelay = 0.17;
     }
 }
 
-- (void)_updateNetworkActivityIndicatorVisibility {
+- (void)_updateNetworkActivityIndicatorVisibility NS_EXTENSION_UNAVAILABLE_IOS("") {
     if (![PFApplication currentApplication].extensionEnvironment) {
         [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:self.networkActivityIndicatorVisible];
     }

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -386,7 +386,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @param userInfo The userInfo dictionary you get in `appplication:didReceiveRemoteNotification:`.
  */
-+ (void)handlePush:(PF_NULLABLE NSDictionary *)userInfo NS_AVAILABLE_IOS(3_0);
++ (void)handlePush:(PF_NULLABLE NSDictionary *)userInfo NS_AVAILABLE_IOS(3_0) PF_EXTENSION_UNAVAILABLE("");
 
 ///--------------------------------------
 /// @name Managing Channel Subscriptions


### PR DESCRIPTION
- Mark extension unavailable APIs
- Add workaround for UIApplication/NSApplication sharedApplication (it will be nil anyway)

Tested that it compiles for extensions by enabling `allow extension only APIs on both targets`.
We probably should have a sample application with a sample extension inside, so we can test this on a CI.
Fixes #43 though, since we fully compile for app extensions now.