### PR TITLE
Lazy-load PFEventuallyQueue in PFAnalyticsController.

### DIFF
--- a/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
+++ b/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
@@ -9,21 +9,22 @@
 
 #import <Foundation/Foundation.h>
 
+#import "PFDataProvider.h"
+
 @class BFTask;
-@class PFEventuallyQueue;
 
 @interface PFAnalyticsController : NSObject
 
-@property (nonatomic, strong, readonly) PFEventuallyQueue *eventuallyQueue;
+@property (nonatomic, weak, readonly) id<PFEventuallyQueueProvider> dataSource;
 
 ///--------------------------------------
 /// @name Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithEventuallyQueue:(PFEventuallyQueue *)eventuallyQueue NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDataSource:(id<PFEventuallyQueueProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
-+ (instancetype)controllerWithEventuallyQueue:(PFEventuallyQueue *)eventuallyQueue;
++ (instancetype)controllerWithDataSource:(id<PFEventuallyQueueProvider>)dataSource;
 
 ///--------------------------------------
 /// @name Track Event

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -318,7 +318,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
     __block PFAnalyticsController *controller = nil;
     dispatch_sync(_controllerAccessQueue, ^{
         if (!_analyticsController) {
-            _analyticsController = [[PFAnalyticsController alloc] initWithEventuallyQueue:self.eventuallyQueue];
+            _analyticsController = [[PFAnalyticsController alloc] initWithDataSource:self];
         }
         controller = _analyticsController;
     });

--- a/Tests/Unit/AnalyticsControllerTests.m
+++ b/Tests/Unit/AnalyticsControllerTests.m
@@ -26,12 +26,18 @@
 #pragma mark - Helpers
 ///--------------------------------------
 
