### PR TITLE
Implemented PFObject.deleteAll through PFObjectBatchController.

### DIFF
--- a/Parse/Internal/Object/BatchController/PFObjectBatchController.h
+++ b/Parse/Internal/Object/BatchController/PFObjectBatchController.h
@@ -12,6 +12,7 @@
 #import "PFDataProvider.h"
 
 @class BFTask;
+@class PFObject;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -34,10 +35,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask *)fetchObjectsAsync:(nullable NSArray *)objects withSessionToken:(nullable NSString *)sessionToken;
 
 ///--------------------------------------
+/// @name Delete
+///--------------------------------------
+
+- (BFTask *)deleteObjectsAsync:(nullable NSArray *)objects withSessionToken:(nullable NSString *)sessionToken;
+
+///--------------------------------------
 /// @name Utilities
 ///--------------------------------------
 
 + (nullable NSArray *)uniqueObjectsArrayFromArray:(nullable NSArray *)objects omitObjectsWithData:(BOOL)omitFetched;
++ (NSArray *)uniqueObjectsArrayFromArray:(NSArray *)objects usingFilter:(BOOL (^)(PFObject *object))filter;
 
 @end
 

--- a/Parse/Internal/Object/BatchController/PFObjectBatchController.m
+++ b/Parse/Internal/Object/BatchController/PFObjectBatchController.m
@@ -9,6 +9,8 @@
 
 #import "PFObjectBatchController.h"
 
+#import <Bolts/Bolts.h>
+
 #import "BFTask+Private.h"
 #import "PFAssert.h"
 #import "PFCommandResult.h"
@@ -19,6 +21,8 @@
 #import "PFObjectPrivate.h"
 #import "PFQueryPrivate.h"
 #import "PFRESTQueryCommand.h"
+#import "PFRESTObjectCommand.h"
+#import "PFRESTObjectBatchCommand.h"
 
 @implementation PFObjectBatchController
 
@@ -99,9 +103,85 @@
 }
 
 ///--------------------------------------
+#pragma mark - Delete
+///--------------------------------------
+
+- (BFTask *)deleteObjectsAsync:(NSArray *)objects withSessionToken:(NSString *)sessionToken {
+    if (objects.count == 0) {
+        return [BFTask taskWithResult:objects];
+    }
+
+    @weakify(self);
+    return [[BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
+        @strongify(self);
+        NSArray *objectBatches = [PFInternalUtils arrayBySplittingArray:objects
+                                        withMaximumComponentsPerSegment:PFRESTObjectBatchCommandSubcommandsLimit];
+        NSMutableArray *tasks = [NSMutableArray arrayWithCapacity:objectBatches.count];
+        for (NSArray *batch in objectBatches) {
+            PFRESTCommand *command = [self _deleteCommandForObjects:batch withSessionToken:sessionToken];
+            BFTask *task = [[self.dataSource.commandRunner runCommandAsync:command
+                                                              withOptions:PFCommandRunningOptionRetryIfFailed] continueWithSuccessBlock:^id(BFTask *task) {
+                PFCommandResult *result = task.result;
+                return [self _processDeleteResultsAsync:[result result] forObjects:batch];
+            }];
+            [tasks addObject:task];
+        }
+        return [[BFTask taskForCompletionOfAllTasks:tasks] continueWithBlock:^id(BFTask *task) {
+            NSError *taskError = task.error;
+            if (taskError && [taskError.domain isEqualToString:BFTaskErrorDomain]) {
+                NSArray *taskErrors = taskError.userInfo[@"errors"];
+                NSMutableArray *errors = [NSMutableArray array];
+                for (NSError *error in taskErrors) {
+                    if ([error.domain isEqualToString:BFTaskErrorDomain]) {
+                        [errors addObjectsFromArray:error.userInfo[@"errors"]];
+                    } else {
+                        [errors addObject:error];
+                    }
+                }
+                return [BFTask taskWithError:[NSError errorWithDomain:BFTaskErrorDomain
+                                                                 code:kBFMultipleErrorsError
+                                                             userInfo:@{ @"errors" : errors }]];
+            }
+            return task;
+        }];
+    }] continueWithSuccessResult:objects];
+}
+
+- (PFRESTCommand *)_deleteCommandForObjects:(NSArray *)objects withSessionToken:(NSString *)sessionToken {
+    NSMutableArray *commands = [NSMutableArray arrayWithCapacity:objects.count];
+    for (PFObject *object in objects) {
+        [object checkDeleteParams];
+        PFRESTCommand *deleteCommand = [PFRESTObjectCommand deleteObjectCommandForObjectState:object._state
+                                                                             withSessionToken:sessionToken];
+        [commands addObject:deleteCommand];
+    }
+    return [PFRESTObjectBatchCommand batchCommandWithCommands:commands sessionToken:sessionToken];
+}
+
+- (BFTask *)_processDeleteResultsAsync:(NSArray *)results forObjects:(NSArray *)objects {
+    NSMutableArray *tasks = [NSMutableArray arrayWithCapacity:results.count];
+    [results enumerateObjectsUsingBlock:^(NSDictionary *result, NSUInteger idx, BOOL *stop) {
+        PFObject *object = objects[idx];
+        NSDictionary *errorResult = result[@"error"];
+        NSDictionary *successResult = result[@"success"];
+
+        id<PFObjectControlling> controller = [[object class] objectController];
+        BFTask *task = [controller processDeleteResultAsync:successResult forObject:object];
+        if (errorResult) {
+            task = [task continueWithBlock:^id(BFTask *task) {
+                return [BFTask taskWithError:[PFErrorUtilities errorFromResult:errorResult]];
+            }];
+        }
+        [tasks addObject:task];
+    }];
+    return [BFTask taskForCompletionOfAllTasks:tasks];
+}
+
+///--------------------------------------
 #pragma mark - Utilities
 ///--------------------------------------
 
