### PR TITLE
Make all synchronous APIs have 'throws' in Swift 2.

### DIFF
--- a/Parse/PFCloud.h
+++ b/Parse/PFCloud.h
@@ -28,7 +28,8 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The response from the cloud function.
  */
-+ (PF_NULLABLE_S id)callFunction:(NSString *)function withParameters:(PF_NULLABLE NSDictionary *)parameters;
++ (PF_NULLABLE_S id)callFunction:(NSString *)function
+                  withParameters:(PF_NULLABLE NSDictionary *)parameters PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Calls the given cloud function *synchronously* with the parameters provided and

--- a/Parse/PFConfig.h
+++ b/Parse/PFConfig.h
@@ -11,6 +11,7 @@
 
 #import <Bolts/BFTask.h>
 
+#import <Parse/PFConstants.h>
 #import <Parse/PFNullability.h>
 
 PF_ASSUME_NONNULL_BEGIN
@@ -47,7 +48,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *PF_NULLABLE_S config, NSError *PF_N
 
  @returns Instance of `PFConfig` if the operation succeeded, otherwise `nil`.
  */
-+ (PF_NULLABLE PFConfig *)getConfig;
++ (PF_NULLABLE PFConfig *)getConfig PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Gets the `PFConfig` object *synchronously* from the server and sets an error if it occurs.

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -420,3 +420,15 @@ typedef void (^PFProgressBlock)(int percentDone);
 #    endif
 #  endif
 #endif
+
+///--------------------------------------
+/// @name Swift Macros
+///--------------------------------------
+
+#ifndef PF_SWIFT_UNAVAILABLE
+#  ifdef NS_SWIFT_UNAVAILABLE
+#    define PF_SWIFT_UNAVAILABLE NS_SWIFT_UNAVAILABLE("")
+#  else
+#    define PF_SWIFT_UNAVAILABLE
+#  endif
+#endif

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -146,7 +146,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns whether the save succeeded.
  */
-- (BOOL)save;
+- (BOOL)save PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Saves the file *synchronously* and sets an error if it occurs.
@@ -217,7 +217,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The `NSData` object containing file data. Returns `nil` if there was an error in fetching.
  */
-- (PF_NULLABLE NSData *)getData;
+- (PF_NULLABLE NSData *)getData PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
@@ -226,7 +226,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns A stream containing the data. Returns `nil` if there was an error in fetching.
  */
-- (PF_NULLABLE NSInputStream *)getDataStream;
+- (PF_NULLABLE NSInputStream *)getDataStream PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* gets the data from cache if available or fetches its contents from the network.

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -300,7 +300,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @returns Returns whether the save succeeded.
  */
-- (BOOL)save;
+- (BOOL)save PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* saves the `PFObject` and sets an error if it occurs.
@@ -387,7 +387,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @returns Returns whether the save succeeded.
  */
-+ (BOOL)saveAll:(PF_NULLABLE NSArray *)objects;
++ (BOOL)saveAll:(PF_NULLABLE NSArray *)objects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Saves a collection of objects *synchronously* all at once and sets an error if necessary.
@@ -443,7 +443,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @returns Returns whether the delete succeeded.
  */
-+ (BOOL)deleteAll:(PF_NULLABLE NSArray *)objects;
++ (BOOL)deleteAll:(PF_NULLABLE NSArray *)objects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* deletes a collection of objects all at once and sets an error if necessary.
@@ -504,7 +504,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @deprecated Please use `-fetch` instead.
  */
-- (instancetype)refresh PARSE_DEPRECATED("Please use `-fetch` instead.");
+- (instancetype)refresh PF_SWIFT_UNAVAILABLE PARSE_DEPRECATED("Please use `-fetch` instead.");
 
 /*!
  @abstract *Synchronously* refreshes the `PFObject` with the current data from the server and sets an error if it occurs.
@@ -544,7 +544,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /*!
  @abstract *Synchronously* fetches the PFObject with the current data from the server.
  */
-- (instancetype)fetch;
+- (instancetype)fetch PF_SWIFT_UNAVAILABLE;
 /*!
  @abstract *Synchronously* fetches the PFObject with the current data from the server and sets an error if it occurs.
 
@@ -555,7 +555,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /*!
  @abstract *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
  */
