### PR TITLE
Support Bolts generics in internal headers, part 5.

### DIFF
--- a/Parse/Internal/BFTask+Private.h
+++ b/Parse/Internal/BFTask+Private.h
@@ -41,14 +41,14 @@
  the block will be given the result and error of this task.
  @returns A new task that will be finished once the block has run.
  */
-- (BFTask *)thenCallBackOnMainThreadAsync:(void(^)(id result, NSError *error))block;
+- (instancetype)thenCallBackOnMainThreadAsync:(void(^)(id result, NSError *error))block;
 
 /*!
  Identical to thenCallBackOnMainThreadAsync:, except that the result of a successful
  task will be converted to a BOOL using the boolValue method, and that will
  be passed to the block instead of the original result.
  */
-- (BFTask *)thenCallBackOnMainThreadWithBoolValueAsync:(void(^)(BOOL result, NSError *error))block;
+- (instancetype)thenCallBackOnMainThreadWithBoolValueAsync:(void(^)(BOOL result, NSError *error))block;
 
 /*!
  Same as `waitForResult:error withMainThreadWarning:YES`

--- a/Parse/Internal/PFEncoder.h
+++ b/Parse/Internal/PFEncoder.h
@@ -62,6 +62,6 @@
 
 + (instancetype)objectEncoderWithOfflineStore:(PFOfflineStore *)store database:(PFSQLiteDatabase *)database;
 
-- (BFTask *)encodeFinished;
+- (BFTask PF_GENERIC(PFVoid) *)encodeFinished;
 
 @end

--- a/Parse/Internal/PFEventuallyPin.h
+++ b/Parse/Internal/PFEventuallyPin.h
@@ -62,15 +62,18 @@ typedef NS_ENUM(NSUInteger, PFEventuallyPinType) {
 /*!
  Wrap given PFObject and PFCommand in a PFEventuallyPin with auto-generated UUID.
  */
-+ (BFTask *)pinEventually:(PFObject *)object forCommand:(id<PFNetworkCommand>)command;
++ (BFTask PF_GENERIC(__kindof PFEventuallyPin *) *)pinEventually:(PFObject *)object
+                                                      forCommand:(id<PFNetworkCommand>)command;
 
 /*!
  Wrap given PFObject and PFCommand in a PFEventuallyPin with given UUID.
  */
-+ (BFTask *)pinEventually:(PFObject *)object forCommand:(id<PFNetworkCommand>)command withUUID:(NSString *)uuid;
++ (BFTask PF_GENERIC(__kindof PFEventuallyPin *) *)pinEventually:(PFObject *)object
+                                                      forCommand:(id<PFNetworkCommand>)command
+                                                        withUUID:(NSString *)uuid;
 
-+ (BFTask *)findAllEventuallyPin;
++ (BFTask PF_GENERIC(NSArray<__kindof PFEventuallyPin *> *) *)findAllEventuallyPin;
 
-+ (BFTask *)findAllEventuallyPinWithExcludeUUIDs:(NSArray *)excludeUUIDs;
++ (BFTask PF_GENERIC(NSArray<__kindof PFEventuallyPin *> *) *)findAllEventuallyPinWithExcludeUUIDs:(NSArray *)excludeUUIDs;
 
 @end

--- a/Parse/Internal/PFEventuallyQueue.h
+++ b/Parse/Internal/PFEventuallyQueue.h
@@ -55,8 +55,9 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 /// @name Running Commands
 ///--------------------------------------
 
-- (BFTask *)enqueueCommandInBackground:(id<PFNetworkCommand>)command;
-- (BFTask *)enqueueCommandInBackground:(id<PFNetworkCommand>)command withObject:(PFObject *)object;
+- (BFTask PF_GENERIC(__kindof PFEventuallyPin *) *)enqueueCommandInBackground:(id<PFNetworkCommand>)command;
+- (BFTask PF_GENERIC(__kindof PFEventuallyPin *) *)enqueueCommandInBackground:(id<PFNetworkCommand>)command
+                                                                   withObject:(PFObject *)object;
 
 ///--------------------------------------
 /// @name Controlling Queue

