### PR TITLE
Update Starter Projects for Swift 2.

### DIFF
--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
@@ -54,19 +54,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         PFPush.subscribeToChannelInBackground("") { (succeeded: Bool, error: NSError?) in
             if succeeded {
-                println("ParseStarterProject successfully subscribed to push notifications on the broadcast channel.");
+                print("ParseStarterProject successfully subscribed to push notifications on the broadcast channel.\n");
             } else {
-                println("ParseStarterProject failed to subscribe to push notifications on the broadcast channel with error = %@.", error)
+                print("ParseStarterProject failed to subscribe to push notifications on the broadcast channel with error = %@.\n", error)
             }
         }
     }
 
     func application(application: NSApplication, didFailToRegisterForRemoteNotificationsWithError error: NSError) {
-        println("application:didFailToRegisterForRemoteNotificationsWithError: %@", error)
+        print("application:didFailToRegisterForRemoteNotificationsWithError: %@\n", error)
     }
 
-    func application(application: NSApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {
-        PFAnalytics.trackAppOpenedWithRemoteNotificationPayload(userInfo)
-    }
-
+    // ****************************************************************************
+    // Uncomment these lines to track Push Notifications open rate in Analytics.
+    //
+    //  Swift 1.2
+    //    func application(application: NSApplication, didReceiveRemoteNotification userInfo: [NSObject : AnyObject]) {
+    //        PFAnalytics.trackAppOpenedWithRemoteNotificationPayload(userInfo)
+    //    }
+    //
+    //  Swift 2.0
+    //    func application(application: NSApplication, didReceiveRemoteNotification userInfo: [String : AnyObject]) {
+    //        PFAnalytics.trackAppOpenedWithRemoteNotificationPayload(userInfo)
+    //    }
 }

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
@@ -68,15 +68,32 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 PFAnalytics.trackAppOpenedWithLaunchOptions(launchOptions)
             }
         }
-        if application.respondsToSelector("registerUserNotificationSettings:") {
-            let userNotificationTypes = UIUserNotificationType.Alert | UIUserNotificationType.Badge | UIUserNotificationType.Sound
-            let settings = UIUserNotificationSettings(forTypes: userNotificationTypes, categories: nil)
-            application.registerUserNotificationSettings(settings)
-            application.registerForRemoteNotifications()
-        } else {
-            let types = UIRemoteNotificationType.Badge | UIRemoteNotificationType.Alert | UIRemoteNotificationType.Sound
-            application.registerForRemoteNotificationTypes(types)
-        }
+
+        //
+        //  Swift 1.2
+        //
+        //        if application.respondsToSelector("registerUserNotificationSettings:") {
+        //            let userNotificationTypes = UIUserNotificationType.Alert | UIUserNotificationType.Badge | UIUserNotificationType.Sound
+        //            let settings = UIUserNotificationSettings(forTypes: userNotificationTypes, categories: nil)
+        //            application.registerUserNotificationSettings(settings)
+        //            application.registerForRemoteNotifications()
+        //        } else {
+        //            let types = UIRemoteNotificationType.Badge | UIRemoteNotificationType.Alert | UIRemoteNotificationType.Sound
+        //            application.registerForRemoteNotificationTypes(types)
+        //        }
+
+        //
+        //  Swift 2.0
+        //
+        //        if #available(iOS 8.0, *) {
+        //            let types: UIUserNotificationType = [.Alert, .Badge, .Sound]
+        //            let settings = UIUserNotificationSettings(forTypes: types, categories: nil)
+        //            application.registerUserNotificationSettings(settings)
+        //            application.registerForRemoteNotifications()
+        //        } else {
+        //            let types: UIRemoteNotificationType = [.Alert, .Badge, .Sound]
+        //            application.registerForRemoteNotificationTypes(types)
+        //        }
 
         return true
     }
@@ -92,18 +109,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         PFPush.subscribeToChannelInBackground("") { (succeeded: Bool, error: NSError?) in
             if succeeded {
-                println("ParseStarterProject successfully subscribed to push notifications on the broadcast channel.");
+                print("ParseStarterProject successfully subscribed to push notifications on the broadcast channel.\n");
             } else {
-                println("ParseStarterProject failed to subscribe to push notifications on the broadcast channel with error = %@.", error)
+                print("ParseStarterProject failed to subscribe to push notifications on the broadcast channel with error = %@.\n", error)
             }
         }
     }
 
     func application(application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: NSError) {
         if error.code == 3010 {
-            println("Push notifications are not supported in the iOS Simulator.")
+            print("Push notifications are not supported in the iOS Simulator.\n")
         } else {
-            println("application:didFailToRegisterForRemoteNotificationsWithError: %@", error)
+            print("application:didFailToRegisterForRemoteNotificationsWithError: %@\n", error)
         }
     }
 


### PR DESCRIPTION
Using `print` instead of `println`, as well as removed code that doesn't work on both version of Swift and replaced with a commented out snippet.
Fixes ParsePlatform/ParseUI-iOS#119