### PR TITLE
Restructure authentication provider APIs on PFUser to be able to publicly support them.

### DIFF
--- a/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
+++ b/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFAuthenticationProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -31,25 +33,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Authentication
 ///--------------------------------------
 
-- (BFTask *)authenticateAsyncWithProviderForAuthType:(NSString *)authType;
 - (BFTask *)deauthenticateAsyncWithProviderForAuthType:(NSString *)authType;
 
-- (BOOL)restoreAuthenticationWithAuthData:(nullable NSDictionary *)authData
-                  withProviderForAuthType:(NSString *)authType;
+- (BFTask *)restoreAuthenticationAsyncWithAuthData:(nullable NSDictionary *)authData
+                           forProviderWithAuthType:(NSString *)authType;
 
 ///--------------------------------------
 /// @name Log In
 ///--------------------------------------
 
-- (BFTask *)logInUserAsyncWithAuthType:(NSString *)authType;
 - (BFTask *)logInUserAsyncWithAuthType:(NSString *)authType authData:(NSDictionary *)authData;
-
-///--------------------------------------
-/// @name Link
-///--------------------------------------
-
-- (BFTask *)linkUserAsync:(PFUser *)user withAuthType:(NSString *)authType;
-- (BFTask *)linkUserAsync:(PFUser *)user withAuthType:(NSString *)authType authData:(NSDictionary *)authData;
 
 @end
 

--- a/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.m
+++ b/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.m
@@ -21,16 +21,12 @@
     return @"anonymous";
 }
 