+//TODO: (nlutsenko) Convert to use `uniqueObjectsArrayFromArray:usingFilter:`
 + (NSArray *)uniqueObjectsArrayFromArray:(NSArray *)objects omitObjectsWithData:(BOOL)omitFetched {
     if (objects.count == 0) {
         return objects;
@@ -115,6 +195,7 @@
                 continue;
             }
 
+            //TODO: (nlutsenko) Convert to using errors instead of assertions.
             PFParameterAssert([className isEqualToString:object.parseClassName],
                               @"All object should be in the same class.");
             PFParameterAssert(object.objectId != nil,
@@ -124,6 +205,26 @@
         }
     }
     return [set allObjects];
+}
+
++ (NSArray *)uniqueObjectsArrayFromArray:(NSArray *)objects usingFilter:(BOOL (^)(PFObject *object))filter {
+    if (objects.count == 0) {
+        return objects;
+    }
+
+    NSMutableDictionary *uniqueObjects = [NSMutableDictionary dictionary];
+    for (PFObject *object in objects) {
+        if (!filter(object)) {
+            continue;
+        }
+
+        // Use stringWithFormat: in case objectId or parseClassName are nil.
+        NSString *objectIdentifier = [NSString stringWithFormat:@"%@%@", object.parseClassName, object.objectId];
+        if (!uniqueObjects[objectIdentifier]) {
+            uniqueObjects[objectIdentifier] = object;
+        }
+    }
+    return [uniqueObjects allValues];
 }
 
 @end

--- a/Tests/Other/OCMock/OCMock+Parse.h
+++ b/Tests/Other/OCMock/OCMock+Parse.h
@@ -9,8 +9,10 @@
 
 #import <OCMock/OCMock.h>
 
+@class PFRESTCommand;
+
 @interface OCMockObject (PFCommandRunning)
 
-- (void)mockCommandResult:(id)result forCommandsPassingTest:(BOOL (^)(id obj))block;
+- (void)mockCommandResult:(id)result forCommandsPassingTest:(BOOL (^)(PFRESTCommand *command))block;
 
 @end

--- a/Tests/Other/OCMock/OCMock+Parse.m
+++ b/Tests/Other/OCMock/OCMock+Parse.m
@@ -16,7 +16,7 @@
 
 @implementation OCMockObject (PFCOmmandRunning)
 