-- (PF_NULLABLE PFObject *)fetchIfNeeded;
+- (PF_NULLABLE PFObject *)fetchIfNeeded PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
@@ -627,7 +627,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The list of objects to fetch.
  */
-+ (NSArray *)fetchAll:(PF_NULLABLE NSArray *)objects;
++ (NSArray *)fetchAll:(PF_NULLABLE NSArray *)objects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server
@@ -642,7 +642,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server.
  @param objects The list of objects to fetch.
  */
-+ (NSArray *)fetchAllIfNeeded:(PF_NULLABLE NSArray *)objects;
++ (NSArray *)fetchAllIfNeeded:(PF_NULLABLE NSArray *)objects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server
@@ -731,7 +731,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @abstract *Synchronously* loads data from the local datastore into this object,
  if it has not been fetched from the server already.
  */
-- (instancetype)fetchFromLocalDatastore;
+- (instancetype)fetchFromLocalDatastore PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* loads data from the local datastore into this object, if it has not been fetched
@@ -770,7 +770,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @returns Returns whether the delete succeeded.
  */
-- (BOOL)delete;
+- (BOOL)delete PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* deletes the `PFObject` and sets an error if it occurs.
@@ -867,7 +867,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @see unpin:
  @see PFObjectDefaultPin
  */
-- (BOOL)pin;
+- (BOOL)pin PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively,
@@ -901,7 +901,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @see unpinWithName:
  */
-- (BOOL)pinWithName:(NSString *)name;
+- (BOOL)pinWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively.
@@ -1006,7 +1006,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @see unpinAll:
  @see PFObjectDefaultPin
  */
-+ (BOOL)pinAll:(PF_NULLABLE NSArray *)objects;
++ (BOOL)pinAll:(PF_NULLABLE NSArray *)objects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively,
@@ -1042,7 +1042,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @see unpinAll:withName:
  */
-+ (BOOL)pinAll:(PF_NULLABLE NSArray *)objects withName:(NSString *)name;
++ (BOOL)pinAll:(PF_NULLABLE NSArray *)objects withName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively.
@@ -1149,7 +1149,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @see pin:
  @see PFObjectDefaultPin
  */
-- (BOOL)unpin;
+- (BOOL)unpin PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively,
@@ -1173,7 +1173,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @see pinWithName:
  */
-- (BOOL)unpinWithName:(NSString *)name;
+- (BOOL)unpinWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively.
@@ -1245,7 +1245,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @see PFObjectDefaultPin
  */
-+ (BOOL)unpinAllObjects;
++ (BOOL)unpinAllObjects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* removes all objects in the local datastore
@@ -1266,7 +1266,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @returns Returns whether the unpin succeeded.
  */
-+ (BOOL)unpinAllObjectsWithName:(NSString *)name;
++ (BOOL)unpinAllObjectsWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* removes all objects with the specified pin name.
@@ -1329,7 +1329,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @see pinAll:
  @see PFObjectDefaultPin
  */
-+ (BOOL)unpinAll:(PF_NULLABLE NSArray *)objects;
++ (BOOL)unpinAll:(PF_NULLABLE NSArray *)objects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively,
@@ -1355,7 +1355,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @see pinAll:withName:
  */
-+ (BOOL)unpinAll:(PF_NULLABLE NSArray *)objects withName:(NSString *)name;
++ (BOOL)unpinAll:(PF_NULLABLE NSArray *)objects withName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively.

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -501,7 +501,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The <PFObject> if found. Returns `nil` if the object isn't found, or if there was an error.
  */
-+ (PF_NULLABLE PFObject *)getObjectOfClass:(NSString *)objectClass objectId:(NSString *)objectId;
++ (PF_NULLABLE PFObject *)getObjectOfClass:(NSString *)objectClass objectId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Returns a <PFObject> with a given class and id and sets an error if necessary.
@@ -526,7 +526,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The <PFObject> if found. Returns nil if the object isn't found, or if there was an error.
  */
-- (PF_NULLABLE PFObject *)getObjectWithId:(NSString *)objectId;
+- (PF_NULLABLE PFObject *)getObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Returns a <PFObject> with the given id and sets an error if necessary.
@@ -592,7 +592,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The PFUser if found. Returns nil if the object isn't found, or if there was an error.
  */