-- (BFTask *)authenticateAsync {
-    return [BFTask taskWithResult:self.authData];
-}
-
-- (BFTask *)deauthenticateAsync {
+- (BFTask *)deauthenticateInBackground {
     return [BFTask taskWithResult:nil];
 }
 
-- (BOOL)restoreAuthenticationWithAuthData:(NSDictionary *)authData {
-    return YES;
+- (BFTask *)restoreAuthenticationInBackgroundWithAuthData:(NSDictionary *)authData {
+    return [BFTask taskWithResult:nil];
 }
 
 ///--------------------------------------

--- a/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousUtils_Private.h
+++ b/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousUtils_Private.h
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "PFAnonymousUtils.h"
+#import <Parse/PFAnonymousUtils.h>
 
 @class PFAnonymousAuthenticationProvider;
 @class PFUser;
@@ -15,6 +15,7 @@
 @interface PFAnonymousUtils (Private)
 
 + (PFAnonymousAuthenticationProvider *)_authenticationProvider;
++ (void)_clearAuthenticationProvider;
 
 + (PFUser *)_lazyLogIn;
 

--- a/Parse/Internal/User/AuthenticationProviders/Providers/PFAuthenticationProvider.h
+++ b/Parse/Internal/User/AuthenticationProviders/Providers/PFAuthenticationProvider.h
@@ -9,7 +9,13 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Bolts/BFTask.h>
+
+#import <Parse/PFConstants.h>
+
+//TODO: (nlutsenko) Update documentation for all these methods.
+
+PF_ASSUME_NONNULL_BEGIN
 
 /*!
  A common protocol for general Parse authentication providers.
@@ -26,16 +32,9 @@
 + (NSString *)authType;
 
 /*!
- Invoked by a PFUser to authenticate with the service.  This function should call back PFUser (using the supplied blocks) to notify it of success.
- The NSDictionary passed to the success block should contain relevant authData (and should match the server's expectations of data to be used
- for verifying identity on the server).
+ Invoked by a PFUser upon logOut. Deauthenticate should be used to clear any state being kept by the provider that is associated with the logged-in user.
  */
-- (BFTask *)authenticateAsync;
-
-/*!
- Invoked by a PFUser upon logOut.  Deauthenticate should be used to clear any state being kept by the provider that is associated with the logged-in user.
- */
-- (BFTask *)deauthenticateAsync;
+- (BFTask *)deauthenticateInBackground;
 
 /*!
  Upon logging in (or restoring a PFUser from disk), authData is returned from the server, and the PFUser passes that data into this function,
@@ -43,6 +42,8 @@
  can be used immediately, without having to reauthorize).  authData can be nil, in which case the user has been unlinked, and the service should clear its
  internal state.  Returning NO from this function indicates the authData was somehow invalid, and the user should be unlinked from the provider.
  */
-- (BOOL)restoreAuthenticationWithAuthData:(NSDictionary *)authData;
+- (BFTask *)restoreAuthenticationInBackgroundWithAuthData:(PF_NULLABLE NSDictionary *)authData;
 
 @end
+
+PF_ASSUME_NONNULL_END

--- a/Parse/Internal/User/PFUserPrivate.h
+++ b/Parse/Internal/User/PFUserPrivate.h
@@ -9,7 +9,7 @@
 
 #import <Foundation/Foundation.h>
 
-# import <Parse/PFUser.h>
+#import <Parse/PFUser.h>
 
 #import "PFAuthenticationProvider.h"
 
@@ -19,6 +19,7 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 
 @class BFTask;
 @class PFCommandResult;
+@class PFUserController;
 
 @interface PFUser (Private)
 
@@ -32,12 +33,7 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 
 - (void)checkSignUpParams;
 
-+ (BFTask *)_logInWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
 - (BFTask *)_handleServiceLoginCommandResult:(PFCommandResult *)result;
-
-- (BFTask *)_linkWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
-
-- (BFTask *)_unlinkWithAuthTypeInBackground:(NSString *)authType;
 
 - (void)synchronizeAuthDataWithAuthType:(NSString *)authType;
 
@@ -51,6 +47,8 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 ///--------------------------------------
 + (BOOL)_isRevocableSessionEnabled;
 + (void)_setRevocableSessionEnabled:(BOOL)enabled;
+
++ (PFUserController *)userController;
 
 @end
 
@@ -73,5 +71,27 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 - (BOOL)_isAuthenticatedWithCurrentUser:(PFUser *)currentUser;
 
 - (BFTask *)_logOutAsync;
+
+///--------------------------------------
+/// @name Authentication Providers
+///--------------------------------------
+
+// TODO: (nlutsenko) Add Documentation
++ (void)registerAuthenticationProvider:(id<PFAuthenticationProvider>)authenticationProvider;
+
+// TODO: (nlutsenko) Add Documentation
++ (BFTask *)logInWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
+
+// TODO: (nlutsenko) Add Documentation
+- (BFTask *)linkWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
+
+// TODO: (nlutsenko) Add Documentation
+- (BFTask *)unlinkWithAuthTypeInBackground:(NSString *)authType;
+
+///--------------------------------------
+/// @name Authentication Providers (Private)
+///--------------------------------------
+
++ (void)_unregisterAuthenticationProvider:(id<PFAuthenticationProvider>)provider;
 
 @end

--- a/Parse/PFAnonymousUtils.m
+++ b/Parse/PFAnonymousUtils.m
@@ -12,33 +12,19 @@
 
 #import "BFTask+Private.h"
 #import "PFAnonymousAuthenticationProvider.h"
-#import "PFCoreManager.h"
 #import "PFInternalUtils.h"
-#import "PFUserAuthenticationController.h"
 #import "PFUserPrivate.h"
-#import "Parse_Private.h"
 
 @implementation PFAnonymousUtils
 
-+ (PFAnonymousAuthenticationProvider *)_authenticationProvider {
-    NSString *authType = [PFAnonymousAuthenticationProvider authType];
-
-    PFUserAuthenticationController *controller = [Parse _currentManager].coreManager.userAuthenticationController;
-    PFAnonymousAuthenticationProvider *provider = [controller authenticationProviderForAuthType:authType];
-    if (!provider) {
-        provider = [[PFAnonymousAuthenticationProvider alloc] init];
-        [controller registerAuthenticationProvider:provider];
-    }
-    return provider;
-}
-
-+ (BOOL)isLinkedWithUser:(PFUser *)user {
-    return [user.linkedServiceNames containsObject:[[[self _authenticationProvider] class] authType]];
-}
+///--------------------------------------
+#pragma mark - Log In
+///--------------------------------------
 
 + (BFTask *)logInInBackground {
-    PFUserAuthenticationController *controller = [Parse _currentManager].coreManager.userAuthenticationController;
-    return [controller logInUserAsyncWithAuthType:[[[self _authenticationProvider] class] authType]];
+    PFAnonymousAuthenticationProvider *provider = [self _authenticationProvider];
+    NSString *authType = [[provider class] authType];
+    return [PFUser logInWithAuthTypeInBackground:authType authData:provider.authData];
 }
 
 + (void)logInWithBlock:(PFUserResultBlock)block {
@@ -46,14 +32,61 @@
 }
 
 + (void)logInWithTarget:(id)target selector:(SEL)selector {
-    [PFAnonymousUtils logInWithBlock:^(PFUser *user, NSError *error) {
+    [self logInWithBlock:^(PFUser *user, NSError *error) {
         [PFInternalUtils safePerformSelector:selector withTarget:target object:user object:error];
     }];
 }
 
+///--------------------------------------
+#pragma mark - Link
+///--------------------------------------
+
++ (BOOL)isLinkedWithUser:(PFUser *)user {
+    return [user.linkedServiceNames containsObject:[[[self _authenticationProvider] class] authType]];
+}
+
+///--------------------------------------
+#pragma mark - Private
+///--------------------------------------
+
+static PFAnonymousAuthenticationProvider *authenticationProvider_;
+
++ (dispatch_queue_t)_providerAccessQueue {
+    static dispatch_queue_t queue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        queue = dispatch_queue_create("com.parse.anonymousUtils.provider.access", DISPATCH_QUEUE_SERIAL);
+    });
+    return queue;
+}
+
++ (PFAnonymousAuthenticationProvider *)_authenticationProvider {
+    __block PFAnonymousAuthenticationProvider *provider = nil;
+    dispatch_sync([self _providerAccessQueue], ^{
+        provider = authenticationProvider_;
+        if (!provider) {
+            provider = [[PFAnonymousAuthenticationProvider alloc] init];
+            [PFUser registerAuthenticationProvider:provider];
+            authenticationProvider_ = provider;
+        }
+    });
+    return provider;
+}
+
++ (void)_clearAuthenticationProvider {
+    [PFUser _unregisterAuthenticationProvider:authenticationProvider_];
+    dispatch_sync([self _providerAccessQueue], ^{
+        authenticationProvider_ = nil;
+    });
+}
+
+///--------------------------------------
+#pragma mark - Lazy Login
+///--------------------------------------
+
 + (PFUser *)_lazyLogIn {
     PFAnonymousAuthenticationProvider *provider = [self _authenticationProvider];
-    return [PFUser logInLazyUserWithAuthType:[[provider class] authType] authData:[provider authData]];
+    return [PFUser logInLazyUserWithAuthType:[[provider class] authType] authData:provider.authData];
 }
 
 @end

--- a/Tests/Unit/AnonymousAuthenticationProviderTests.m
+++ b/Tests/Unit/AnonymousAuthenticationProviderTests.m
@@ -36,25 +36,11 @@
     XCTAssertEqualObjects([PFAnonymousAuthenticationProvider authType], @"anonymous");
 }
 
-- (void)testAuthenticateAsync {
+- (void)testDeauthenticateInBackground {
     PFAnonymousAuthenticationProvider *provider = [[PFAnonymousAuthenticationProvider alloc] init];
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
-    [[provider authenticateAsync] continueWithBlock:^id(BFTask *task) {
-        NSDictionary *authData = task.result;
-        XCTAssertNotNil(authData);
-        XCTAssertNotNil(authData[@"id"]);
-        [expectation fulfill];
-        return nil;
-    }];
-    [self waitForTestExpectations];
-}
-
-- (void)testDeauthenticateAsync {
-    PFAnonymousAuthenticationProvider *provider = [[PFAnonymousAuthenticationProvider alloc] init];
-
-    XCTestExpectation *expectation = [self currentSelectorTestExpectation];
-    [[provider deauthenticateAsync] continueWithBlock:^id(BFTask *task) {
+    [[provider deauthenticateInBackground] continueWithBlock:^id(BFTask *task) {
         XCTAssertNil(task.result);
         XCTAssertFalse(task.faulted);
         XCTAssertFalse(task.cancelled);
@@ -66,12 +52,16 @@
 
 - (void)testRestoreAuthentication {
     PFAnonymousAuthenticationProvider *provider = [[PFAnonymousAuthenticationProvider alloc] init];
-    XCTAssertTrue([provider restoreAuthenticationWithAuthData:@{ @"id" : @"123" }]);
+    BFTask *task = [provider restoreAuthenticationInBackgroundWithAuthData:@{ @"id" : @"123" }];
+    [task waitUntilFinished];
+    XCTAssertFalse(task.faulted);
 }
 
 - (void)testRestoreAuthenticationWithNoData {
     PFAnonymousAuthenticationProvider *provider = [[PFAnonymousAuthenticationProvider alloc] init];
-    XCTAssertTrue([provider restoreAuthenticationWithAuthData:nil]);
+    BFTask *task = [provider restoreAuthenticationInBackgroundWithAuthData:nil];
+    [task waitUntilFinished];
+    XCTAssertFalse(task.faulted);
 }
 
 @end

--- a/Tests/Unit/AnonymousUtilsTests.m
+++ b/Tests/Unit/AnonymousUtilsTests.m
@@ -15,6 +15,7 @@
 #import "PFUnitTestCase.h"
 #import "PFUserAuthenticationController.h"
 #import "Parse_Private.h"
+#import "PFAnonymousAuthenticationProvider.h"
 
 @protocol AnonymousUtilsObserver <NSObject>
 
@@ -27,6 +28,21 @@
 @end
 
 @implementation AnonymousUtilsTests
+
+- (void)setUp {
+    [super setUp];
+
+    // Put this into setUp to make sure our state is fully clean.
+    [PFAnonymousUtils _clearAuthenticationProvider];
+}
+
+- (void)tearDown {
+    // Clear the manager first - to make sure we don't have any mocks set.
+    [Parse _clearCurrentManager];
+    [PFAnonymousUtils _clearAuthenticationProvider];
+
+    [super tearDown];
+}
 
 ///--------------------------------------
 #pragma mark - Helpers
@@ -44,18 +60,16 @@
 
 - (void)testInitialize {
     id authController = [self mockedUserAuthenticationController];
-
-    __block id provider = nil;
-    OCMExpect([authController authenticationProviderForAuthType:@"anonymous"]);
     OCMExpect([authController registerAuthenticationProvider:[OCMArg checkWithBlock:^BOOL(id obj) {
-        provider = obj;
         return [[[obj class] authType] isEqualToString:@"anonymous"];
     }]]);
 
+    PFAnonymousAuthenticationProvider *provider = [PFAnonymousUtils _authenticationProvider];
+    XCTAssertNotNil(provider);
+    XCTAssertEqual(provider, [PFAnonymousUtils _authenticationProvider]);
+
     provider = [PFAnonymousUtils _authenticationProvider];
     XCTAssertNotNil(provider);
-
-    OCMStub([authController authenticationProviderForAuthType:@"anonymous"]).andReturn(provider);
     XCTAssertEqual(provider, [PFAnonymousUtils _authenticationProvider]);
 
     OCMVerifyAll(authController);
@@ -63,13 +77,13 @@
 
 - (void)testLogInViaTask {
     id authController = [self mockedUserAuthenticationController];
-    OCMExpect([authController authenticationProviderForAuthType:@"anonymous"]).andReturn(nil);
+    OCMStub([authController authenticationProviderForAuthType:@"anonymous"]).andReturn([[PFAnonymousAuthenticationProvider alloc] init]);
     OCMExpect([authController registerAuthenticationProvider:[OCMArg checkWithBlock:^BOOL(id obj) {
         return [[[obj class] authType] isEqualToString:@"anonymous"];
     }]]);
 
     PFUser *user = [PFUser user];
-    [OCMExpect([authController logInUserAsyncWithAuthType:@"anonymous"]) andReturn:[BFTask taskWithResult:user]];
+    OCMExpect([authController logInUserAsyncWithAuthType:@"anonymous" authData:[OCMArg isNotNil]]).andReturn([BFTask taskWithResult:user]);
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[PFAnonymousUtils logInInBackground] continueWithSuccessBlock:^id(BFTask *task) {
@@ -83,13 +97,13 @@
 
 - (void)testLogInViaBlock {
     id authController = [self mockedUserAuthenticationController];
-    OCMExpect([authController authenticationProviderForAuthType:@"anonymous"]).andReturn(nil);
+    OCMStub([authController authenticationProviderForAuthType:@"anonymous"]).andReturn([[PFAnonymousAuthenticationProvider alloc] init]);
     OCMExpect([authController registerAuthenticationProvider:[OCMArg checkWithBlock:^BOOL(id obj) {
         return [[[obj class] authType] isEqualToString:@"anonymous"];
     }]]);
 
     PFUser *user = [PFUser user];
-    [OCMExpect([authController logInUserAsyncWithAuthType:@"anonymous"]) andReturn:[BFTask taskWithResult:user]];
+    OCMExpect([authController logInUserAsyncWithAuthType:@"anonymous" authData:[OCMArg isNotNil]]).andReturn([BFTask taskWithResult:user]);
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [PFAnonymousUtils logInWithBlock:^(PFUser *resultUser, NSError *error) {
@@ -103,13 +117,13 @@
 
 - (void)testLogInViaTargetSelector {
     id authController = [self mockedUserAuthenticationController];
-    OCMExpect([authController authenticationProviderForAuthType:@"anonymous"]).andReturn(nil);
+    OCMStub([authController authenticationProviderForAuthType:@"anonymous"]).andReturn([[PFAnonymousAuthenticationProvider alloc] init]);
     OCMExpect([authController registerAuthenticationProvider:[OCMArg checkWithBlock:^BOOL(id obj) {
         return [[[obj class] authType] isEqualToString:@"anonymous"];
     }]]);
 
     PFUser *user = [PFUser user];
-    [OCMExpect([authController logInUserAsyncWithAuthType:@"anonymous"]) andReturn:[BFTask taskWithResult:user]];
+    OCMExpect([authController logInUserAsyncWithAuthType:@"anonymous" authData:[OCMArg isNotNil]]).andReturn([BFTask taskWithResult:user]);
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
 


### PR DESCRIPTION
This is just restructuring internal APIs that are used for `PFAuthenticationProvider` instance for Facebook/Twitter/Anonymous.
- Restructured and renamed APIs on `PFUser`, `PFAuthenticationProvider`.
- Moved `logInWithAuthType:authData` from `PFUser` into `PFUserAuthenticationController` (yay!)
- Updated `PFAnonymousUtils` and `PFAnonymousAuthenticationProvider` to use new APIs
- Updated tests