-- (void)mockCommandResult:(id)result forCommandsPassingTest:(BOOL (^)(id obj))block {
+- (void)mockCommandResult:(id)result forCommandsPassingTest:(BOOL (^)(PFRESTCommand *command))block {
     PFCommandResult *commandResult = [PFCommandResult commandResultWithResult:result
                                                                  resultString:nil
                                                                  httpResponse:nil];

--- a/Tests/Unit/ObjectBatchControllerTests.m
+++ b/Tests/Unit/ObjectBatchControllerTests.m
@@ -14,9 +14,11 @@
 #import "PFCommandResult.h"
 #import "PFCommandRunning.h"
 #import "PFHTTPRequest.h"
-#import "PFObject.h"
+#import "PFObjectPrivate.h"
 #import "PFObjectBatchController.h"
+#import "PFObjectState.h"
 #import "PFRESTCommand.h"
+#import "PFRESTObjectBatchCommand.h"
 #import "PFUnitTestCase.h"
 
 @interface ObjectBatchControllerTests : PFUnitTestCase
@@ -51,6 +53,8 @@
     XCTAssertNotNil(controller);
     XCTAssertEqual((id)controller.dataSource, dataSource);
 }
+
+#pragma mark Fetch
 
 - (void)testFetchAll {
     id<PFCommandRunnerProvider> dataSource = [self mockedDataSource];
@@ -128,12 +132,94 @@
     OCMVerifyAll(commandRunner);
 }
 
+#pragma mark Delete
+
+- (void)testDeleteAll {
+    id<PFCommandRunnerProvider> dataSource = [self mockedDataSource];
+    id commandRunner = dataSource.commandRunner;
+
+    NSString *sessionToken = [[NSUUID UUID] UUIDString];
+
+    NSArray *result = @[ @{ @"success" : @{} }, @{ @"success" : @{} } ];
+    [commandRunner mockCommandResult:result forCommandsPassingTest:^BOOL(PFRESTCommand *command) {
+        XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
+        XCTAssertEqualObjects(command.parameters, (@{ @"requests" : @[ @{ @"method" : @"DELETE",
+                                                                          @"path" : @"/1/classes/Yolo/id1" },
+                                                                       @{ @"method" : @"DELETE",
+                                                                          @"path" : @"/1/classes/Yolo/id2" }] }));
+        XCTAssertEqualObjects(command.sessionToken, sessionToken);
+        return YES;
+    }];
+
+    PFObjectBatchController *controller = [[PFObjectBatchController alloc] initWithDataSource:dataSource];
+    NSArray *objects = @[ [PFObject objectWithoutDataWithClassName:@"Yolo" objectId:@"id1"],
+                          [PFObject objectWithoutDataWithClassName:@"Yolo" objectId:@"id2"] ];
+
+    XCTestExpectation *expectation = [self currentSelectorTestExpectation];
+    [[controller deleteObjectsAsync:objects withSessionToken:sessionToken] continueWithSuccessBlock:^id(BFTask *task) {
+        XCTAssertEqual(task.result, objects);
+        for (PFObject *object in objects) {
+            XCTAssertTrue(object._state.deleted);
+        }
+        [expectation fulfill];
+        return nil;
+    }];
+    [self waitForTestExpectations];
+}
+
+- (void)testDeleteAllWithoutObjects {
+    id dataSource = [self mockedDataSource];
+    PFObjectBatchController *controller = [PFObjectBatchController controllerWithDataSource:dataSource];
+
+    XCTAssertEqualObjects([[controller deleteObjectsAsync:@[] withSessionToken:nil] waitForResult:nil], @[]);
+    XCTAssertNil([[controller deleteObjectsAsync:nil withSessionToken:nil] waitForResult:nil]);
+}
+
+- (void)testDeleteAllError {
+    id<PFCommandRunnerProvider> dataSource = [self mockedDataSource];
+    id commandRunner = dataSource.commandRunner;
+
+    NSString *sessionToken = [[NSUUID UUID] UUIDString];
+
+    NSMutableArray *result = [NSMutableArray arrayWithCapacity:PFRESTObjectBatchCommandSubcommandsLimit];
+    while (result.count < PFRESTObjectBatchCommandSubcommandsLimit) {
+        [result addObject:@{ @"error" : @{@"code" : @(kPFErrorObjectNotFound), @"error" : @"yolo"} }];
+    }
+    [commandRunner mockCommandResult:result forCommandsPassingTest:^BOOL(PFRESTCommand *command) {
+        XCTAssertEqualObjects(command.httpMethod, PFHTTPRequestMethodPOST);
+        XCTAssertEqual([command.parameters[@"requests"] count], PFRESTObjectBatchCommandSubcommandsLimit);
+        XCTAssertEqualObjects(command.sessionToken, sessionToken);
+        return YES;
+    }];
+
+    PFObjectBatchController *controller = [[PFObjectBatchController alloc] initWithDataSource:dataSource];
+
+    NSMutableArray *objects = [NSMutableArray arrayWithCapacity:PFRESTObjectBatchCommandSubcommandsLimit * 3];
+    while (objects.count < PFRESTObjectBatchCommandSubcommandsLimit * 3) {
+        PFObject *object = [PFObject objectWithoutDataWithClassName:@"Yolo" objectId:[[NSUUID UUID] UUIDString]];
+        [objects addObject:object];
+    }
+
+    XCTestExpectation *expectation = [self currentSelectorTestExpectation];
+    [[controller deleteObjectsAsync:objects withSessionToken:sessionToken] continueWithBlock:^id(BFTask *task) {
+        NSError *error = task.error;
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.domain, BFTaskErrorDomain);
+        XCTAssertEqual([error.userInfo[@"errors"] count], objects.count);
+        [expectation fulfill];
+        return nil;
+    }];
+    [self waitForTestExpectations];
+}
+
+#pragma mark Utilities
+
 - (void)testUniqueObjects {
     PFObject *object = [PFObject objectWithoutDataWithClassName:@"Yarr" objectId:@"123"];
     PFObject *fetchedObject = [PFObject objectWithClassName:@"Yarr"];
     fetchedObject.objectId = @"yarr";
 
-    NSArray *array = [PFObjectBatchController uniqueObjectsArrayFromArray:@[ object, object, fetchedObject]
+    NSArray *array = [PFObjectBatchController uniqueObjectsArrayFromArray:@[ object, object, fetchedObject ]
                                                       omitObjectsWithData:NO];
     XCTAssertEqual(array.count, 2);
     XCTAssertTrue([array containsObject:object]);
@@ -145,7 +231,7 @@
     PFObject *fetchedObject = [PFObject objectWithClassName:@"Yarr"];
     fetchedObject.objectId = @"yarr";
 
-    NSArray *array = [PFObjectBatchController uniqueObjectsArrayFromArray:@[ object, object, fetchedObject]
+    NSArray *array = [PFObjectBatchController uniqueObjectsArrayFromArray:@[ object, object, fetchedObject ]
                                                       omitObjectsWithData:YES];
     XCTAssertEqualObjects(array, @[ object ]);
 }
@@ -170,6 +256,25 @@
                                                                              omitObjectsWithData:NO]));
     PFAssertThrowsInvalidArgumentException(([PFObjectBatchController uniqueObjectsArrayFromArray:@[ object, object2 ]
                                                                              omitObjectsWithData:YES]));
