### PR TITLE
Added PFFileManager moveItemAsyncAtPath.

### DIFF
--- a/Parse/Internal/PFFileManager.h
+++ b/Parse/Internal/PFFileManager.h
@@ -33,6 +33,7 @@ typedef NS_OPTIONS(uint8_t, PFFileManagerOptions) {
 + (BFTask *)writeDataAsync:(NSData *)data toFile:(NSString *)filePath;
 
 + (BFTask *)copyItemAsyncAtPath:(NSString *)fromPath toPath:(NSString *)toPath;
++ (BFTask *)moveItemAsyncAtPath:(NSString *)fromPath toPath:(NSString *)toPath;
 
 + (BFTask *)moveContentsOfDirectoryAsyncAtPath:(NSString *)fromPath
                              toDirectoryAtPath:(NSString *)toPath

--- a/Parse/Internal/PFFileManager.m
+++ b/Parse/Internal/PFFileManager.m
@@ -112,6 +112,17 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
     }];
 }
 
++ (BFTask *)moveItemAsyncAtPath:(NSString *)fromPath toPath:(NSString *)toPath {
+    return [BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
+        NSError *error = nil;
+        [[NSFileManager defaultManager] moveItemAtPath:fromPath toPath:toPath error:&error];
+        if (error) {
+            return [BFTask taskWithError:error];
+        }
+        return nil;
+    }];
+}
+
 + (BFTask *)moveContentsOfDirectoryAsyncAtPath:(NSString *)fromPath
                              toDirectoryAtPath:(NSString *)toPath
                                       executor:(BFExecutor *)executor {

--- a/Tests/Unit/FileControllerTests.m
+++ b/Tests/Unit/FileControllerTests.m
@@ -105,7 +105,14 @@
 
     id mockedCommandRunner = [mockedDataSource commandRunner];
     OCMStub([mockedCommandRunner runFileDownloadCommandAsyncWithFileURL:tempPath
-                                                         targetFilePath:[OCMArg isNotNil]
+                                                         targetFilePath:[OCMArg checkWithBlock:^BOOL(id obj) {
+        NSString *path = obj;
+        if (!path) {
+            return NO;
+        }
+        [[NSData data] writeToFile:path atomically:YES];
+        return YES;
+    }]
                                                       cancellationToken:nil
                                                           progressBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
         PFProgressBlock block = obj;
@@ -160,7 +167,14 @@
 
     id mockedCommandRunner = [mockedDataSource commandRunner];
     OCMStub([mockedCommandRunner runFileDownloadCommandAsyncWithFileURL:tempPath
-                                                         targetFilePath:[OCMArg isNotNil]
+                                                         targetFilePath:[OCMArg checkWithBlock:^BOOL(id obj) {
+        NSString *path = obj;
+        if (!path) {
+            return NO;
+        }
+        [[NSData data] writeToFile:path atomically:YES];
+        return YES;
+    }]
                                                       cancellationToken:nil
                                                           progressBlock:[OCMArg checkWithBlock:^BOOL(id obj) {
         progressBlock = obj;


### PR DESCRIPTION
Implemented an old TODO. We already have `copyItemAsyncAtPath:toPath:` in PFFileManager - so simply add a move method.
Also fixed a bug, where we were returning an NSError from continuation block instead of wrapping with BFTask, so the entire pipe was never failing.