### PR TITLE
Support bolts generics in internal headers, part 1.

### DIFF
--- a/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
+++ b/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
@@ -9,7 +9,9 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFACL;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
+++ b/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
@@ -9,9 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFDataProvider.h"
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 
 @interface PFAnalyticsController : NSObject
 

--- a/Parse/Internal/CloudCode/PFCloudCodeController.h
+++ b/Parse/Internal/CloudCode/PFCloudCodeController.h
@@ -9,7 +9,9 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @protocol PFCommandRunning;
 
 @interface PFCloudCodeController : NSObject

--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
@@ -14,7 +14,8 @@
 #import "PFDataProvider.h"
 
 @class BFCancellationToken;
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
+@class PFCommandResult;
 @class PFRESTCommand;
 @protocol PFNetworkCommand;
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
@@ -12,7 +12,8 @@
 #import <Parse/PFConstants.h>
 
 @class BFCancellationToken;
-@class BFTask;
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFRESTCommand;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.h
@@ -9,8 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 @class BFCancellationToken;
-@class BFTask;
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Parse/Internal/Config/Controller/PFConfigController.h
+++ b/Parse/Internal/Config/Controller/PFConfigController.h
@@ -9,7 +9,10 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
+@class PFConfig;
 @class PFCurrentConfigController;
 @class PFFileManager;
 @protocol PFCommandRunning;

--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.h
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.h
@@ -9,7 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+#import "PFMacros.h"
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFConfig;
 @class PFFileManager;
 

--- a/Parse/Internal/File/Controller/PFFileController.h
+++ b/Parse/Internal/File/Controller/PFFileController.h
@@ -12,9 +12,10 @@
 #import <Parse/PFConstants.h>
 
 #import "PFDataProvider.h"
+#import "PFMacros.h"
 
 @class BFCancellationToken;
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFFileState;
 @class PFFileStagingController;
 

--- a/Parse/Internal/File/Controller/PFFileStagingController.h
+++ b/Parse/Internal/File/Controller/PFFileStagingController.h
@@ -9,7 +9,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
+#import <Parse/PFConstants.h>
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Parse/Internal/File/PFFile_Private.h
+++ b/Parse/Internal/File/PFFile_Private.h
@@ -14,8 +14,6 @@
 
 #import "PFFileState.h"
 
-@class BFTask;
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface PFFile (Private)

--- a/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.h
+++ b/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.h
@@ -9,14 +9,17 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFCoreDataProvider.h"
 #import "PFCurrentObjectControlling.h"
 #import "PFDataProvider.h"
+#import "PFMacros.h"
 
 extern NSString *const PFCurrentInstallationFileName;
 extern NSString *const PFCurrentInstallationPinName;
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFInstallation;
 
 @interface PFCurrentInstallationController : NSObject <PFCurrentObjectControlling>

--- a/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.h
+++ b/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.h
@@ -9,14 +9,18 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+#import "PFMacros.h"
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFObject;
 @class PFOfflineStore;
 @class PFQueryState;
 @class PFSQLiteDatabase;
 @class PFUser;
 