--- a/Parse/Internal/PFEventuallyQueue_Private.h
+++ b/Parse/Internal/PFEventuallyQueue_Private.h
@@ -10,6 +10,7 @@
 #import <SystemConfiguration/SCNetworkReachability.h>
 
 #import "PFEventuallyQueue.h"
+#import "PFMacros.h"
 
 @class BFExecutor;
 @class PFEventuallyPin;
@@ -22,8 +23,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 
 @class BFTaskCompletionSource;
 
-@interface PFEventuallyQueue ()
-{
+@interface PFEventuallyQueue () {
 @protected
     BFExecutor *_synchronizationExecutor;
     dispatch_queue_t _synchronizationQueue;
@@ -92,7 +92,6 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 /// @name Pending Commands
 ///--------------------------------------
 
-
 /*!
  Generates a new identifier for a command so that it can be sorted later by this identifier.
  */
@@ -129,11 +128,11 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
  @param identifier           Unique identifier used to represent a command.
  @returns Task that is resolved when the command is complete enqueueing.
  */
-- (BFTask *)_enqueueCommandInBackground:(id<PFNetworkCommand>)command
-                                 object:(PFObject *)object
-                             identifier:(NSString *)identifier;
+- (BFTask PF_GENERIC(PFEventuallyPin *)*)_enqueueCommandInBackground:(id<PFNetworkCommand>)command
+                                                              object:(PFObject *)object
+                                                          identifier:(NSString *)identifier;
 
-- (BFTask *)_waitForOperationSet:(PFOperationSet *)operationSet
-                   eventuallyPin:(PFEventuallyPin *)eventuallyPin;
+- (BFTask PF_GENERIC(PFVoid) *)_waitForOperationSet:(PFOperationSet *)operationSet
+                                      eventuallyPin:(PFEventuallyPin *)eventuallyPin;
 
 @end

--- a/Parse/Internal/PFFileManager.h
+++ b/Parse/Internal/PFFileManager.h
@@ -28,24 +28,24 @@ typedef NS_OPTIONS(uint8_t, PFFileManagerOptions) {
 
 + (BOOL)isApplicationGroupContainerReachableForGroupIdentifier:(NSString *)applicationGroup;
 
-+ (BFTask *)createDirectoryIfNeededAsyncAtPath:(NSString *)path;
-+ (BFTask *)createDirectoryIfNeededAsyncAtPath:(NSString *)path
-                                   withOptions:(PFFileManagerOptions)options
-                                      executor:(BFExecutor *)executor;
++ (BFTask PF_GENERIC(PFVoid) *)createDirectoryIfNeededAsyncAtPath:(NSString *)path;
++ (BFTask PF_GENERIC(PFVoid) *)createDirectoryIfNeededAsyncAtPath:(NSString *)path
+                                                      withOptions:(PFFileManagerOptions)options
+                                                         executor:(BFExecutor *)executor;
 
-+ (BFTask *)writeStringAsync:(NSString *)string toFile:(NSString *)filePath;
-+ (BFTask *)writeDataAsync:(NSData *)data toFile:(NSString *)filePath;
++ (BFTask PF_GENERIC(PFVoid) *)writeStringAsync:(NSString *)string toFile:(NSString *)filePath;
++ (BFTask PF_GENERIC(PFVoid) *)writeDataAsync:(NSData *)data toFile:(NSString *)filePath;
 
-+ (BFTask *)copyItemAsyncAtPath:(NSString *)fromPath toPath:(NSString *)toPath;
-+ (BFTask *)moveItemAsyncAtPath:(NSString *)fromPath toPath:(NSString *)toPath;
++ (BFTask PF_GENERIC(PFVoid) *)copyItemAsyncAtPath:(NSString *)fromPath toPath:(NSString *)toPath;
++ (BFTask PF_GENERIC(PFVoid) *)moveItemAsyncAtPath:(NSString *)fromPath toPath:(NSString *)toPath;
 
-+ (BFTask *)moveContentsOfDirectoryAsyncAtPath:(NSString *)fromPath
-                             toDirectoryAtPath:(NSString *)toPath
-                                      executor:(BFExecutor *)executor;
++ (BFTask PF_GENERIC(PFVoid) *)moveContentsOfDirectoryAsyncAtPath:(NSString *)fromPath
+                                                toDirectoryAtPath:(NSString *)toPath
+                                                         executor:(BFExecutor *)executor;
 
-+ (BFTask *)removeItemAtPathAsync:(NSString *)path;
-+ (BFTask *)removeItemAtPathAsync:(NSString *)path withFileLock:(BOOL)useFileLock;
-+ (BFTask *)removeDirectoryContentsAsyncAtPath:(NSString *)path;
++ (BFTask PF_GENERIC(PFVoid) *)removeItemAtPathAsync:(NSString *)path;
++ (BFTask PF_GENERIC(PFVoid) *)removeItemAtPathAsync:(NSString *)path withFileLock:(BOOL)useFileLock;
++ (BFTask PF_GENERIC(PFVoid) *)removeDirectoryContentsAsyncAtPath:(NSString *)path;
 
 ///--------------------------------------
 /// @name Instance

--- a/Parse/Internal/ParseManager.h
+++ b/Parse/Internal/ParseManager.h
@@ -96,6 +96,6 @@ PFInstallationIdentifierStoreProvider>
 /// @name Preloading
 ///--------------------------------------
 
-- (BFTask *)preloadDiskObjectsToMemoryAsync;
+- (BFTask PF_GENERIC(PFVoid)*)preloadDiskObjectsToMemoryAsync;
 
 @end

--- a/Parse/Internal/Query/Controller/PFQueryController.h
+++ b/Parse/Internal/Query/Controller/PFQueryController.h
@@ -50,9 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @returns Task that resolves to `NSArray` of `PFObject`s.
  */
-- (BFTask *)findObjectsAsyncForQueryState:(PFQueryState *)queryState
-                    withCancellationToken:(nullable BFCancellationToken *)cancellationToken
-                                     user:(nullable PFUser *)user; // TODO: (nlutsenko) Pass `PFUserState` instead of user.
+- (BFTask PF_GENERIC(NSArray<PFObject *> *)*)findObjectsAsyncForQueryState:(PFQueryState *)queryState
+                                                     withCancellationToken:(nullable BFCancellationToken *)cancellationToken
+                                                                      user:(nullable PFUser *)user; // TODO: (nlutsenko) Pass `PFUserState` instead of user.
 
 ///--------------------------------------
 /// @name Count
@@ -68,9 +68,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @returns Task that resolves to `NSNumber` with a count of results.
  */
-- (BFTask *)countObjectsAsyncForQueryState:(PFQueryState *)queryState
-                     withCancellationToken:(nullable BFCancellationToken *)cancellationToken
-                                      user:(nullable PFUser *)user; // TODO: (nlutsenko) Pass `PFUserState` instead of user.
+- (BFTask PF_GENERIC(NSNumber *)*)countObjectsAsyncForQueryState:(PFQueryState *)queryState
+                                           withCancellationToken:(nullable BFCancellationToken *)cancellationToken
+                                                            user:(nullable PFUser *)user; // TODO: (nlutsenko) Pass `PFUserState` instead of user.
 
 ///--------------------------------------
 /// @name Caching
@@ -95,9 +95,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @returns `BFTask` instance with result of `PFCommandResult`.
  */
-- (BFTask *)runNetworkCommandAsync:(PFRESTCommand *)command
-             withCancellationToken:(nullable BFCancellationToken *)cancellationToken
-                     forQueryState:(PFQueryState *)queryState;
+- (BFTask PF_GENERIC(PFCommandResult *)*)runNetworkCommandAsync:(PFRESTCommand *)command
+                                          withCancellationToken:(nullable BFCancellationToken *)cancellationToken
+                                                  forQueryState:(PFQueryState *)queryState;
 
 @end
 

--- a/Parse/Internal/Session/Controller/PFSessionController.h
+++ b/Parse/Internal/Session/Controller/PFSessionController.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Current Session
 ///--------------------------------------
 
-- (BFTask *)getCurrentSessionAsyncWithSessionToken:(nullable NSString *)sessionToken;
+- (BFTask PF_GENERIC(PFSession *)*)getCurrentSessionAsyncWithSessionToken:(nullable NSString *)sessionToken;
 
 @end
 

--- a/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
+++ b/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
@@ -33,16 +33,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Authentication
 ///--------------------------------------
 
-- (BFTask *)deauthenticateAsyncWithProviderForAuthType:(NSString *)authType;
+- (BFTask PF_GENERIC(PFVoid) *)deauthenticateAsyncWithProviderForAuthType:(NSString *)authType;
 
-- (BFTask *)restoreAuthenticationAsyncWithAuthData:(nullable NSDictionary *)authData
-                           forProviderWithAuthType:(NSString *)authType;
+- (BFTask PF_GENERIC(PFVoid) *)restoreAuthenticationAsyncWithAuthData:(nullable NSDictionary *)authData
+                                              forProviderWithAuthType:(NSString *)authType;
 
 ///--------------------------------------
 /// @name Log In
 ///--------------------------------------
 
-- (BFTask *)logInUserAsyncWithAuthType:(NSString *)authType authData:(NSDictionary *)authData;
+- (BFTask PF_GENERIC(PFUser *) *)logInUserAsyncWithAuthType:(NSString *)authType authData:(NSDictionary *)authData;
 
 @end
 

--- a/Parse/Internal/User/AuthenticationProviders/Providers/PFAuthenticationProvider.h
+++ b/Parse/Internal/User/AuthenticationProviders/Providers/PFAuthenticationProvider.h
@@ -13,6 +13,8 @@
 
 #import <Parse/PFConstants.h>
 
+#import "PFMacros.h"
+
 //TODO: (nlutsenko) Update documentation for all these methods.
 
 PF_ASSUME_NONNULL_BEGIN
@@ -34,7 +36,7 @@ PF_ASSUME_NONNULL_BEGIN
 /*!
  Invoked by a PFUser upon logOut. Deauthenticate should be used to clear any state being kept by the provider that is associated with the logged-in user.
  */
-- (BFTask *)deauthenticateInBackground;
+- (BFTask PF_GENERIC(PFVoid)*)deauthenticateInBackground;
 
 /*!
  Upon logging in (or restoring a PFUser from disk), authData is returned from the server, and the PFUser passes that data into this function,
@@ -42,7 +44,7 @@ PF_ASSUME_NONNULL_BEGIN
  can be used immediately, without having to reauthorize).  authData can be nil, in which case the user has been unlinked, and the service should clear its
  internal state.  Returning NO from this function indicates the authData was somehow invalid, and the user should be unlinked from the provider.
  */
-- (BFTask *)restoreAuthenticationInBackgroundWithAuthData:(PF_NULLABLE NSDictionary *)authData;
+- (BFTask PF_GENERIC(PFVoid)*)restoreAuthenticationInBackgroundWithAuthData:(PF_NULLABLE NSDictionary *)authData;
 
 @end
 

--- a/Parse/Internal/User/Controller/PFUserController.h
+++ b/Parse/Internal/User/Controller/PFUserController.h
@@ -11,7 +11,11 @@
 
 #import "PFCoreDataProvider.h"
 #import "PFDataProvider.h"
+#import "PFMacros.h"
 #import "PFObjectControlling.h"
+
+@class PFUser;
+@class PFCommandResult;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -34,27 +38,27 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Log In
 ///--------------------------------------
 
-- (BFTask *)logInCurrentUserAsyncWithSessionToken:(NSString *)sessionToken;
-- (BFTask *)logInCurrentUserAsyncWithUsername:(NSString *)username
-                                     password:(NSString *)password
-                             revocableSession:(BOOL)revocableSession;
+- (BFTask PF_GENERIC(PFUser *)*)logInCurrentUserAsyncWithSessionToken:(NSString *)sessionToken;
+- (BFTask PF_GENERIC(PFUser *)*)logInCurrentUserAsyncWithUsername:(NSString *)username
+                                                         password:(NSString *)password
+                                                 revocableSession:(BOOL)revocableSession;
 
 //TODO: (nlutsenko) Move this method into PFUserAuthenticationController after PFUser is decoupled further.
-- (BFTask *)logInCurrentUserAsyncWithAuthType:(NSString *)authType
-                                     authData:(NSDictionary *)authData
-                             revocableSession:(BOOL)revocableSession;
+- (BFTask PF_GENERIC(PFUser *)*)logInCurrentUserAsyncWithAuthType:(NSString *)authType
+                                                         authData:(NSDictionary *)authData
+                                                 revocableSession:(BOOL)revocableSession;
 
 ///--------------------------------------
 /// @name Reset Password
 ///--------------------------------------
 
-- (BFTask *)requestPasswordResetAsyncForEmail:(NSString *)email;
+- (BFTask PF_GENERIC(PFVoid) *)requestPasswordResetAsyncForEmail:(NSString *)email;
 
 ///--------------------------------------
 /// @name Log Out
 ///--------------------------------------
 
-- (BFTask *)logOutUserAsyncWithSessionToken:(NSString *)sessionToken;
+- (BFTask PF_GENERIC(PFVoid) *)logOutUserAsyncWithSessionToken:(NSString *)sessionToken;
 
 @end
 

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
@@ -46,14 +46,14 @@ typedef NS_OPTIONS(NSUInteger, PFCurrentUserLoadingOptions) {
 /// @name User
 ///--------------------------------------
 
-- (BFTask *)getCurrentUserAsyncWithOptions:(PFCurrentUserLoadingOptions)options;
+- (BFTask PF_GENERIC(PFUser *) *)getCurrentUserAsyncWithOptions:(PFCurrentUserLoadingOptions)options;
 
-- (BFTask *)logOutCurrentUserAsync;
+- (BFTask PF_GENERIC(PFVoid) *)logOutCurrentUserAsync;
 
 ///--------------------------------------
 /// @name Session Token
 ///--------------------------------------
 
-- (BFTask *)getCurrentUserSessionTokenAsync;
+- (BFTask PF_GENERIC(NSString *) *)getCurrentUserSessionTokenAsync;
 
 @end

--- a/Parse/Internal/User/PFUserPrivate.h
+++ b/Parse/Internal/User/PFUserPrivate.h
@@ -27,17 +27,17 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 ///--------------------------------------
 /// @name Current User
 ///--------------------------------------
-+ (BFTask *)_getCurrentUserSessionTokenAsync;
++ (BFTask PF_GENERIC(NSString *)*)_getCurrentUserSessionTokenAsync;
 + (NSString *)currentSessionToken;
 
 - (void)synchronizeAllAuthData;
 
-- (BFTask *)_handleServiceLoginCommandResult:(PFCommandResult *)result;
+- (BFTask PF_GENERIC(PFUser *)*)_handleServiceLoginCommandResult:(PFCommandResult *)result;
 
 - (void)synchronizeAuthDataWithAuthType:(NSString *)authType;
 
 + (PFUser *)logInLazyUserWithAuthType:(NSString *)authType authData:(NSDictionary *)authData;
-- (BFTask *)resolveLazinessAsync:(BFTask *)toAwait;
+- (BFTask PF_GENERIC(PFUser *)*)resolveLazinessAsync:(BFTask *)toAwait;
 - (void)stripAnonymity;
 - (void)restoreAnonymity:(id)data;
 
@@ -69,7 +69,7 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 
 - (BOOL)_isAuthenticatedWithCurrentUser:(PFUser *)currentUser;
 
-- (BFTask *)_logOutAsync;
+- (BFTask PF_GENERIC(PFVoid) *)_logOutAsync;
 
 ///--------------------------------------
 /// @name Authentication Providers
@@ -79,13 +79,13 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 + (void)registerAuthenticationProvider:(id<PFAuthenticationProvider>)authenticationProvider;
 
 // TODO: (nlutsenko) Add Documentation
-+ (BFTask *)logInWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
++ (BFTask PF_GENERIC(PFUser *)*)logInWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
 
 // TODO: (nlutsenko) Add Documentation
-- (BFTask *)linkWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
+- (BFTask PF_GENERIC(NSNumber *)*)linkWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
 
 // TODO: (nlutsenko) Add Documentation
-- (BFTask *)unlinkWithAuthTypeInBackground:(NSString *)authType;
+- (BFTask PF_GENERIC(NSNumber *)*)unlinkWithAuthTypeInBackground:(NSString *)authType;
 
 // TODO: (nlutsenko) Add Documentation
 - (BOOL)isLinkedWithAuthType:(NSString *)authType;


### PR DESCRIPTION
Part 5/5.

Adds definitions to the following internal sections:

 - Query
 - Session
 - User
 - Internal

Each should be able to function completely independent of the others.