### PR TITLE
Fixed error on network requests to Object APIs with 'error' column.

### DIFF
--- a/Tests/Unit/URLSessionDataTaskDelegateTests.m
+++ b/Tests/Unit/URLSessionDataTaskDelegateTests.m
@@ -70,11 +70,11 @@
     NSData *chunkA = [@"{ \"foo\" :" dataUsingEncoding:NSUTF8StringEncoding];
     NSData *chunkB = [@" \"bar\" }" dataUsingEncoding:NSUTF8StringEncoding];
 
-    NSURLResponse *urlResponse = [[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
-                                                           MIMEType:@"application/json"
-                                              expectedContentLength:chunkA.length + chunkB.length
-                                                   textEncodingName:@"UTF-8"];
-
+    NSHTTPURLResponse *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
+                                                                 statusCode:200
+                                                                HTTPVersion:@"HTTP/1.1"
+                                                               headerFields:nil];
+    
     [delegate URLSession:mockedSession
                     task:mockedTask
          didSendBodyData:5

--- a/Tests/Unit/URLSessionTests.m
+++ b/Tests/Unit/URLSessionTests.m
@@ -64,29 +64,29 @@
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *URLSession = [NSURLSession sharedSession];
     id delegate = PFStrictProtocolMock(@protocol(PFURLSessionDelegate));
-
+    
     PFURLSession *session = [[PFURLSession alloc] initWithConfiguration:configuration
                                                                delegate:delegate];
     XCTAssertNotNil(session);
     XCTAssertEqual((id)session.delegate, delegate);
     [session invalidateAndCancel];
-
+    
     session = [PFURLSession sessionWithConfiguration:configuration
                                             delegate:delegate];
     XCTAssertNotNil(session);
     XCTAssertEqual((id)session.delegate, delegate);
     [session invalidateAndCancel];
-
+    
     session = [[PFURLSession alloc] initWithURLSession:URLSession
                                               delegate:delegate];
     XCTAssertNotNil(URLSession);
     XCTAssertEqual((id)session.delegate, delegate);
-
+    
     session = [PFURLSession sessionWithURLSession:URLSession
                                          delegate:delegate];
     XCTAssertNotNil(session);
     XCTAssertEqual((id)session.delegate, delegate);
-
+    
     PFAssertThrowsInconsistencyException([PFURLSession new]);
 }
 
@@ -95,26 +95,26 @@
     NSURLRequest *mockedURLRequest = PFStrictClassMock([NSURLRequest class]);
     PFRESTCommand *mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     NSArray *mocks = @[ mockedURLSession, mockedURLRequest, mockedCommand ];
-
+    
     MockedSessionTask *mockedDataTask = [[MockedSessionTask alloc] init];
     mockedDataTask.originalRequest = mockedURLRequest;
-
+    
     __block id<NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate> sessionDelegate = nil;
-
+    
     OCMExpect([mockedURLSession dataTaskWithRequest:mockedURLRequest]).andReturn(mockedDataTask);
-
+    
     mockedDataTask.taskIdentifier = 1337;
-
+    
     @weakify(mockedDataTask);
     mockedDataTask.resumeBlock = ^{
         @strongify(mockedDataTask);
-
+        
         NSData *dataRecieved = [@"{ \"foo\": \"bar\" }" dataUsingEncoding:NSUTF8StringEncoding];
-        NSURLResponse *response = [[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
-                                                            MIMEType:@"application/json"
-                                               expectedContentLength:dataRecieved.length
-                                                    textEncodingName:@"UTF-8"];
-
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
+                                                                  statusCode:200
+                                                                 HTTPVersion:@"HTTP/1.1"
+                                                                headerFields:nil];
+        
         [sessionDelegate URLSession:mockedURLSession
                            dataTask:(id)mockedDataTask
                  didReceiveResponse:response
@@ -122,17 +122,17 @@
                       XCTAssertEqual(disposition, NSURLSessionResponseAllow);
                   }];
         [sessionDelegate URLSession:mockedURLSession dataTask:(id)mockedDataTask didReceiveData:dataRecieved];
-
+        
         [sessionDelegate URLSession:mockedURLSession task:(id)mockedDataTask didCompleteWithError:nil];
     };
-
+    
     id delegate = PFStrictProtocolMock(@protocol(PFURLSessionDelegate));
     PFURLSession *session = [PFURLSession sessionWithURLSession:mockedURLSession delegate:delegate];
     sessionDelegate = (id)session;
-
+    
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
     OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
