### PR TITLE
Added response body string to network notifications, don't supply any user info if running outside of debug mode.

### DIFF
--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.h
@@ -50,10 +50,18 @@ extern NSString *const PFCommandRunnerDidReceiveURLResponseNotification;
 
 /*!
  @abstract The key of request(NSURLRequest) in the userInfo dictionary of a notification.
+ @note This key is populated in userInfo, only of `PFLogLevel` in `PFLogger` is set to `PFLogLevelDebug`.
  */
 extern NSString *const PFCommandRunnerNotificationURLRequestUserInfoKey;
 
 /*!
  @abstract The key of response(NSHTTPURLResponse) in the userInfo dictionary of a notification.
+ @note This key is populated in userInfo, only of `PFLogLevel` in `PFLogger` is set to `PFLogLevelDebug`.
  */
 extern NSString *const PFCommandRunnerNotificationURLResponseUserInfoKey;
+
+/*!
+ @abstract The key of repsonse body (usually `NSString` with JSON) in the userInfo dictionary of a notification.
+ @note This key is populated in userInfo, only of `PFLogLevel` in `PFLogger` is set to `PFLogLevelDebug`.
+ */
+extern NSString *const PFCommandRunnerNotificationURLResponseBodyUserInfoKey;

--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.m
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.m
@@ -30,3 +30,4 @@ NSString *const PFCommandRunnerWillSendURLRequestNotification = @"PFCommandRunne
 NSString *const PFCommandRunnerDidReceiveURLResponseNotification = @"PFCommandRunnerDidReceiveURLResponseNotification";
 NSString *const PFCommandRunnerNotificationURLRequestUserInfoKey = @"PFCommandRunnerNotificationURLRequestUserInfoKey";
 NSString *const PFCommandRunnerNotificationURLResponseUserInfoKey = @"PFCommandRunnerNotificationURLResponseUserInfoKey";
+NSString *const PFCommandRunnerNotificationURLResponseBodyUserInfoKey = @"PFCommandRunnerNotificationURLResponseBodyUserInfoKey";

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -252,19 +252,29 @@
 
 - (void)urlSession:(PFURLSession *)session willPerformURLRequest:(NSURLRequest *)request {
     [[BFExecutor defaultPriorityBackgroundExecutor] execute:^{
-        NSDictionary *userInfo = @{ PFCommandRunnerNotificationURLRequestUserInfoKey : request };
+        NSDictionary *userInfo = ([PFLogger sharedLogger].logLevel == PFLogLevelDebug ?
+                                  @{ PFCommandRunnerNotificationURLRequestUserInfoKey : request } : nil);
         [self.notificationCenter postNotificationName:PFCommandRunnerWillSendURLRequestNotification
                                                object:self
                                              userInfo:userInfo];
     }];
 }
 
