### PR TITLE
Added proper caching to PFObjectSubclassInfo.

### DIFF
--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassInfo.m
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassInfo.m
@@ -88,6 +88,9 @@ static objc_property_t getAccessorMutatorPair(Class klass, SEL sel, SEL outPair[
     _dataAccessQueue = dispatch_queue_create("com.parse.object.subclassing.data.access", DISPATCH_QUEUE_SERIAL);
     _subclass = kls;
 
+    _knownProperties = [NSMutableDictionary dictionary];
+    _knownMethodSignatures = [NSMutableDictionary dictionary];
+
     return self;
 }
 


### PR DESCRIPTION
Silly mistake. Doesn't cause any real-world problems other than performance and memory usage thankfully. Fixes #125.