-
+    
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performDataURLRequestAsync:mockedURLRequest forCommand:mockedCommand cancellationToken:nil] continueWithBlock:^id(BFTask *task) {
         PFCommandResult *actualResult = task.result;
@@ -141,7 +141,7 @@
         return nil;
     }];
     [self waitForTestExpectations];
-
+    
     OCMVerifyAll((id)mockedURLSession);
     OCMVerifyAll(delegate);
     [mocks makeObjectsPerformSelector:@selector(stopMocking)];
@@ -153,12 +153,12 @@
     PFRESTCommand *mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     id delegate = PFStrictProtocolMock(@protocol(PFURLSessionDelegate));
     NSArray *mocks = @[ mockedURLSession, mockedURLRequest, mockedCommand ];
-
+    
     BFCancellationTokenSource *cancellationTokenSource = [BFCancellationTokenSource cancellationTokenSource];
     PFURLSession *session = [PFURLSession sessionWithURLSession:mockedURLSession delegate:delegate];
-
+    
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
-
+    
     [cancellationTokenSource cancel];
     [[session performDataURLRequestAsync:mockedURLRequest
                               forCommand:mockedCommand
@@ -177,27 +177,27 @@
     NSURLRequest *mockedURLRequest = PFStrictClassMock([NSURLRequest class]);
     PFRESTCommand *mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     NSArray *mocks = @[ mockedURLSession, mockedURLRequest, mockedCommand ];
-
+    
     MockedSessionTask *mockedDataTask = [[MockedSessionTask alloc] init];
     mockedDataTask.originalRequest = mockedURLRequest;
-
+    
     BFCancellationTokenSource *cancellationTokenSource = [BFCancellationTokenSource cancellationTokenSource];
     __block id<NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate> sessionDelegate = nil;
-
+    
     OCMExpect([mockedURLSession dataTaskWithRequest:mockedURLRequest]).andReturn(mockedDataTask);
-
+    
     mockedDataTask.taskIdentifier = 1337;
-
+    
     @weakify(mockedDataTask);
     mockedDataTask.resumeBlock = ^{
         @strongify(mockedDataTask);
-
+        
         NSData *dataRecieved = [@"{ \"foo\": \"bar\" }" dataUsingEncoding:NSUTF8StringEncoding];
         NSURLResponse *response = [[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
                                                             MIMEType:@"application/json"
                                                expectedContentLength:dataRecieved.length
                                                     textEncodingName:@"UTF-8"];
-
+        
         [sessionDelegate URLSession:mockedURLSession
                            dataTask:(id)mockedDataTask
                  didReceiveResponse:response
@@ -206,24 +206,24 @@
                   }];
         [sessionDelegate URLSession:mockedURLSession dataTask:(id)mockedDataTask didReceiveData:dataRecieved];
         [cancellationTokenSource cancel];
-
+        
         [sessionDelegate URLSession:mockedURLSession
                                task:(id)mockedDataTask
                didCompleteWithError:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:nil]];
     };
-
+    
     XCTestExpectation *cancelExpectation = [self expectationWithDescription:@"cancel"];
     mockedDataTask.cancelBlock = ^{
         [cancelExpectation fulfill];
     };
-
+    
     id delegate = PFStrictProtocolMock(@protocol(PFURLSessionDelegate));
     PFURLSession *session = [PFURLSession sessionWithURLSession:mockedURLSession delegate:delegate];
     sessionDelegate = (id)session;
-
+    
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
     OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
-
+    
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performDataURLRequestAsync:mockedURLRequest
                               forCommand:mockedCommand
@@ -233,7 +233,7 @@
         return nil;
     }];
     [self waitForTestExpectations];
-
+    
     OCMVerifyAll((id)mockedURLSession);
     OCMVerifyAll(delegate);
     [mocks makeObjectsPerformSelector:@selector(stopMocking)];
@@ -244,30 +244,30 @@
     NSURLRequest *mockedURLRequest = PFStrictClassMock([NSURLRequest class]);
     PFRESTCommand *mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     NSArray *mocks = @[ mockedURLSession, mockedURLRequest, mockedCommand ];
-
+    
     MockedSessionTask *mockedDataTask = [[MockedSessionTask alloc] init];
     mockedDataTask.originalRequest = mockedURLRequest;
-
+    
     NSError *expectedError = [NSError errorWithDomain:PFParseErrorDomain code:1337 userInfo:nil];
     __block id<NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate> sessionDelegate = nil;