-- (void)urlSession:(PFURLSession *)session didPerformURLRequest:(NSURLRequest *)request withURLResponse:(nullable NSURLResponse *)response {
+- (void)urlSession:(PFURLSession *)session
+didPerformURLRequest:(NSURLRequest *)request
+   withURLResponse:(nullable NSURLResponse *)response
+    responseString:(nullable NSString *)responseString {
     [[BFExecutor defaultPriorityBackgroundExecutor] execute:^{
-        NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
-        userInfo[PFCommandRunnerNotificationURLRequestUserInfoKey] = request;
-        if (response) {
-            userInfo[PFCommandRunnerNotificationURLResponseUserInfoKey] = response;
+        NSMutableDictionary *userInfo = nil;
+        if ([PFLogger sharedLogger].logLevel == PFLogLevelDebug) {
+            userInfo = [NSMutableDictionary dictionaryWithObject:request
+                                                          forKey:PFCommandRunnerNotificationURLRequestUserInfoKey];
+            if (response) {
+                userInfo[PFCommandRunnerNotificationURLResponseUserInfoKey] = response;
+            }
+            if (responseString) {
+                userInfo[PFCommandRunnerNotificationURLResponseBodyUserInfoKey] = responseString;
+            }
         }
         [self.notificationCenter postNotificationName:PFCommandRunnerDidReceiveURLResponseNotification
                                                object:self

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
@@ -22,7 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol PFURLSessionDelegate <NSObject>
 
 - (void)urlSession:(PFURLSession *)session willPerformURLRequest:(NSURLRequest *)request;
-- (void)urlSession:(PFURLSession *)session didPerformURLRequest:(NSURLRequest *)request withURLResponse:(nullable NSURLResponse *)response;
+
+- (void)urlSession:(PFURLSession *)session didPerformURLRequest:(NSURLRequest *)request withURLResponse:(nullable NSURLResponse *)response responseString:(nullable NSString *)string;
 
 @end
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.m
@@ -177,7 +177,10 @@ typedef void (^PFURLSessionTaskCompletionHandler)(NSData *data, NSURLResponse *r
 
         BFTask *resultTask = [delegate.resultTask continueWithBlock:^id(BFTask *task) {
             @strongify(self);
-            [self.delegate urlSession:self didPerformURLRequest:dataTask.originalRequest withURLResponse:delegate.response];
+            [self.delegate urlSession:self
+                 didPerformURLRequest:dataTask.originalRequest
+                      withURLResponse:delegate.response
+                       responseString:delegate.responseString];
 
             [self _removeDelegateForTaskWithIdentifier:taskIdentifier];
             return task;

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) BFTask *resultTask;
 
 @property (nonatomic, strong, readonly) NSHTTPURLResponse *response;
+@property (nullable, nonatomic, copy, readonly) NSString *responseString;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initForDataTask:(NSURLSessionDataTask *)dataTask

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate_Private.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate_Private.h
@@ -9,6 +9,8 @@
 
 #import "PFURLSessionDataTaskDelegate.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PFURLSessionDataTaskDelegate ()
 
 @property (nonatomic, strong, readonly) dispatch_queue_t dataQueue;
@@ -19,10 +21,14 @@
 @property (nonatomic, strong, readonly) NSOutputStream *dataOutputStream;
 @property (nonatomic, assign, readonly) uint64_t downloadedBytes;
 
-@property (nonatomic, strong) id result;
-@property (nonatomic, strong) NSError *error;
+@property (nullable, nonatomic, strong) id result;
+@property (nullable, nonatomic, strong) NSError *error;
+
+@property (nullable, nonatomic, copy, readwrite) NSString *responseString;
 
 - (void)_taskDidFinish NS_REQUIRES_SUPER;
 - (void)_taskDidCancel NS_REQUIRES_SUPER;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionJSONDataTaskDelegate.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionJSONDataTaskDelegate.m
@@ -32,12 +32,11 @@
 - (void)_taskDidFinish {
     NSData *data = [self.dataOutputStream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];
 
-    NSString *resultString = nil;
     id result = nil;
 
     NSError *jsonError = nil;
     if (data) {
-        resultString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        self.responseString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         result = [NSJSONSerialization JSONObjectWithData:data
                                                  options:0
                                                    error:&jsonError];
@@ -64,7 +63,7 @@
     if (self.response.statusCode >= 200) {
         if (self.response.statusCode < 400) {
             PFCommandResult *commandResult = [PFCommandResult commandResultWithResult:result
-                                                                         resultString:resultString
+                                                                         resultString:self.responseString
                                                                          httpResponse:self.response];
             self.result = commandResult;
         } else if ([result isKindOfClass:[NSDictionary class]]) {
@@ -78,7 +77,7 @@
     }
 
     if (!self.result && !self.error) {
-        self.error = [PFErrorUtilities errorWithCode:kPFErrorInternalServer message:resultString];
+        self.error = [PFErrorUtilities errorWithCode:kPFErrorInternalServer message:self.responseString];
     }
     [super _taskDidFinish];
 }

--- a/Parse/Internal/PFLogger.h
+++ b/Parse/Internal/PFLogger.h
@@ -26,7 +26,7 @@ A shared instance of `PFLogger` that should be used for all logging.
 
 @returns An shared singleton instance of `PFLogger`.
 */
-+ (instancetype)sharedLogger;
++ (instancetype)sharedLogger; //TODO: (nlutsenko) Convert to use an instance everywhere instead of a shared singleton.
 
 ///--------------------------------------
 /// @name Logging Messages

--- a/Tests/Unit/URLSessionTests.m
+++ b/Tests/Unit/URLSessionTests.m
@@ -131,7 +131,10 @@
     sessionDelegate = (id)session;
     
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
-    OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
+    OCMExpect([delegate urlSession:session
+              didPerformURLRequest:mockedURLRequest
+                   withURLResponse:[OCMArg isNotNil]
+                    responseString:[OCMArg isNotNil]]);
     
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performDataURLRequestAsync:mockedURLRequest forCommand:mockedCommand cancellationToken:nil] continueWithBlock:^id(BFTask *task) {
@@ -222,7 +225,10 @@
     sessionDelegate = (id)session;
     
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
-    OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
+    OCMExpect([delegate urlSession:session
+              didPerformURLRequest:mockedURLRequest
+                   withURLResponse:[OCMArg isNotNil]
+                    responseString:nil]);
     
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performDataURLRequestAsync:mockedURLRequest
@@ -266,7 +272,10 @@
     sessionDelegate = (id)session;
     
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
-    OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:nil]);
+    OCMExpect([delegate urlSession:session
+              didPerformURLRequest:mockedURLRequest
+                   withURLResponse:nil
+                    responseString:[OCMArg isNotNil]]);
     
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performDataURLRequestAsync:mockedURLRequest forCommand:mockedCommand cancellationToken:nil]
@@ -367,7 +376,10 @@
     sessionDelegate = (id)session;
     
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
-    OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
+    OCMExpect([delegate urlSession:session
+              didPerformURLRequest:mockedURLRequest
+                   withURLResponse:[OCMArg isNotNil]
+                    responseString:[OCMArg isNotNil]]);
     
     __block int lastProgress = 0;
     
@@ -457,7 +469,10 @@
     sessionDelegate = (id)session;
     
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
-    OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
+    OCMExpect([delegate urlSession:session
+              didPerformURLRequest:mockedURLRequest
+                   withURLResponse:[OCMArg isNotNil]
+                    responseString:nil]);
     
     __block int lastProgress = 0;
     
@@ -527,7 +542,10 @@
     sessionDelegate = (id)session;
     
     OCMExpect([delegate urlSession:session willPerformURLRequest:mockedURLRequest]);
-    OCMExpect([delegate urlSession:session didPerformURLRequest:mockedURLRequest withURLResponse:[OCMArg isNotNil]]);
+    OCMExpect([delegate urlSession:session
+              didPerformURLRequest:mockedURLRequest
+                   withURLResponse:[OCMArg isNotNil]
+                    responseString:[OCMArg isNotNil]]);
     
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[session performDataURLRequestAsync:mockedURLRequest forCommand:mockedCommand cancellationToken:nil]


### PR DESCRIPTION
- Added another property on every PFURLSessionDataTaskDelegate - `responseString`, which is set only if we have a string to set there
- Added new user info key in PFCommandRunningConstants
- Use `PFLogger.sharedLogger()` to get the log level
- Add user info only if logLevel is set to `PFLogLevelDebug`

cc @wangmengyan95 @grantland