### PR TITLE
Support Bolts generics in internal headers, part 3.

### DIFF
--- a/Parse/Internal/Config/Controller/PFConfigController.h
+++ b/Parse/Internal/Config/Controller/PFConfigController.h
@@ -43,6 +43,6 @@
 
  @returns `BFTask` with result set to `PFConfig`.
  */
-- (BFTask *)fetchConfigAsyncWithSessionToken:(NSString *)sessionToken;
+- (BFTask PF_GENERIC(PFConfig *) *)fetchConfigAsyncWithSessionToken:(NSString *)sessionToken;
 
 @end

--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.h
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.h
@@ -34,10 +34,10 @@
 /// @name Accessors
 ///--------------------------------------
 
-- (BFTask *)getCurrentConfigAsync;
-- (BFTask *)setCurrentConfigAsync:(PFConfig *)config;
+- (BFTask PF_GENERIC(PFConfig *) *)getCurrentConfigAsync;
+- (BFTask PF_GENERIC(PFConfig *) *)setCurrentConfigAsync:(PFConfig *)config;
 
-- (BFTask *)clearCurrentConfigAsync;
-- (BFTask *)clearMemoryCachedCurrentConfigAsync;
+- (BFTask PF_GENERIC(PFVoid) *)clearCurrentConfigAsync;
+- (BFTask PF_GENERIC(PFVoid) *)clearMemoryCachedCurrentConfigAsync;
 
 @end

--- a/Parse/Internal/File/Controller/PFFileController.h
+++ b/Parse/Internal/File/Controller/PFFileController.h
@@ -36,7 +36,6 @@
 
 + (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider, PFFileManagerProvider>)dataSource;
 
-
 ///--------------------------------------
 /// @name Download
 ///--------------------------------------
@@ -50,9 +49,9 @@
 
  @returns `BFTask` with a result set to `nil`.
  */
-- (BFTask *)downloadFileAsyncWithState:(PFFileState *)fileState
-                     cancellationToken:(BFCancellationToken *)cancellationToken
-                         progressBlock:(PFProgressBlock)progressBlock;
+- (BFTask PF_GENERIC(PFVoid)*)downloadFileAsyncWithState:(PFFileState *)fileState
+                                         cancellationToken:(BFCancellationToken *)cancellationToken
+                                             progressBlock:(PFProgressBlock)progressBlock;
 
 /*!
  Downloads a file asynchronously with a given state and yields a stream to the live download of that file.
@@ -63,9 +62,9 @@
 
  @return `BFTask` with a result set to live `NSInputStream` of the file.
  */
-- (BFTask *)downloadFileStreamAsyncWithState:(PFFileState *)fileState
-                           cancellationToken:(BFCancellationToken *)cancellationToken
-                               progressBlock:(PFProgressBlock)progressBlock;
+- (BFTask PF_GENERIC(NSInputStream *)*)downloadFileStreamAsyncWithState:(PFFileState *)fileState
+                                                      cancellationToken:(BFCancellationToken *)cancellationToken
+                                                          progressBlock:(PFProgressBlock)progressBlock;
 
 ///--------------------------------------
 /// @name Upload
@@ -82,17 +81,17 @@
 
  @returns `BFTask` with a result set to `PFFileState` of uploaded file.
  */
-- (BFTask *)uploadFileAsyncWithState:(PFFileState *)fileState
-                      sourceFilePath:(NSString *)sourceFilePath
-                        sessionToken:(NSString *)sessionToken
-                   cancellationToken:(BFCancellationToken *)cancellationToken
-                       progressBlock:(PFProgressBlock)progressBlock;
+- (BFTask PF_GENERIC(PFFileState *)*)uploadFileAsyncWithState:(PFFileState *)fileState
+                                               sourceFilePath:(NSString *)sourceFilePath
+                                                 sessionToken:(NSString *)sessionToken
+                                            cancellationToken:(BFCancellationToken *)cancellationToken
+                                                progressBlock:(PFProgressBlock)progressBlock;
 
 ///--------------------------------------
 /// @name Cache
 ///--------------------------------------
 
-- (BFTask *)clearFileCacheAsync;
+- (BFTask PF_GENERIC(PFVoid)*)clearFileCacheAsync;
 
 - (NSString *)cachedFilePathForFileState:(PFFileState *)fileState;
 

