### PR TITLE
Support Bolts generics in internal headers, part 2.

### DIFF
--- a/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
+++ b/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A task that returns the ACL encapsulated by this controller.
  */
-- (BFTask *)getDefaultACLAsync;
+- (BFTask PF_GENERIC(PFACL *) *)getDefaultACLAsync;
 
 /*!
  Set the new default default ACL to be encapsulated in this controller.
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A task that returns the new (copied) ACL now encapsulated in this controller.
  */
-- (BFTask *)setDefaultACLAsync:(PFACL *)acl withCurrentUserAccess:(BOOL)accessForCurrentUser;
+- (BFTask PF_GENERIC(PFACL *) *)setDefaultACLAsync:(PFACL *)acl withCurrentUserAccess:(BOOL)accessForCurrentUser;
 
 @end
 

--- a/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
+++ b/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
@@ -42,8 +42,8 @@
 
  @returns `BFTask` with result set to `@YES`.
  */
-- (BFTask *)trackAppOpenedEventAsyncWithRemoteNotificationPayload:(NSDictionary *)payload
-                                                     sessionToken:(NSString *)sessionToken;
+- (BFTask PF_GENERIC(NSNumber *) *)trackAppOpenedEventAsyncWithRemoteNotificationPayload:(NSDictionary *)payload
+                                                                            sessionToken:(NSString *)sessionToken;
 
 /*!
  @abstract Tracks the occurrence of a custom event with additional dimensions.
@@ -54,8 +54,8 @@
 
  @returns `BFTask` with result set to `@YES`.
  */
-- (BFTask *)trackEventAsyncWithName:(NSString *)name
-                         dimensions:(NSDictionary *)dimensions
-                       sessionToken:(NSString *)sessionToken;
+- (BFTask PF_GENERIC(NSNumber *) *)trackEventAsyncWithName:(NSString *)name
+                                                dimensions:(NSDictionary *)dimensions
+                                              sessionToken:(NSString *)sessionToken;
 
 @end

--- a/Parse/Internal/CloudCode/PFCloudCodeController.h
+++ b/Parse/Internal/CloudCode/PFCloudCodeController.h
@@ -40,8 +40,8 @@
 
  @returns `BFTask` with a result set to a result of Cloud Function.
  */
-- (BFTask *)callCloudCodeFunctionAsync:(NSString *)functionName
-                        withParameters:(NSDictionary *)parameters
-                          sessionToken:(NSString *)sessionToken;
+- (BFTask PF_GENERIC(id) *)callCloudCodeFunctionAsync:(NSString *)functionName
+                                       withParameters:(NSDictionary *)parameters
+                                         sessionToken:(NSString *)sessionToken;
 
 @end

--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
@@ -59,8 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  @returns `BFTask` with result set to `PFCommandResult`.
  */
-- (BFTask *)runCommandAsync:(PFRESTCommand *)command
-                withOptions:(PFCommandRunningOptions)options;
+- (BFTask PF_GENERIC(PFCommandResult *)*)runCommandAsync:(PFRESTCommand *)command
+                                             withOptions:(PFCommandRunningOptions)options;
 
 /*!
  Run command.
@@ -71,25 +71,25 @@ NS_ASSUME_NONNULL_BEGIN
 
  @returns `BFTask` with result set to `PFCommandResult`.
  */
-- (BFTask *)runCommandAsync:(PFRESTCommand *)command
-                withOptions:(PFCommandRunningOptions)options
-          cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+- (BFTask PF_GENERIC(PFCommandResult *)*)runCommandAsync:(PFRESTCommand *)command
+                                             withOptions:(PFCommandRunningOptions)options
+                                       cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 ///--------------------------------------
 /// @name File Commands
 ///--------------------------------------
 
-- (BFTask *)runFileUploadCommandAsync:(PFRESTCommand *)command
-                      withContentType:(NSString *)contentType
-                contentSourceFilePath:(NSString *)sourceFilePath
-                              options:(PFCommandRunningOptions)options
-                    cancellationToken:(nullable BFCancellationToken *)cancellationToken
-                        progressBlock:(nullable PFProgressBlock)progressBlock;
+- (BFTask PF_GENERIC(id) *)runFileUploadCommandAsync:(PFRESTCommand *)command
+                                     withContentType:(NSString *)contentType
+                               contentSourceFilePath:(NSString *)sourceFilePath
+                                             options:(PFCommandRunningOptions)options
+                                   cancellationToken:(nullable BFCancellationToken *)cancellationToken
+                                       progressBlock:(nullable PFProgressBlock)progressBlock;
 
-- (BFTask *)runFileDownloadCommandAsyncWithFileURL:(NSURL *)url
-                                    targetFilePath:(NSString *)filePath
-                                 cancellationToken:(nullable BFCancellationToken *)cancellationToken
-                                     progressBlock:(nullable PFProgressBlock)progressBlock;
+- (BFTask PF_GENERIC(id) *)runFileDownloadCommandAsyncWithFileURL:(NSURL *)url
+                                                   targetFilePath:(NSString *)filePath
+                                                cancellationToken:(nullable BFCancellationToken *)cancellationToken
+                                                    progressBlock:(nullable PFProgressBlock)progressBlock;
 
 @end
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
@@ -53,20 +53,20 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Network Requests
 ///--------------------------------------
 
-- (BFTask *)performDataURLRequestAsync:(NSURLRequest *)request
-                            forCommand:(PFRESTCommand *)command
-                     cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+- (BFTask PF_GENERIC(id) *)performDataURLRequestAsync:(NSURLRequest *)request
+                                           forCommand:(PFRESTCommand *)command
+                                    cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
-- (BFTask *)performFileUploadURLRequestAsync:(NSURLRequest *)request
-                                  forCommand:(PFRESTCommand *)command
-                   withContentSourceFilePath:(NSString *)sourceFilePath
-                           cancellationToken:(nullable BFCancellationToken *)cancellationToken
-                               progressBlock:(nullable PFProgressBlock)progressBlock;
+- (BFTask PF_GENERIC(id) *)performFileUploadURLRequestAsync:(NSURLRequest *)request
+                                                 forCommand:(PFRESTCommand *)command
+                                  withContentSourceFilePath:(NSString *)sourceFilePath
+                                          cancellationToken:(nullable BFCancellationToken *)cancellationToken
+                                              progressBlock:(nullable PFProgressBlock)progressBlock;
 
-- (BFTask *)performFileDownloadURLRequestAsync:(NSURLRequest *)request
-                                  toFileAtPath:(NSString *)filePath
-                         withCancellationToken:(nullable BFCancellationToken *)cancellationToken
-                                 progressBlock:(nullable PFProgressBlock)progressBlock;
+- (BFTask PF_GENERIC(id) *)performFileDownloadURLRequestAsync:(NSURLRequest *)request
+                                                 toFileAtPath:(NSString *)filePath
+                                        withCancellationToken:(nullable BFCancellationToken *)cancellationToken
+                                                progressBlock:(nullable PFProgressBlock)progressBlock;
 
 @end
 


### PR DESCRIPTION
Part 2/5.

Adds definitions to the following internal sections:
 - ACL
 - Analytics
 - CloudCode
 - Commands

Each should be able to function completely independent of the others.