### PR TITLE
Fixed iOS 9 deprecation warnings in PFAlertView, PFPushUtilities.

### DIFF
--- a/Parse/Internal/PFAlertView.m
+++ b/Parse/Internal/PFAlertView.m
@@ -9,8 +9,6 @@
 
 #import "PFAlertView.h"
 
-#import <UIKit/UIKit.h>
-
 @interface PFAlertView () <UIAlertViewDelegate>
 
 @property (nonatomic, copy) PFAlertViewCompletion completion;
@@ -62,6 +60,7 @@
 
         [viewController presentViewController:alertController animated:YES completion:nil];
     } else {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
         __block PFAlertView *pfAlertView = [[self alloc] init];
         UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title
                                                             message:message
@@ -83,8 +82,11 @@
 
         alertView.delegate = pfAlertView;
         [alertView show];
+#endif
     }
 }
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
 
 ///--------------------------------------
 #pragma mark - UIAlertViewDelegate
@@ -99,5 +101,7 @@
         }
     }
 }
+
+#endif
 
 @end

--- a/Parse/Internal/Push/Utilites/PFPushUtilities.m
+++ b/Parse/Internal/Push/Utilites/PFPushUtilities.m
@@ -12,9 +12,9 @@
 #import <dlfcn.h>
 
 #if TARGET_OS_IPHONE
-
 #import <AudioToolbox/AudioToolbox.h>
 
+#import "PFAlertView.h"
 #endif
 
 #import "PFInstallationPrivate.h"
@@ -60,12 +60,11 @@
     NSString *cancelButtonTitle = NSLocalizedStringFromTableInBundle(@"OK", @"Parse",
                                                                      [NSBundle bundleForClass:[self class]],
                                                                      @"Default alert view cancel button title.");
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title
-                                                    message:message
-                                                   delegate:nil
-                                          cancelButtonTitle:cancelButtonTitle
-                                          otherButtonTitles:nil];
-    [alert show];
+    [PFAlertView showAlertWithTitle:title
+                            message:message
+                  cancelButtonTitle:cancelButtonTitle
+                  otherButtonTitles:nil
+                         completion:nil];
 }
 
 + (void)playAudioWithName:(NSString *)audioFileName {


### PR DESCRIPTION
If used with Cocoapods and minimum deployment target is set to iOS 9 - these two places were providing warnings.
- Added compile time check for PFAlertView
- Made PFPushUtilities use PFAlertView