--- a/Parse/Internal/File/Controller/PFFileStagingController.h
+++ b/Parse/Internal/File/Controller/PFFileStagingController.h
@@ -45,7 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A task, which yields the path of the staged file on disk.
  */
-- (BFTask *)stageFileAsyncAtPath:(NSString *)filePath name:(NSString *)name uniqueId:(uint64_t)uniqueId;
+- (BFTask PF_GENERIC(NSString *)*)stageFileAsyncAtPath:(NSString *)filePath
+                                                  name:(NSString *)name
+                                              uniqueId:(uint64_t)uniqueId;
 
 /*!
  Creates a file from the specified data and places it into the staging directory based off of the name and unique 
@@ -57,7 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return A task, which yields the path of the staged file on disk.
  */
-- (BFTask *)stageFileAsyncWithData:(NSData *)fileData name:(NSString *)name uniqueId:(uint64_t)uniqueId;
+- (BFTask PF_GENERIC(NSString *)*)stageFileAsyncWithData:(NSData *)fileData
+                                                    name:(NSString *)name
+                                                uniqueId:(uint64_t)uniqueId;
 
 /*!
  Get the staged directory path for a file with the specified name and unique ID.

--- a/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.h
+++ b/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.h
@@ -46,7 +46,7 @@ extern NSString *const PFCurrentInstallationPinName;
 
 @property (nonatomic, strong, readonly) PFInstallation *memoryCachedCurrentInstallation;
 
-- (BFTask *)clearCurrentInstallationAsync;
-- (BFTask *)clearMemoryCachedCurrentInstallationAsync;
+- (BFTask PF_GENERIC(PFVoid) *)clearCurrentInstallationAsync;
+- (BFTask PF_GENERIC(PFVoid) *)clearMemoryCachedCurrentInstallationAsync;
 
 @end

--- a/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.h
+++ b/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.h
@@ -65,15 +65,15 @@ typedef NS_OPTIONS(uint8_t, PFOfflineQueryOption) {
 /*!
  Make sure all of the objects included by the given query get fetched.
  */
-- (BFTask *)fetchIncludesAsyncForResults:(NSArray *)results
-                            ofQueryState:(PFQueryState *)queryState
-                              inDatabase:(PFSQLiteDatabase *)database;
+- (BFTask PF_GENERIC(PFVoid) *)fetchIncludesAsyncForResults:(NSArray *)results
+                                               ofQueryState:(PFQueryState *)queryState
+                                                 inDatabase:(PFSQLiteDatabase *)database;
 
 /*!
  Make sure all of the objects included by the given query get fetched.
  */
-- (BFTask *)fetchIncludesForObjectAsync:(PFObject *)object
-                             queryState:(PFQueryState *)queryState
-                               database:(PFSQLiteDatabase *)database;
+- (BFTask PF_GENERIC(PFVoid) *)fetchIncludesForObjectAsync:(PFObject *)object
+                                                queryState:(PFQueryState *)queryState
+                                                  database:(PFSQLiteDatabase *)database;
 
 @end

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
@@ -21,8 +21,7 @@
 @class PFSQLiteDatabase;
 @class PFUser;
 
-typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
-{
+typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions) {
     PFOfflineStoreOptionAlwaysFetchFromSQLite = 1 << 0,
 };
 
@@ -44,7 +43,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /// @name Fetch
 ///--------------------------------------
 
-- (BFTask *)fetchObjectLocallyAsync:(PFObject *)object;
+- (BFTask PF_GENERIC(PFObject *)*)fetchObjectLocallyAsync:(PFObject *)object;
 
 /*!
  Gets the data for the given object from the offline database. Returns a task that will be
@@ -54,15 +53,15 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
  @param     object      The object to fetch.
  @param     database    A database connection to use.
  */
-- (BFTask *)fetchObjectLocallyAsync:(PFObject *)object database:(PFSQLiteDatabase *)database;
+- (BFTask PF_GENERIC(PFObject *)*)fetchObjectLocallyAsync:(PFObject *)object database:(PFSQLiteDatabase *)database;
 
 ///--------------------------------------
 /// @name Save
 ///--------------------------------------
 
 //TODO: (nlutsenko) Remove `includChildren` method, replace with PFLocalStore that wraps OfflineStore + Pin.