-
+    
     OCMExpect([mockedURLSession dataTaskWithRequest:mockedURLRequest]).andReturn(mockedDataTask);
-
+    
     mockedDataTask.taskIdentifier = 1337;
-
+    
     @weakify(mockedDataTask);
     mockedDataTask.resumeBlock = ^{
         @strongify(mockedDataTask);
         [sessionDelegate URLSession:mockedURLSession task:(id)mockedDataTask didCompleteWithError:expectedError];
     };
-
+    
     id delegate = PFStrictProtocolMock(@protocol(PFURLSessionDelegate));
     PFURLSession *session = [PFURLSession sessionWithURLSession:mockedURLSession delegate:delegate];
     sessionDelegate = (id)session;
-
+    
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
     OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:nil]);
-
+    
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performDataURLRequestAsync:mockedURLRequest forCommand:mockedCommand cancellationToken:nil]
      continueWithBlock:^id(BFTask *task) {
@@ -277,7 +277,7 @@
          return nil;
      }];
     [self waitForTestExpectations];
-
+    
     OCMVerifyAll((id)mockedURLSession);
     OCMVerifyAll(delegate);
     [mocks makeObjectsPerformSelector:@selector(stopMocking)];
@@ -288,13 +288,13 @@
     NSURLRequest *mockedURLRequest = PFStrictClassMock([NSURLRequest class]);
     PFRESTCommand *mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     NSArray *mocks = @[ mockedURLSession, mockedURLRequest, mockedCommand ];
-
+    
     BFCancellationTokenSource *cancellationTokenSource = [BFCancellationTokenSource cancellationTokenSource];
     NSString *exampleFile = @"file.txt";
-
+    
     id delegate = PFStrictProtocolMock(@protocol(PFURLSessionDelegate));
     PFURLSession *session = [PFURLSession sessionWithURLSession:mockedURLSession delegate:delegate];
-
+    
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [cancellationTokenSource cancel];
     [[session performFileUploadURLRequestAsync:mockedURLRequest
@@ -318,26 +318,26 @@
     NSURLRequest *mockedURLRequest = PFStrictClassMock([NSURLRequest class]);
     PFRESTCommand *mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     NSArray *mocks = @[ mockedURLSession, mockedURLRequest, mockedCommand ];
-
+    
     MockedSessionTask *mockedUploadTask = [[MockedSessionTask alloc] init];
     mockedUploadTask.originalRequest = mockedURLRequest;
-
+    
     NSString *exampleFile = @"file.txt";
     __block id<NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate> sessionDelegate = nil;
-
+    
     OCMExpect([mockedURLSession uploadTaskWithRequest:mockedURLRequest fromFile:[NSURL fileURLWithPath:exampleFile]]).andReturn(mockedUploadTask);
-
+    
     mockedUploadTask.taskIdentifier = 1337;
-
+    
     @weakify(mockedUploadTask);
     mockedUploadTask.resumeBlock = ^{
         @strongify(mockedUploadTask);
         NSData *dataToSend = [@"{ \"foo\": \"bar\" }" dataUsingEncoding:NSUTF8StringEncoding];
-        NSURLResponse *response = [[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
-                                                            MIMEType:@"application/json"
-                                               expectedContentLength:dataToSend.length
-                                                    textEncodingName:@"UTF-8"];
-
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
+                                                                  statusCode:200
+                                                                 HTTPVersion:@"HTTP/1.1"
+                                                                headerFields:nil];
+        
         for (NSUInteger progress = 0; progress < dataToSend.length; progress++) {
             [sessionDelegate URLSession:mockedURLSession
                                    task:(id)mockedUploadTask
@@ -345,32 +345,32 @@
                          totalBytesSent:progress
                totalBytesExpectedToSend:dataToSend.length];
         }
-
+        
         [sessionDelegate URLSession:mockedURLSession
                            dataTask:(id)mockedUploadTask
                  didReceiveResponse:response
                   completionHandler:^(NSURLSessionResponseDisposition disposition) {
                       XCTAssertEqual(disposition, NSURLSessionResponseAllow);
                   }];
-
+        
         [sessionDelegate URLSession:mockedURLSession
                            dataTask:(id)mockedUploadTask
                      didReceiveData:dataToSend];
-
+        
         [sessionDelegate URLSession:mockedURLSession
                                task:(id)mockedUploadTask
                didCompleteWithError:nil];
     };
-
+    
     id delegate = PFStrictProtocolMock(@protocol(PFURLSessionDelegate));
     PFURLSession *session = [PFURLSession sessionWithURLSession:mockedURLSession delegate:delegate];
     sessionDelegate = (id)session;
-
+    
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
     OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
-
+    
     __block int lastProgress = 0;
-
+    
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performFileUploadURLRequestAsync:mockedURLRequest
                                     forCommand:mockedCommand
@@ -387,7 +387,7 @@
          return nil;
      }];
     [self waitForTestExpectations];
