### PR TITLE
Fix subclasses of PFObject subclasses failing registration assert.

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -1878,7 +1878,7 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
 + (PFQuery *)query {
     PFConsistencyAssert([self conformsToProtocol:@protocol(PFSubclassing)],
                         @"+[PFObject query] can only be called on subclasses conforming to PFSubclassing.");
-    [PFObject assertSubclassIsRegistered:[self class]];
+    [PFObject assertSubclassIsRegistered:self];
     return [PFQuery queryWithClassName:[(id<PFSubclassing>)self parseClassName]];
 }
 
@@ -1895,7 +1895,7 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
         Class registration = [[self subclassingController] subclassForParseClassName:[subclass parseClassName]];
 
         // It's OK to subclass a subclass (i.e. custom PFUser implementation)
-        PFConsistencyAssert(registration && (registration == subclass || [registration isKindOfClass:subclass]),
+        PFConsistencyAssert(registration && (registration == subclass || [registration isSubclassOfClass:subclass]),
                             @"The class %@ must be registered with registerSubclass before using Parse.", subclass);
     }
 }

--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -99,7 +99,10 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (NSString *)displayClassName {
-    return @"PFUser";
+    if ([self isMemberOfClass:[PFUser class]]) {
+        return @"PFUser";
+    }
+    return NSStringFromClass([self class]);
 }
 
 // Validates a class name. We override this to only allow the user class name.


### PR DESCRIPTION
`isKindOfClass:` doesn't work reliably on Classes, since it's an instance method on NSObject, whilst `isSubclassOfClass:` works great (class level method).
This diff also improves logging of `PFUser` subclasses (they now report proper class names).

Fixes #176 