### PR TITLE
Add ability to remove all field operations from PFOperationSet.

### DIFF
--- a/Parse/Internal/Object/OperationSet/PFOperationSet.h
+++ b/Parse/Internal/Object/OperationSet/PFOperationSet.h
@@ -65,5 +65,6 @@
 - (void)setObject:(id)anObject forKey:(id<NSCopying>)aKey;
 - (void)setObject:(id)anObject forKeyedSubscript:(id<NSCopying>)aKey;
 - (void)removeObjectForKey:(id)aKey;
+- (void)removeAllObjects;
 
 @end

--- a/Parse/Internal/Object/OperationSet/PFOperationSet.m
+++ b/Parse/Internal/Object/OperationSet/PFOperationSet.m
@@ -166,6 +166,11 @@ NSString *const PFOperationSetKeyACL = @"ACL";
     self.updatedAt = [NSDate date];
 }
 
+- (void)removeAllObjects {
+    [self.dictionary removeAllObjects];
+    self.updatedAt = [NSDate date];
+}
+
 ///--------------------------------------
 #pragma mark - NSFastEnumeration
 ///--------------------------------------

--- a/Tests/Unit/OperationSetUnitTests.m
+++ b/Tests/Unit/OperationSetUnitTests.m
@@ -103,6 +103,24 @@
     XCTAssertNotEqualObjects(date, operationSet.updatedAt);
 }
 
+- (void)testRemoveAllObjects {
+    PFOperationSet *operationSet = [[PFOperationSet alloc] init];
+
+    operationSet[@"yarr"] = [PFSetOperation setWithValue:@"a"];
+    operationSet[@"yolo"] = [PFAddOperation addWithObjects:@[ @"b" ]];
+
+    XCTAssertNotNil(operationSet[@"yarr"]);
+    XCTAssertNotNil(operationSet[@"yolo"]);
+    XCTAssertEqual(operationSet.count, 2);
+
+    NSDate *date = operationSet.updatedAt;
+    [operationSet removeAllObjects];
+    XCTAssertNil(operationSet[@"yarr"]);
+    XCTAssertNil(operationSet[@"yolo"]);
+    XCTAssertEqual(operationSet.count, 0);
+    XCTAssertNotEqualObjects(date, operationSet.updatedAt);
+}
+
 - (void)testCopying {
     PFOperationSet *operationSet = [[PFOperationSet alloc] init];
     operationSet[@"yarr"] = [PFSetOperation setWithValue:@"yolo"];


### PR DESCRIPTION
- Add `removeAllObjects` to `PFOperationSet`.
- Add a test for it.
Should help to implement #52, specifically #70