-
+    
     OCMVerifyAll((id)mockedURLSession);
     OCMVerifyAll(delegate);
     [mocks makeObjectsPerformSelector:@selector(stopMocking)];
@@ -399,28 +399,28 @@
     NSURLRequest *mockedURLRequest = PFStrictClassMock([NSURLRequest class]);
     PFRESTCommand *mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     NSArray *mocks = @[ mockedURLSession, mockedURLRequest, mockedCommand ];
-
+    
     MockedSessionTask *mockedUploadTask = [[MockedSessionTask alloc] init];
     mockedUploadTask.originalRequest = mockedURLRequest;
-
+    
     BFCancellationTokenSource *cancellationTokenSource = [BFCancellationTokenSource cancellationTokenSource];
     NSString *exampleFile = @"file.txt";
     __block id<NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate> sessionDelegate = nil;
-
+    
     OCMExpect([mockedURLSession uploadTaskWithRequest:mockedURLRequest fromFile:[NSURL fileURLWithPath:exampleFile]]).andReturn(mockedUploadTask);
-
+    
     mockedUploadTask.taskIdentifier = 1337;
-
+    
     @weakify(mockedUploadTask);
     mockedUploadTask.resumeBlock = ^{
         @strongify(mockedUploadTask);
-
+        
         NSData *dataToSend = [@"{ \"foo\": \"bar\" }" dataUsingEncoding:NSUTF8StringEncoding];
         NSURLResponse *response = [[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
                                                             MIMEType:@"application/json"
                                                expectedContentLength:dataToSend.length
                                                     textEncodingName:@"UTF-8"];
-
+        
         for (NSUInteger progress = 0; progress < dataToSend.length; progress++) {
             [sessionDelegate URLSession:mockedURLSession
                                    task:(id)mockedUploadTask
@@ -428,39 +428,39 @@
                          totalBytesSent:progress
                totalBytesExpectedToSend:dataToSend.length];
         }
-
+        
         [sessionDelegate URLSession:mockedURLSession
                            dataTask:(id)mockedUploadTask
                  didReceiveResponse:response
                   completionHandler:^(NSURLSessionResponseDisposition disposition) {
                       XCTAssertEqual(disposition, NSURLSessionResponseAllow);
                   }];
-
+        
         [sessionDelegate URLSession:mockedURLSession
                            dataTask:(id)mockedUploadTask
                      didReceiveData:dataToSend];
-
+        
         [cancellationTokenSource cancel];
-
+        
         [sessionDelegate URLSession:mockedURLSession
                                task:(id)mockedUploadTask
                didCompleteWithError:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:nil]];
     };
-
+    
     XCTestExpectation *cancelExpectation = [self expectationWithDescription:@"cancel"];
     mockedUploadTask.cancelBlock = ^{
         [cancelExpectation fulfill];
     };
-
+    
     id delegate = PFProtocolMock(@protocol(PFURLSessionDelegate));
     PFURLSession *session = [PFURLSession sessionWithURLSession:mockedURLSession delegate:delegate];
     sessionDelegate = (id)session;
-
+    
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
     OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
-
+    
     __block int lastProgress = 0;
-
+    
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performFileUploadURLRequestAsync:mockedURLRequest
                                     forCommand:mockedCommand
@@ -476,7 +476,7 @@
          return nil;
      }];
     [self waitForTestExpectations];
-
+    
     OCMVerifyAll((id)mockedURLSession);
     OCMVerifyAll(delegate);
     [mocks makeObjectsPerformSelector:@selector(stopMocking)];
@@ -487,27 +487,26 @@
     NSURLRequest *mockedURLRequest = PFStrictClassMock([NSURLRequest class]);
     PFRESTCommand *mockedCommand = PFStrictClassMock([PFRESTCommand class]);
     NSArray *mocks = @[ mockedURLSession, mockedURLRequest, mockedCommand ];
-
+    
     MockedSessionTask *mockedDataTask = [[MockedSessionTask alloc] init];
     mockedDataTask.originalRequest = mockedURLRequest;
-
+    
     __block id<NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate> sessionDelegate = nil;
