### PR TITLE
Fixed rare crash in PFQuery related to weakify/strongify.

### DIFF
--- a/Parse/PFQuery.m
+++ b/Parse/PFQuery.m
@@ -842,6 +842,9 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
                                                                         user:user];
     }] continueWithBlock:^id(BFTask *task) {
         @strongify(self);
+        if (!self) {
+            return task;
+        }
         @synchronized (self) {
             if (_cancellationTokenSource == cancellationTokenSource) {
                 _cancellationTokenSource = nil;


### PR DESCRIPTION
In some rare scenarios (e.g. Parse is being torn down), the query will lose all references to it, and the strongify will yield `nil`. When that happens, we cannot read or write to any instance variables in that context.