### PR TITLE
Replace exception with error on PFObject.fetch without an objectId.

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -870,7 +870,6 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
     PFParameterAssert(![className hasPrefix:@"_"], @"Invalid class name. Class names cannot start with an underscore.");
 }
 
-
 ///--------------------------------------
 #pragma mark - Serialization helpers
 ///--------------------------------------
@@ -2123,9 +2122,10 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
 }
 
 - (BFTask *)fetchInBackground {
-    //TODO: (nlutsenko) Replace with an error?
-    @synchronized (lock) {
-        PFParameterAssert(self._state.objectId, @"Can't refresh an object that hasn't been saved to the server.");
+    if (!self._state.objectId) {
+        NSError *error = [PFErrorUtilities errorWithCode:kPFErrorMissingObjectId
+                                                 message:@"Can't refresh an object that hasn't been saved to the server."];
+        return [BFTask taskWithError:error];
     }
     return [self.taskQueue enqueue:^BFTask *(BFTask *toAwait) {
         return [self fetchAsync:toAwait];

--- a/Tests/Unit/ObjectUnitTests.m
+++ b/Tests/Unit/ObjectUnitTests.m
@@ -182,4 +182,20 @@
     XCTAssertEqualObjects([object valueForKey:@"yarr"], @"yolo");
 }
 
+#pragma mark Fetch
+
+- (void)testFetchObjectWithoutObjectIdError {
+    PFObject *object = [PFObject objectWithClassName:@"Test"];
+    
+    XCTestExpectation *expectation = [self currentSelectorTestExpectation];
+    [[object fetchInBackground] continueWithBlock:^id(BFTask *task) {
+        XCTAssertNotNil(task.error);
+        XCTAssertEqualObjects(task.error.domain, PFParseErrorDomain);
+        XCTAssertEqual(task.error.code, kPFErrorMissingObjectId);
+        [expectation fulfill];
+        return nil;
+    }];
+    [self waitForTestExpectations];
+}
+
 @end


### PR DESCRIPTION
Return an error, avoid throwing, add test.
Contributes to #6.
cc @grantland