+}
+
+- (void)testUniqueObjectsUsingFilter {
+    PFObject *nonUniqueObject = [PFObject objectWithClassName:@"Yolo"];
+    NSArray *array = @[ nonUniqueObject,
+                        [PFObject objectWithClassName:@"Yarr"],
+                        nonUniqueObject ];
+    NSArray *filteredArray = [PFObjectBatchController uniqueObjectsArrayFromArray:array usingFilter:^BOOL(PFObject *object) {
+        return [object.parseClassName isEqualToString:@"Yolo"];
+    }];
+
+    XCTAssertNotNil(filteredArray);
+    XCTAssertEqualObjects(filteredArray, @[ nonUniqueObject ]);
+
+    filteredArray = [PFObjectBatchController uniqueObjectsArrayFromArray:@[] usingFilter:^BOOL(PFObject *object) {
+        return YES;
+    }];
+    XCTAssertNotNil(filteredArray);
+    XCTAssertEqualObjects(filteredArray, @[]);
 }
 
 @end


### PR DESCRIPTION
- Implemented PFObject.deleteAll through PFObjectBatchController
- Tested against api.parse.com - it works beautifully
- Way better decoupled state, as well as properly using dependency injected command runner
- Fixed bugs around `deleteAll` not properly deleting objects from LDS, as well as not updating the `deleted` property on state