-- (BFTask *)saveObjectLocallyAsync:(PFObject *)object includeChildren:(BOOL)includeChildren;
-- (BFTask *)saveObjectLocallyAsync:(PFObject *)object withChildren:(NSArray *)children;
+- (BFTask PF_GENERIC(PFVoid) *)saveObjectLocallyAsync:(PFObject *)object includeChildren:(BOOL)includeChildren;
+- (BFTask PF_GENERIC(PFVoid) *)saveObjectLocallyAsync:(PFObject *)object withChildren:(NSArray *)children;
 
 /*!
  Stores an object (and optionally, every object it points to recursively) in the local database.
@@ -77,9 +76,9 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
  @param children If non-empty - these children will be saved to LDS as well.
  @param database A database connection to use.
  */
-- (BFTask *)saveObjectLocallyAsync:(PFObject *)object
-                      withChildren:(NSArray *)children
-                          database:(PFSQLiteDatabase *)database;
+- (BFTask PF_GENERIC(PFVoid) *)saveObjectLocallyAsync:(PFObject *)object
+                                         withChildren:(NSArray *)children
+                                             database:(PFSQLiteDatabase *)database;
 
 ///--------------------------------------
 /// @name Find
@@ -90,28 +89,28 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 
  @returns The objects that match the query's constraint.
  */
-- (BFTask *)findAsyncForQueryState:(PFQueryState *)queryState
-                              user:(PFUser *)user
-                               pin:(PFPin *)pin;
+- (BFTask PF_GENERIC(NSArray<__kindof PFObject *> *)*)findAsyncForQueryState:(PFQueryState *)queryState
+                                                                        user:(PFUser *)user
+                                                                         pin:(PFPin *)pin;
 
 /*!
  Runs a PFQueryState against the store's contents.
 
  @returns The count of objects that match the query's constraint.
  */
-- (BFTask *)countAsyncForQueryState:(PFQueryState *)queryState
-                               user:(PFUser *)user
-                                pin:(PFPin *)pin;
+- (BFTask PF_GENERIC(NSNumber *)*)countAsyncForQueryState:(PFQueryState *)queryState
+                                                     user:(PFUser *)user
+                                                      pin:(PFPin *)pin;
 
 /*!
  Runs a PFQueryState against the store's contents.
 
  @returns The objects that match the query's constraint.
  */
-- (BFTask *)findAsyncForQueryState:(PFQueryState *)queryState
-                              user:(PFUser *)user
-                               pin:(PFPin *)pin
-                           isCount:(BOOL)isCount;
+- (BFTask PF_GENERIC(NSArray<__kindof PFObject *> *)*)findAsyncForQueryState:(PFQueryState *)queryState
+                                                                        user:(PFUser *)user
+                                                                         pin:(PFPin *)pin
+                                                                     isCount:(BOOL)isCount;
 
 /*!
  Runs a PFQueryState against the store's contents. May cause any instances of the object to get fetched from
@@ -125,11 +124,11 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 
  @returns The objects that match the query's constraint.
  */
-- (BFTask *)findAsyncForQueryState:(PFQueryState *)queryState
-                              user:(PFUser *)user
-                               pin:(PFPin *)pin
-                           isCount:(BOOL)isCount
-                          database:(PFSQLiteDatabase *)database;
+- (BFTask PF_GENERIC(NSArray<__kindof PFObject *> *)*)findAsyncForQueryState:(PFQueryState *)queryState
+                                                                        user:(PFUser *)user
+                                                                         pin:(PFPin *)pin
+                                                                     isCount:(BOOL)isCount
+                                                                    database:(PFSQLiteDatabase *)database;
 
 ///--------------------------------------
 /// @name Update Internal State
@@ -140,7 +139,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
  data is in memory. This will only be used when data comes back from the server after a fetch
  or a save.
  */
-- (BFTask *)updateDataForObjectAsync:(PFObject *)object;
+- (BFTask PF_GENERIC(__kindof PFObject *)*)updateDataForObjectAsync:(PFObject *)object;
 
 ///--------------------------------------
 /// @name Delete
@@ -149,13 +148,13 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /*!
  Deletes the given object from Offline Store's pins
  */