-+ (PF_NULLABLE PFUser *)getUserObjectWithId:(NSString *)objectId;
++ (PF_NULLABLE PFUser *)getUserObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
 /*!
  Returns a PFUser with a given class and id and sets an error if necessary.
@@ -617,7 +617,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns an array of <PFObject> objects that were found.
  */
-- (PF_NULLABLE NSArray *)findObjects;
+- (PF_NULLABLE NSArray *)findObjects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Finds objects *synchronously* based on the constructed query and sets an error if there was one.
@@ -664,7 +664,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns a <PFObject>, or `nil` if none was found.
  */
-- (PF_NULLABLE PFObject *)getFirstObject;
+- (PF_NULLABLE PFObject *)getFirstObject PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Gets an object *synchronously* based on the constructed query and sets an error if any occurred.
@@ -720,7 +720,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns the number of <PFObject> objects that match the query, or `-1` if there is an error.
  */
-- (NSInteger)countObjects;
+- (NSInteger)countObjects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Counts objects *synchronously* based on the constructed query and sets an error if there was one.

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -119,7 +119,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
 
  @returns Returns `YES` if the sign up was successful, otherwise `NO`.
  */
-- (BOOL)signUp;
+- (BOOL)signUp PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Signs up the user *synchronously*.
@@ -189,7 +189,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
  If login failed for either wrong password or wrong username, returns `nil`.
  */
 + (PF_NULLABLE instancetype)logInWithUsername:(NSString *)username
-                                     password:(NSString *)password;
+                                     password:(NSString *)password PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Makes a *synchronous* request to login a user with specified credentials.
@@ -269,7 +269,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
  @returns Returns an instance of the `PFUser` on success.
  If becoming a user fails due to incorrect token, it returns `nil`.
  */
-+ (PF_NULLABLE instancetype)become:(NSString *)sessionToken;
++ (PF_NULLABLE instancetype)become:(NSString *)sessionToken PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Makes a *synchronous* request to become a user with the given session token.
@@ -396,7 +396,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
 
  @returns Returns `YES` if the reset email request is successful. `NO` - if no account was found for the email address.
  */
-+ (BOOL)requestPasswordResetForEmail:(NSString *)email;
++ (BOOL)requestPasswordResetForEmail:(NSString *)email PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract *Synchronously* send a password reset request for a specified email and sets an error object.
@@ -408,8 +408,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
  @param error Error object to set on error.
  @returns Returns `YES` if the reset email request is successful. `NO` - if no account was found for the email address.
  */
-+ (BOOL)requestPasswordResetForEmail:(NSString *)email
-                               error:(NSError **)error;
++ (BOOL)requestPasswordResetForEmail:(NSString *)email error:(NSError **)error;
 
 /*!
  @abstract Send a password reset request asynchronously for a specified email and sets an

--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject-Swift.xcodeproj/project.pbxproj
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject-Swift.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		81CC85B01A49F2E00076DE19 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = Parse;
 				TargetAttributes = {

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject-Swift.xcodeproj/project.pbxproj
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject-Swift.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		81BA813D1A49DA1800E65899 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = Parse;
 				TargetAttributes = {
@@ -405,6 +406,7 @@
 				81993FC91B69AA950077D6B9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		81BA81401A49DA1800E65899 /* Build configuration list for PBXProject "ParseStarterProject-Swift" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
- Made all synchronous APIs have `throws` when used from Swift.
- Added backward compatible macro `PF_SWIFT_UNAVAILABLE`, please note that this macro does nothing when compiled with Xcode 6.4, but only works on Xcode 7 (the one that has Swift 2).

After change (Swift 2):
```swift
class PFObject : NSObject {
    public func save() throws
}
```

Before change (Swift 2):
```swift
class PFObject : NSObject {
    public func save() -> Bool
    public func save(error: NSErrorPointer) -> Bool
}
```

Before && After Change (Swift 1.2):
```swift
class PFObject : NSObject {
    public func save() -> Bool
    public func save(error: NSErrorPointer) -> Bool
}
```

closes #152 

cc @richardjrossiii