### PR TITLE
Replace exceptions in PFUser.signUp with errors.

### DIFF
--- a/Parse/Internal/User/PFUserPrivate.h
+++ b/Parse/Internal/User/PFUserPrivate.h
@@ -31,8 +31,6 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 
 - (void)synchronizeAllAuthData;
 
-- (void)checkSignUpParams;
-
 - (BFTask *)_handleServiceLoginCommandResult:(PFCommandResult *)result;
 
 - (void)synchronizeAuthDataWithAuthType:(NSString *)authType;


### PR DESCRIPTION
Replace all exceptions with errors, so we don't crash end applications, but rather fail signup requests.
Contributes to #6