-- (PFEventuallyQueue *)eventuallyQueueMockWithCommandResult:(PFCommandResult *)result {
-    BFTask *task = [BFTask taskWithResult:result];
+- (id<PFEventuallyQueueProvider>)dataSourceMock {
+    id queueMock = PFStrictClassMock([PFEventuallyQueue class]);
+    id dataSource = PFStrictProtocolMock(@protocol(PFEventuallyQueueProvider));
+    OCMStub([dataSource eventuallyQueue]).andReturn(queueMock);
+    return dataSource;
+}
 
-    id queueMock = PFClassMock([PFEventuallyQueue class]);
-    OCMStub([queueMock enqueueCommandInBackground:OCMOCK_ANY]).andReturn(task);
-    return queueMock;
+- (id<PFEventuallyQueueProvider>)dataSourceMockWithCommandResult:(PFCommandResult *)result {
+    id dataSource = [self dataSourceMock];
+    id queue = [dataSource eventuallyQueue];
+    OCMStub([queue enqueueCommandInBackground:OCMOCK_ANY]).andReturn([BFTask taskWithResult:result]);
+    return dataSource;
 }
 
 ///--------------------------------------
@@ -39,26 +45,26 @@
 ///--------------------------------------
 
 - (void)testConstructors {
-    PFEventuallyQueue *queue = [self eventuallyQueueMockWithCommandResult:nil];
+    id dataSource = [self dataSourceMock];
 
-    PFAnalyticsController *controller = [[PFAnalyticsController alloc] initWithEventuallyQueue:queue];
+    PFAnalyticsController *controller = [[PFAnalyticsController alloc] initWithDataSource:dataSource];
     XCTAssertNotNil(controller);
-    XCTAssertEqual(controller.eventuallyQueue, queue);
+    XCTAssertEqual((id)controller.dataSource, dataSource);
 
-    controller = [PFAnalyticsController controllerWithEventuallyQueue:queue];
+    controller = [PFAnalyticsController controllerWithDataSource:dataSource];
     XCTAssertNotNil(controller);
-    XCTAssertEqual(controller.eventuallyQueue, queue);
+    XCTAssertEqual((id)controller.dataSource, dataSource);
 }
 
 - (void)testTrackEventWithInvalidParameters {
-    PFEventuallyQueue *queue = [self eventuallyQueueMockWithCommandResult:nil];
-    PFAnalyticsController *controller = [PFAnalyticsController controllerWithEventuallyQueue:queue];
+    id dataSource = [self dataSourceMockWithCommandResult:nil];
+    PFAnalyticsController *controller = [PFAnalyticsController controllerWithDataSource:dataSource];
 
     PFAssertThrowsInvalidArgumentException([controller trackEventAsyncWithName:nil dimensions:nil sessionToken:nil]);
     PFAssertThrowsInvalidArgumentException([controller trackEventAsyncWithName:@" " dimensions:nil sessionToken:nil]);
     PFAssertThrowsInvalidArgumentException([controller trackEventAsyncWithName:@"\n" dimensions:nil sessionToken:nil]);
     PFAssertThrowsInvalidArgumentException([controller trackEventAsyncWithName:@"f"
-                                                                    dimensions:@{ @2: @"five" }
+                                                                    dimensions:@{ @2 : @"five" }
                                                                   sessionToken:nil]);
     PFAssertThrowsInvalidArgumentException([controller trackEventAsyncWithName:@"f"
                                                                     dimensions:@{ @"num" : @5 }
@@ -66,7 +72,8 @@
 }
 
 - (void)testTrackEventParameters {
-    id queue = PFStrictClassMock([PFEventuallyQueue class]);
+    id dataSource = [self dataSourceMock];
+    id queue = [dataSource eventuallyQueue];
     OCMExpect([queue enqueueCommandInBackground:[OCMArg checkWithBlock:^BOOL(id obj) {
         PFRESTCommand *command = obj;
 
@@ -77,7 +84,7 @@
         return YES;
     }]]);
 
-    PFAnalyticsController *controller = [PFAnalyticsController controllerWithEventuallyQueue:queue];
+    PFAnalyticsController *controller = [PFAnalyticsController controllerWithDataSource:dataSource];
     [[controller trackEventAsyncWithName:@"boom"
                               dimensions:@{ @"yarr" : @"yolo" }
                             sessionToken:@"argh"] waitUntilFinished];
@@ -89,13 +96,13 @@
     PFCommandResult *result = [PFCommandResult commandResultWithResult:@{}
                                                           resultString:nil
                                                           httpResponse:nil];
-    PFEventuallyQueue *queue = [self eventuallyQueueMockWithCommandResult:result];
-    PFAnalyticsController *controller = [PFAnalyticsController controllerWithEventuallyQueue:queue];
+    id dataSource = [self dataSourceMockWithCommandResult:result];
+    PFAnalyticsController *controller = [PFAnalyticsController controllerWithDataSource:dataSource];
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[controller trackEventAsyncWithName:@"a"
-                             dimensions:nil
-                           sessionToken:nil] continueWithSuccessBlock:^id(BFTask *task) {
+                              dimensions:nil
+                            sessionToken:nil] continueWithSuccessBlock:^id(BFTask *task) {
         XCTAssertEqualObjects(task.result, @YES);
         [expectation fulfill];
         return nil;
@@ -104,7 +111,8 @@
 }
 
 - (void)testTrackAppOpenedParameters {
-    id queue = PFStrictClassMock([PFEventuallyQueue class]);
+    id dataSource = [self dataSourceMock];
+    id queue = [dataSource eventuallyQueue];
     OCMExpect([queue enqueueCommandInBackground:[OCMArg checkWithBlock:^BOOL(id obj) {
         PFRESTCommand *command = obj;
 
@@ -115,9 +123,9 @@
         return YES;
     }]]);
 
-    PFAnalyticsController *controller = [PFAnalyticsController controllerWithEventuallyQueue:queue];
-    [[controller trackAppOpenedEventAsyncWithRemoteNotificationPayload:@{ @"aps" : @{ @"alert" : @"yolo" } }
-                                                         sessionToken:@"argh"] waitUntilFinished];
+    PFAnalyticsController *controller = [PFAnalyticsController controllerWithDataSource:dataSource];
+    [[controller trackAppOpenedEventAsyncWithRemoteNotificationPayload:@{ @"aps" : @{@"alert" : @"yolo"} }
+                                                          sessionToken:@"argh"] waitUntilFinished];
 
     OCMVerifyAll(queue);
 }
@@ -126,8 +134,8 @@
     PFCommandResult *result = [PFCommandResult commandResultWithResult:@{}
                                                           resultString:nil
                                                           httpResponse:nil];
-    PFEventuallyQueue *queue = [self eventuallyQueueMockWithCommandResult:result];
-    PFAnalyticsController *controller = [PFAnalyticsController controllerWithEventuallyQueue:queue];
+    id dataSource = [self dataSourceMockWithCommandResult:result];
+    PFAnalyticsController *controller = [PFAnalyticsController controllerWithDataSource:dataSource];
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[controller trackAppOpenedEventAsyncWithRemoteNotificationPayload:nil


### PR DESCRIPTION
- Make `PFAnalyticsController` follow the provider pattern
- Fixed rare main thread stall inside PFAnalyticsController on `trackAppLaunched`
- Fixed rare main thread stall on loading `PFEventuallyQueue`