### PR TITLE
Checks for nil applicationId and clientKey

### DIFF
--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -55,8 +55,9 @@ static NSString *containingApplicationBundleIdentifier_;
 ///--------------------------------------
 
 + (void)setApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey {
-    // TODO: (nlutsenko) Add assert and unit test here that checks applicationId, clientKey not being nil.
-
+    PFConsistencyAssert([applicationId length], @"'applicationId' should not be nil.");
+    PFConsistencyAssert([clientKey length], @"'clientKey' should not be nil.");
+    
     // Setup new manager first, so it's 100% ready whenever someone sends a request for anything.
     ParseManager *manager = [[ParseManager alloc] initWithApplicationId:applicationId clientKey:clientKey];
     [manager configureWithApplicationGroupIdentifier:applicationGroupIdentifier_

--- a/Tests/Unit/ParseSetupUnitTests.m
+++ b/Tests/Unit/ParseSetupUnitTests.m
@@ -45,4 +45,12 @@
     [Parse setApplicationId:@"a" clientKey:@"b"];
     PFAssertThrowsInconsistencyException([Parse enableLocalDatastore]);
 }
+
+- (void)testInitializeWithNilApplicationIdNilClientKeyShouldThrowException {
+    NSString *yolo = nil;
+    PFAssertThrowsInconsistencyException([Parse setApplicationId:yolo clientKey:yolo]);
+    PFAssertThrowsInconsistencyException([Parse setApplicationId:yolo clientKey:@"a"]);
+    PFAssertThrowsInconsistencyException([Parse setApplicationId:@"a" clientKey:yolo]);
+}
+
 @end


### PR DESCRIPTION
Searched over the TODOs and found this. The reason I passed the nil string 'yolo' in the tests is because if you actually pass in nil you'll get a warning.

I don't have too much professional experience with unit tests, please let me know if there's anything wrong with these tests.