### PR TITLE
Base work for public Bolts task generics.

### DIFF
--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -438,8 +438,8 @@ typedef void (^PFProgressBlock)(int percentDone);
 ///--------------------------------------
 
 #if __has_feature(objc_generics) || __has_extension(objc_generics)
-#  define PF_GENERIC(type) <type>
+#  define PF_GENERIC(...) <__VA_ARGS__>
 #else
-#  define PF_GENERIC(type)
+#  define PF_GENERIC(...)
 #  define PFGenericObject PFObject *
 #endif


### PR DESCRIPTION
We need to be able to use PF_GENERIC with multiple types (e.g. NSDictionary). Make it varargs.