-
+    
     OCMStub([mockedURLSession dataTaskWithRequest:mockedURLRequest]).andReturn(mockedDataTask);
-
+    
     mockedDataTask.taskIdentifier = 1337;
     @weakify(mockedDataTask);
     mockedDataTask.resumeBlock = ^{
         @strongify(mockedDataTask);
         NSData *dataRecieved = [@"{ \"foo\": \"bar\" }" dataUsingEncoding:NSUTF8StringEncoding];
-        NSURLResponse *response = [[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
-                                                            MIMEType:@"application/json"
-                                               expectedContentLength:dataRecieved.length
-                                                    textEncodingName:@"UTF-8"];
-
-        NSCachedURLResponse *cachedResponse =
-        [[NSCachedURLResponse alloc] initWithResponse:response data:dataRecieved];
-
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
+                                                                  statusCode:200
+                                                                 HTTPVersion:@"HTTP/1.1"
+                                                                headerFields:nil];
+        NSCachedURLResponse *cachedResponse = [[NSCachedURLResponse alloc] initWithResponse:response
+                                                                                       data:dataRecieved];
+        
         [sessionDelegate URLSession:mockedURLSession
                            dataTask:(id)mockedDataTask
                  didReceiveResponse:response
@@ -516,20 +515,20 @@
                   }];
         [sessionDelegate URLSession:mockedURLSession dataTask:(id)mockedDataTask didReceiveData:dataRecieved];
         [sessionDelegate URLSession:mockedURLSession task:(id)mockedDataTask didCompleteWithError:nil];
-
+        
         [sessionDelegate URLSession:mockedURLSession
                            dataTask:(id)mockedDataTask
                   willCacheResponse:cachedResponse
                   completionHandler:^(NSCachedURLResponse *cached) { XCTAssertNil(cached); }];
     };
-
+    
     id delegate = PFProtocolMock(@protocol(PFURLSessionDelegate));
     PFURLSession *session = [PFURLSession sessionWithURLSession:mockedURLSession delegate:delegate];
     sessionDelegate = (id)session;
-
+    
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
     OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
-
+    
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performDataURLRequestAsync:mockedURLRequest forCommand:mockedCommand cancellationToken:nil]
      continueWithBlock:^id(BFTask *task) {
@@ -538,7 +537,7 @@
          return nil;
      }];
     [self waitForTestExpectations];
-
+    
     OCMVerifyAll((id)mockedURLSession);
     OCMVerifyAll(delegate);
     [mocks makeObjectsPerformSelector:@selector(stopMocking)];

--- a/Tests/Unit/URLSessionUploadTaskDelegateTests.m
+++ b/Tests/Unit/URLSessionUploadTaskDelegateTests.m
@@ -98,10 +98,10 @@
     NSData *chunkA = [@"{ \"foo\" :" dataUsingEncoding:NSUTF8StringEncoding];
     NSData *chunkB = [@" \"bar\" }" dataUsingEncoding:NSUTF8StringEncoding];
 
-    NSURLResponse *urlResponse = [[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
-                                                           MIMEType:@"application/json"
-                                              expectedContentLength:chunkA.length + chunkB.length
-                                                   textEncodingName:@"UTF-8"];
+    NSHTTPURLResponse *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
+                                                                 statusCode:200
+                                                                HTTPVersion:@"HTTP/1.1"
+                                                               headerFields:nil];
 
     for (int progress = 1; progress <= 10; progress++) {
         [delegate URLSession:mockedSession
@@ -145,10 +145,10 @@
     NSData *chunkA = [@"{ \"foo\" :" dataUsingEncoding:NSUTF8StringEncoding];
     NSData *chunkB = [@" \"bar\" }" dataUsingEncoding:NSUTF8StringEncoding];
 
-    NSURLResponse *urlResponse = [[NSURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
-                                                           MIMEType:@"application/json"
-                                              expectedContentLength:chunkA.length + chunkB.length
-                                                   textEncodingName:@"UTF-8"];
+    NSHTTPURLResponse *urlResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"http://foo.bar"]
+                                                                 statusCode:200
+                                                                HTTPVersion:@"HTTP/1.1"
+                                                               headerFields:nil];
 
     [delegate URLSession:mockedSession
                     task:mockedTask


### PR DESCRIPTION
The logic here was slightly wrong - there is a possibility that custom subclasses of `PFObject` will have an `error` column, and that shouldn't be treated as a problem.
This fixes the problem as well as covers any possible scenario of errors (setting the internal server one, where we have no idea what to do with the error).
Fixes #140