### PR TITLE
Add backward compatible ObjC generic support for PFQuery.

### DIFF
--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -432,3 +432,14 @@ typedef void (^PFProgressBlock)(int percentDone);
 #    define PF_SWIFT_UNAVAILABLE
 #  endif
 #endif
+
+///--------------------------------------
+/// @name Obj-C Generics Macros
+///--------------------------------------
+
+#if __has_feature(objc_generics) || __has_extension(objc_generics)
+#  define PF_GENERIC(type) <type>
+#else
+#  define PF_GENERIC(type)
+#  define PFGenericObject PFObject *
+#endif

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -21,7 +21,13 @@ PF_ASSUME_NONNULL_BEGIN
 /*!
  The `PFQuery` class defines a query that is used to query for <PFObject>s.
  */
-@interface PFQuery : NSObject <NSCopying>
+@interface PFQuery PF_GENERIC(PFGenericObject : PFObject *) : NSObject<NSCopying>
+
+///--------------------------------------
+/// @name Blocks
+///--------------------------------------
+
+typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * PF_NULLABLE_S objects, NSError * PF_NULLABLE_S error);
 
 ///--------------------------------------
 /// @name Creating a Query for a Class
@@ -501,7 +507,8 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The <PFObject> if found. Returns `nil` if the object isn't found, or if there was an error.
  */
-+ (PF_NULLABLE PFObject *)getObjectOfClass:(NSString *)objectClass objectId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
++ (PF_NULLABLE PFGenericObject)getObjectOfClass:(NSString *)objectClass
+                                       objectId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Returns a <PFObject> with a given class and id and sets an error if necessary.
@@ -512,9 +519,9 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The <PFObject> if found. Returns `nil` if the object isn't found, or if there was an `error`.
  */
-+ (PF_NULLABLE PFObject *)getObjectOfClass:(NSString *)objectClass
-                                  objectId:(NSString *)objectId
-                                     error:(NSError **)error;
++ (PF_NULLABLE PFGenericObject)getObjectOfClass:(NSString *)objectClass
+                                       objectId:(NSString *)objectId
+                                          error:(NSError **)error;
 
 /*!
  @abstract Returns a <PFObject> with the given id.
@@ -526,7 +533,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The <PFObject> if found. Returns nil if the object isn't found, or if there was an error.
  */
-- (PF_NULLABLE PFObject *)getObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
+- (PF_NULLABLE PFGenericObject)getObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Returns a <PFObject> with the given id and sets an error if necessary.
@@ -539,7 +546,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The <PFObject> if found. Returns nil if the object isn't found, or if there was an error.
  */
-- (PF_NULLABLE PFObject *)getObjectWithId:(NSString *)objectId error:(NSError **)error;
+- (PF_NULLABLE PFGenericObject)getObjectWithId:(NSString *)objectId error:(NSError **)error;
 
 /*!
  @abstract Gets a <PFObject> asynchronously and calls the given block with the result.
@@ -564,7 +571,7 @@ PF_ASSUME_NONNULL_BEGIN
  The block should have the following argument signature: `^(NSArray *object, NSError *error)`
  */
 - (void)getObjectInBackgroundWithId:(NSString *)objectId
-                              block:(PF_NULLABLE PFObjectResultBlock)block;
+                              block:(PF_NULLABLE void(^)(PFGenericObject PF_NULLABLE_S object, NSError *PF_NULLABLE_S error))block;
 
 /*
  @abstract Gets a <PFObject> asynchronously.
@@ -617,7 +624,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns an array of <PFObject> objects that were found.
  */
-- (PF_NULLABLE NSArray *)findObjects PF_SWIFT_UNAVAILABLE;
+- (PF_NULLABLE NSArray PF_GENERIC(PFGenericObject) *)findObjects PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Finds objects *synchronously* based on the constructed query and sets an error if there was one.
@@ -626,7 +633,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns an array of <PFObject> objects that were found.
  */
-- (PF_NULLABLE NSArray *)findObjects:(NSError **)error;
+- (PF_NULLABLE NSArray PF_GENERIC(PFGenericObject) *)findObjects:(NSError **)error;
 
 /*!
  @abstract Finds objects *asynchronously* and sets the `NSArray` of <PFObject> objects as a result of the task.
@@ -641,7 +648,7 @@ PF_ASSUME_NONNULL_BEGIN
  @param block The block to execute.
  It should have the following argument signature: `^(NSArray *objects, NSError *error)`
  */
-- (void)findObjectsInBackgroundWithBlock:(PF_NULLABLE PFArrayResultBlock)block;
+- (void)findObjectsInBackgroundWithBlock:(PF_NULLABLE PFQueryArrayResultBlock)block;
 
 /*
  @abstract Finds objects *asynchronously* and calls the given callback with the results.
@@ -664,7 +671,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns a <PFObject>, or `nil` if none was found.
  */
-- (PF_NULLABLE PFObject *)getFirstObject PF_SWIFT_UNAVAILABLE;
+- (PF_NULLABLE PFGenericObject)getFirstObject PF_SWIFT_UNAVAILABLE;
 
 /*!
  @abstract Gets an object *synchronously* based on the constructed query and sets an error if any occurred.
@@ -675,7 +682,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns a <PFObject>, or `nil` if none was found.
  */
-- (PF_NULLABLE PFObject *)getFirstObject:(NSError **)error;
+- (PF_NULLABLE PFGenericObject)getFirstObject:(NSError **)error;
 
 /*!
  @abstract Gets an object *asynchronously* and sets it as a result of the task.
@@ -696,7 +703,7 @@ PF_ASSUME_NONNULL_BEGIN
  `result` will be `nil` if `error` is set OR no object was found matching the query.
  `error` will be `nil` if `result` is set OR if the query succeeded, but found no results.
  */
-- (void)getFirstObjectInBackgroundWithBlock:(PF_NULLABLE PFObjectResultBlock)block;
+- (void)getFirstObjectInBackgroundWithBlock:(PF_NULLABLE void(^)(PFGenericObject PF_NULLABLE_S object, NSError *PF_NULLABLE_S error))block;
 
 /*
  @abstract Gets an object *asynchronously* and calls the given callback with the results.

--- a/Parse/PFQuery.m
+++ b/Parse/PFQuery.m
@@ -798,7 +798,7 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
     return [self _findObjectsAsyncForQueryState:state after:nil];
 }
 
-- (void)findObjectsInBackgroundWithBlock:(PFArrayResultBlock)block {
+- (void)findObjectsInBackgroundWithBlock:(PFQueryArrayResultBlock)block {
     @synchronized (self) {
         if (!self.state.queriesLocalDatastore && self.state.cachePolicy == kPFCachePolicyCacheThenNetwork) {
             PFQueryState *cacheQueryState = [self _queryStateCopyWithCachePolicy:kPFCachePolicyCacheOnly];


### PR DESCRIPTION
This adds an ability to do the following on Xcode 7.
```objc
PFQuery<PFUser *> *query = [PFQuery queryWithClassName:@"_User"];
PFUser *user = [query getFirstObject];
PFObject *yolo = [query getFirstObject];
PFInstallation *installation = [query getFirstObject]; // Will put a warning here saying that it's an incompatible type.
```

Please note that we explicitly don't support covariants (discussable) as the best practice is to use a single objc/swift class for any given parse class name, so the following will log a warning:
```objc
PFQuery<PFObject *> *objectQuery = nil;
PFQuery<PFUser *> *query = [PFQuery queryWithClassName:@"_User"];
objectQuery = query; // Warning here saying that the type is incompatible.
```