### PR TITLE
Add coverage through codecov.io.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,8 @@ install:
   - bundle install
 script:
   - bundle exec rake test:$TEST_TYPE
+after_success:
+- | 
+  if [ "$TEST_TYPE" = ios || "$TEST_TYPE" = osx ]; then
+    bash <(curl -s https://codecov.io/bash)
+  fi


### PR DESCRIPTION
Testing new coverage service as a replacement to `coveralls`, let's see how it goes.