### PR TITLE
Add Xcode 7 to Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,51 @@ branches:
   only:
     - master
 language: objective-c
-osx_image: xcode6.4
+os: osx
+matrix:
+  include:
+    - osx_image: xcode6.4
+      env: 
+        - TEST_TYPE=ios
+        - SDK_VERSION=8.4
+    - osx_image: xcode6.4
+      env: 
+        - TEST_TYPE=osx
+        - SDK_VERSION=10.10
+    - osx_image: xcode6.4
+      env: TEST_TYPE=deployment
+    - osx_image: xcode6.4
+      env: TEST_TYPE=starters
+    - osx_image: xcode6.4
+      env: TEST_TYPE=podspecs
+    - osx_image: xcode7
+      env: 
+        - TEST_TYPE=ios
+        - SDK_VERSION=9.0
+    - osx_image: xcode7
+      env: 
+        - TEST_TYPE=osx
+        - SDK_VERSION=10.11
+    - osx_image: xcode7
+      env: TEST_TYPE=podspecs
 env:
   global:
     - LC_CTYPE=en_US.UTF-8
     - LANG=en_US.UTF-8
-  matrix:
-    - TEST_TYPE=ios
-    - TEST_TYPE=osx
-    - TEST_TYPE=deployment
-    - TEST_TYPE=starters
-    - TEST_TYPE=podspecs
 install:
-  - bundle install
+- |
+  if [ -n "$TEST_TYPE" ]; then
+    bundle install
+  fi
 script:
-  - bundle exec rake test:$TEST_TYPE
+- |
+  if [ -n "$TEST_TYPE" ]; then
+    if [ -n "$SDK_VERSION" ]; then
+      bundle exec rake test:$TEST_TYPE[$SDK_VERSION]
+    else
+      bundle exec rake test:$TEST_TYPE
+    fi
+  fi
 after_success:
 - | 
   if [ "$TEST_TYPE" = "ios" ] || [ "$TEST_TYPE" = "osx" ]; then

--- a/Rakefile
+++ b/Rakefile
@@ -200,15 +200,16 @@ end
 
 namespace :test do
   desc 'Run iOS Tests'
-  task :ios do |_|
+  task :ios, :sdk_version do |_, args|
+    sdk_version = args[:sdk_version] || '8.4'
     task = XCTask::BuildTask.new do |t|
       t.directory = script_folder
       t.workspace = 'Parse.xcworkspace'
 
       t.scheme = 'Parse-iOS'
-      t.sdk = 'iphonesimulator8.4'
-      t.destinations = ['"platform=iOS Simulator,OS=8.4,name=iPhone 4s"',
-                        '"platform=iOS Simulator,OS=8.4,name=iPhone 6 Plus"']
+      t.sdk = "iphonesimulator#{sdk_version}"
+      t.destinations = ["\"platform=iOS Simulator,OS=#{sdk_version},name=iPhone 4s\"",
+                        "\"platform=iOS Simulator,OS=#{sdk_version},name=iPhone 6 Plus\"",]
       t.configuration = 'Test'
 
       t.actions = [XCTask::BuildAction::TEST]
@@ -223,13 +224,14 @@ namespace :test do
   end
 
   desc 'Run OS X Tests'
-  task :osx do |_|
+  task :osx, :sdk_version do |_, args|
+    sdk_version = args[:sdk_version] || '10.10'
     task = XCTask::BuildTask.new do |t|
       t.directory = script_folder
       t.workspace = 'Parse.xcworkspace'
 
       t.scheme = 'Parse-OSX'
-      t.sdk = 'macosx10.10'
+      t.sdk = "macosx#{sdk_version}"
       t.destinations = ['arch=x86_64']
       t.configuration = 'Test'
 


### PR DESCRIPTION
Adding Xcode 7 image, since it's finally supported by Travis.
Please note - we are testing only `ios`/`osx`/`podspecs` with Xcode 7 and not starters or deployment, since we still deploy with Xcode 6.4.