### PR TITLE
Remove usage of deprecated APIs in PFLocationManager.

### DIFF
--- a/Parse/Internal/PFLocationManager.m
+++ b/Parse/Internal/PFLocationManager.m
@@ -115,12 +115,9 @@
 #pragma mark - CLLocationManagerDelegate
 ///--------------------------------------
 
-// TODO: (nlutsenko) Remove usage of this method, when we drop support for OSX 10.8
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-implementations"
-- (void)locationManager:(CLLocationManager *)manager
-    didUpdateToLocation:(CLLocation *)newLocation
-           fromLocation:(CLLocation *)oldLocation {
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
+    CLLocation *location = [locations lastObject];
+
     [manager stopUpdatingLocation];
 
     NSMutableSet *callbacks = [NSMutableSet setWithCapacity:1];
@@ -128,21 +125,9 @@
         [callbacks setSet:self.blockSet];
         [self.blockSet removeAllObjects];
     }
-    for (void(^block)(CLLocation *, NSError *) in callbacks) {
-        block(newLocation, nil);
+    for (PFLocationManagerLocationUpdateBlock block in callbacks) {
+        block(location, nil);
     }
-}
-#pragma clang diagnostic pop
-
-- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
-    CLLocation *location = [locations lastObject];
-    CLLocation *oldLocation = [locations count] > 1 ? [locations objectAtIndex:[locations count] - 2] : nil;
-
-    // TODO: (nlutsenko) Remove usage of this method, when we drop support for OSX 10.8 (didUpdateLocations is 10.9+)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [self locationManager:manager didUpdateToLocation:location fromLocation:oldLocation];
-#pragma clang diagnostic pop
 }
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error {

--- a/Tests/Other/LocationManager/CLLocationManager+TestAdditions.m
+++ b/Tests/Other/LocationManager/CLLocationManager+TestAdditions.m
@@ -79,13 +79,7 @@ static BOOL mockingEnabled = NO;
     } else if (returnLocation) {
         CLLocation *fakeLocation = [[CLLocation alloc] initWithLatitude:CL_DEFAULT_LATITUDE
                                                               longitude:CL_DEFAULT_LONGITUDE];
-#if PARSE_IOS_ONLY
-        [self.delegate locationManager:self didUpdateLocations:[NSArray arrayWithObject:fakeLocation]];
-#else
-        CLLocation *emptyLocation = [[CLLocation alloc] initWithLatitude:CL_DEFAULT_LATITUDE
-                                                               longitude:CL_DEFAULT_LONGITUDE];
-        [self.delegate locationManager:self didUpdateToLocation:fakeLocation fromLocation:emptyLocation];
-#endif
+        [self.delegate locationManager:self didUpdateLocations:@[ fakeLocation ]];
     }
 }
 


### PR DESCRIPTION
These APIs are deprecated and no longer needed since we are iOS 7.0+ and OS X 10.9+.