-typedef BFTask *(^PFConstraintMatcherBlock)(PFObject *object, PFSQLiteDatabase *database);
+typedef BFTask PF_GENERIC(NSNumber *)* (^PFConstraintMatcherBlock)(PFObject *object, PFSQLiteDatabase *database);
 
 typedef NS_OPTIONS(uint8_t, PFOfflineQueryOption) {
     PFOfflineQueryOptionOrder = 1 << 0,

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
@@ -9,7 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+#import "PFMacros.h"
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFFileManager;
 @class PFObject;
 @class PFPin;

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
@@ -9,8 +9,13 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+#import "PFMacros.h"
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFFileManager;
+@class PFSQLiteDatabaseResult;
 
 /*!
  Argument count given in executeSQLAsync or executeQueryAsync is invalid.

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
@@ -9,7 +9,9 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFFileManager;
 @class PFSQLiteDatabase;
 

--- a/Parse/Internal/Object/BatchController/PFObjectBatchController.h
+++ b/Parse/Internal/Object/BatchController/PFObjectBatchController.h
@@ -9,9 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
-#import "PFDataProvider.h"
+#import <Parse/PFConstants.h>
 
-@class BFTask;
+#import "PFDataProvider.h"
+#import "PFMacros.h"
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFObject;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Parse/Internal/Object/Controller/PFObjectController.h
+++ b/Parse/Internal/Object/Controller/PFObjectController.h
@@ -12,7 +12,8 @@
 #import "PFDataProvider.h"
 #import "PFObjectControlling.h"
 
-@class BFTask;
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFObject;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Parse/Internal/Object/Controller/PFObjectControlling.h
+++ b/Parse/Internal/Object/Controller/PFObjectControlling.h
@@ -9,7 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+#import "PFMacros.h"
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFObject;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Parse/Internal/Object/CurrentController/PFCurrentObjectControlling.h
+++ b/Parse/Internal/Object/CurrentController/PFCurrentObjectControlling.h
@@ -9,9 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFObject;
 
 typedef NS_ENUM(NSUInteger, PFCurrentObjectStorageType) {

--- a/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
+++ b/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
@@ -9,9 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
-#import "PFDataProvider.h"
+#import <Parse/PFConstants.h>
 
-@class BFTask;
+#import "PFDataProvider.h"
+#import "PFMacros.h"
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFObject;
 
 @interface PFObjectFilePersistenceController : NSObject

--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -18,7 +18,7 @@
 #import "PFMulticastDelegate.h"
 #import "PFObjectControlling.h"
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFCurrentUserController;
 @class PFFieldOperation;
 @class PFJSONCacheItem;

--- a/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
+++ b/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
@@ -9,11 +9,14 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFDataProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
+@class PFPin;
 
 @interface PFPinningObjectStore : NSObject
 

--- a/Parse/Internal/PFCommandCache.h
+++ b/Parse/Internal/PFCommandCache.h
@@ -9,9 +9,10 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFEventuallyQueue.h"
 
-@class BFTask;
 @class PFCommandCacheTestHelper;
 @class PFObject;
 

--- a/Parse/Internal/PFEncoder.h
+++ b/Parse/Internal/PFEncoder.h
@@ -9,7 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+#import "PFMacros.h"
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFObject;
 @class PFOfflineStore;
 @class PFSQLiteDatabase;

--- a/Parse/Internal/PFEventuallyPin.h
+++ b/Parse/Internal/PFEventuallyPin.h
@@ -9,10 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFObject.h"
 #import "PFSubclassing.h"
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @protocol PFNetworkCommand;
 
 extern NSString *const PFEventuallyPinPinName;

--- a/Parse/Internal/PFEventuallyQueue.h
+++ b/Parse/Internal/PFEventuallyQueue.h
@@ -9,10 +9,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFMacros.h"
 #import "PFNetworkCommand.h"
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
+@class PFEventuallyPin;
 @class PFEventuallyQueueTestHelper;
 @class PFObject;
 @protocol PFCommandRunning;

--- a/Parse/Internal/PFFileManager.h
+++ b/Parse/Internal/PFFileManager.h
@@ -9,8 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
+#import "PFMacros.h"
+
 @class BFExecutor;
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 
 typedef NS_OPTIONS(uint8_t, PFFileManagerOptions) {
     PFFileManagerOptionSkipBackup = 1 << 0,

--- a/Parse/Internal/PFMacros.h
+++ b/Parse/Internal/PFMacros.h
@@ -122,4 +122,16 @@ __strong __typeof__(var) var = var ## _weak;
     })                                                                               \
 )
 
+/*!
+ This exists to use along with bolts generic tasks. Instead of returning a BFTask with no generic type, or a generic
+ type of 'NSNull' when there is no usable result from a task, we use the type 'PFVoid', which will always have a value
+ of  'nil'.
+
+ This allows us to more easily descern between methods that have not yet updated the return type of their tasks, as well
+ as provide a more enforced API contract to the caller (as sending any message to PFVoid will result in a compile time
+ error).
+ */
+@class _PFVoid_Nonexistant;
+typedef _PFVoid_Nonexistant *PFVoid;
+
 #endif

--- a/Parse/Internal/PFTaskQueue.h
+++ b/Parse/Internal/PFTaskQueue.h
@@ -9,7 +9,9 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 
 @interface PFTaskQueue : NSObject
 

--- a/Parse/Internal/ParseManager.h
+++ b/Parse/Internal/ParseManager.h
@@ -9,9 +9,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFDataProvider.h"
 #import "PFOfflineStore.h"
+#import "PFMacros.h"
 
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFAnalyticsController;
 @class PFCoreManager;
 @class PFInstallationIdentifierStore;

--- a/Parse/Internal/Product/ProductsRequestHandler/PFProductsRequestHandler.h
+++ b/Parse/Internal/Product/ProductsRequestHandler/PFProductsRequestHandler.h
@@ -10,7 +10,9 @@
 #import <Foundation/Foundation.h>
 #import <StoreKit/StoreKit.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 
 @interface PFProductsRequestResult : NSObject
 

--- a/Parse/Internal/Purchase/Controller/PFPurchaseController.h
+++ b/Parse/Internal/Purchase/Controller/PFPurchaseController.h
@@ -11,9 +11,13 @@
 
 #import <Parse/PFConstants.h>
 
-@class BFTask;
+#import "PFMacros.h"
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFFileManager;
 @class PFPaymentTransactionObserver;
+@class PFProductsRequestResult;
+
 @protocol PFCommandRunning;
 @class SKPaymentQueue;
 @class SKPaymentTransaction;

--- a/Parse/Internal/Push/ChannelsController/PFPushChannelsController.h
+++ b/Parse/Internal/Push/ChannelsController/PFPushChannelsController.h
@@ -9,9 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFCoreDataProvider.h"
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Parse/Internal/Push/Controller/PFPushController.h
+++ b/Parse/Internal/Push/Controller/PFPushController.h
@@ -9,7 +9,9 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Parse/PFConstants.h>
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFPushState;
 @protocol PFCommandRunning;
 

--- a/Parse/Internal/Query/Controller/PFQueryController.h
+++ b/Parse/Internal/Query/Controller/PFQueryController.h
@@ -9,12 +9,16 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFDataProvider.h"
 
 @class BFCancellationToken;
-@class BFTask;
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFQueryState;
 @class PFRESTCommand;
+@class PFCommandResult;
 @class PFUser;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Parse/Internal/Query/PFQueryPrivate.h
+++ b/Parse/Internal/Query/PFQueryPrivate.h
@@ -39,7 +39,8 @@ extern NSString *const PFQueryOptionKeyMaxDistance;
 extern NSString *const PFQueryOptionKeyBox;
 extern NSString *const PFQueryOptionKeyRegexOptions;
 
-@class BFTask;
+
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFObject;
 
 @interface PFQuery ()

--- a/Parse/Internal/Session/Controller/PFSessionController.h
+++ b/Parse/Internal/Session/Controller/PFSessionController.h
@@ -9,9 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFDataProvider.h"
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
+@class PFSession;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
+++ b/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFUser;
 
 @interface PFUserAuthenticationController : NSObject

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
@@ -9,11 +9,14 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFCoreDataProvider.h"
 #import "PFCurrentObjectControlling.h"
 #import "PFDataProvider.h"
+#import "PFMacros.h"
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFUser;
 
 typedef NS_OPTIONS(NSUInteger, PFCurrentUserLoadingOptions) {

--- a/Parse/Internal/User/PFUserPrivate.h
+++ b/Parse/Internal/User/PFUserPrivate.h
@@ -12,12 +12,13 @@
 #import <Parse/PFUser.h>
 
 #import "PFAuthenticationProvider.h"
+#import "PFMacros.h"
 
 extern NSString *const PFUserCurrentUserFileName;
 extern NSString *const PFUserCurrentUserPinName;
 extern NSString *const PFUserCurrentUserKeychainItemName;
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFCommandResult;
 @class PFUserController;
 


### PR DESCRIPTION
Part 1/X. This is the initial groundwork that will be necessary for supporting bolts generics in the SDK's internal headers.

Each should be able to function completely independent of the others.