-- (BFTask *)deleteDataForObjectAsync:(PFObject *)object;
+- (BFTask PF_GENERIC(PFVoid) *)deleteDataForObjectAsync:(PFObject *)object;
 
 ///--------------------------------------
 /// @name Unpin
 ///--------------------------------------
 
-- (BFTask *)unpinObjectAsync:(PFObject *)object;
+- (BFTask PF_GENERIC(PFVoid) *)unpinObjectAsync:(PFObject *)object;
 
 ///--------------------------------------
 /// @name Internal Helper Methods
@@ -165,8 +164,8 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
  Gets the UUID for the given object, if it has one. Otherwise, creates a new UUID for the object
  and adds a new row to the database for the object with no data.
  */
-- (BFTask *)getOrCreateUUIDAsyncForObject:(PFObject *)object
-                                 database:(PFSQLiteDatabase *)database;
+- (BFTask PF_GENERIC(NSString *)*)getOrCreateUUIDAsyncForObject:(PFObject *)object
+                                                       database:(PFSQLiteDatabase *)database;
 
 /*!
  This should only be called from `PFObject.objectWithoutDataWithClassName`.

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
@@ -60,17 +60,17 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  @returns A `BFTask` that resolves to `YES` if the database is open.
  */
-- (BFTask *)isOpenAsync;
+- (BFTask PF_GENERIC(NSNumber *)*)isOpenAsync;
 
 /*!
  Opens database. Database is one time use. Open > Close > Open is forbidden.
  */
-- (BFTask *)openAsync;
+- (BFTask PF_GENERIC(PFVoid) *)openAsync;
 
 /*!
  Closes the database connection.
  */
-- (BFTask *)closeAsync;
+- (BFTask PF_GENERIC(PFVoid) *)closeAsync;
 
 ///--------------------------------------
 /// @name Transaction
@@ -79,17 +79,17 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  Begins a database transaction in EXCLUSIVE mode.
  */
-- (BFTask *)beginTransactionAsync;
+- (BFTask PF_GENERIC(PFVoid) *)beginTransactionAsync;
 
 /*!
  Commits running transaction.
  */
-- (BFTask *)commitAsync;
+- (BFTask PF_GENERIC(PFVoid) *)commitAsync;
 
 /*!
  Rollbacks running transaction.
  */
-- (BFTask *)rollbackAsync;
+- (BFTask PF_GENERIC(PFVoid) *)rollbackAsync;
 
 ///--------------------------------------
 /// @name Query Methods
@@ -98,17 +98,17 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  Runs a single SQL statement which return result (SELECT).
  */
-- (BFTask *)executeQueryAsync:(NSString *)sql withArgumentsInArray:(nullable NSArray *)args;
+- (BFTask PF_GENERIC(PFSQLiteDatabaseResult *) *)executeQueryAsync:(NSString *)sql withArgumentsInArray:(nullable NSArray *)args;
 
 /*!
  Runs a single SQL statement, while caching the resulting statement for future use.
  */
-- (BFTask *)executeCachedQueryAsync:(NSString *)sql withArgumentsInArray:(nullable NSArray *)args;
+- (BFTask PF_GENERIC(PFSQLiteDatabaseResult *)*)executeCachedQueryAsync:(NSString *)sql withArgumentsInArray:(nullable NSArray *)args;
 
 /*!
  Runs a single SQL statement which doesn't return result (UPDATE/INSERT/DELETE).
  */
-- (BFTask *)executeSQLAsync:(NSString *)sql withArgumentsInArray:(nullable NSArray *)args;
+- (BFTask PF_GENERIC(PFVoid) *)executeSQLAsync:(NSString *)sql withArgumentsInArray:(nullable NSArray *)args;
 
 @end
 

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return A task, which yields a `PFSQLiteDatabase`, with the open database. 
  When the database is closed, a new database connection can be opened.
  */
-- (BFTask *)openDatabaseWithNameAsync:(NSString *)name;
+- (BFTask PF_GENERIC(PFSQLiteDatabase *) *)openDatabaseWithNameAsync:(NSString *)name;
 
 @end
 


### PR DESCRIPTION
Part 3/5.

Adds definitions to the following internal sections:
 - Config
 - File
 - Installation
 - LocalDataStore

Each should be able to function completely independent of the others.