### PR TITLE
Add bitcode support to precompiled frameworks on iOS 9.

### DIFF
--- a/Configurations/Parse-iOS.xcconfig
+++ b/Configurations/Parse-iOS.xcconfig
@@ -18,3 +18,7 @@ DEFINES_MODULE = YES
 FRAMEWORK_SEARCH_PATHS = $(inherited) $(BUILT_PRODUCTS_DIR) $(VENDOR_DIR)/Bolts-ObjC/build/ios/
 
 INFOPLIST_FILE = $(PARSE_DIR)/Parse/Resources/Framework.plist
+
+PF_BITCODE_FLAG = $()
+PF_BITCODE_FLAG[sdk=iphoneos9.0] = -fembed-bitcode
+OTHER_LD_FLAGS = $(inherited) $(PF_BITCODE_FLAG)


### PR DESCRIPTION
Add bitcode only for iphoneos slice.
Closes #75