### PR TITLE
Added BFTask generics to header of PFSession

### DIFF
--- a/Parse/PFSession.h
+++ b/Parse/PFSession.h
@@ -37,7 +37,7 @@ typedef void(^PFSessionResultBlock)(PFSession *PF_NULLABLE_S session, NSError *P
 
  @returns A task that is `completed` with an instance of `PFSession` class or is `faulted` if the operation fails.
  */
-+ (BFTask *)getCurrentSessionInBackground;
++ (BFTask PF_GENERIC(PFSession *)*)getCurrentSessionInBackground;
 
 /*!
  *Asynchronously* fetches a `PFSession` object related to the current user.


### PR DESCRIPTION
I guess you could say 

(•\_•) 
( •\_•)>⌐■-■
(⌐■\_■)

Bolts is now in session.