### PR TITLE
Publicize network notifications.

### DIFF
--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.h
@@ -33,35 +33,3 @@ extern NSString *const PFCommandHeaderNameSessionToken;
 ///--------------------------------------
 
 extern NSString *const PFCommandParameterNameMethodOverride;
-
-///--------------------------------------
-/// @name Notifications
-///--------------------------------------
-
-/*!
- @abstract The name of the notification that is going to be sent before any URL request is sent.
- */
-extern NSString *const PFCommandRunnerWillSendURLRequestNotification;
-
-/*!
- @abstract The name of the notification that is going to be sent after any URL response is received.
- */
-extern NSString *const PFCommandRunnerDidReceiveURLResponseNotification;
-
-/*!
- @abstract The key of request(NSURLRequest) in the userInfo dictionary of a notification.
- @note This key is populated in userInfo, only of `PFLogLevel` in `PFLogger` is set to `PFLogLevelDebug`.
- */
-extern NSString *const PFCommandRunnerNotificationURLRequestUserInfoKey;
-
-/*!
- @abstract The key of response(NSHTTPURLResponse) in the userInfo dictionary of a notification.
- @note This key is populated in userInfo, only of `PFLogLevel` in `PFLogger` is set to `PFLogLevelDebug`.
- */
-extern NSString *const PFCommandRunnerNotificationURLResponseUserInfoKey;
-
-/*!
- @abstract The key of repsonse body (usually `NSString` with JSON) in the userInfo dictionary of a notification.
- @note This key is populated in userInfo, only of `PFLogLevel` in `PFLogger` is set to `PFLogLevelDebug`.
- */
-extern NSString *const PFCommandRunnerNotificationURLResponseBodyUserInfoKey;

--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.m
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.m
@@ -21,13 +21,3 @@ NSString *const PFCommandHeaderNameOSVersion = @"X-Parse-OS-Version";
 NSString *const PFCommandHeaderNameSessionToken = @"X-Parse-Session-Token";
 
 NSString *const PFCommandParameterNameMethodOverride = @"_method";
-
-///--------------------------------------
-#pragma mark - Notifications
-///--------------------------------------
-
-NSString *const PFCommandRunnerWillSendURLRequestNotification = @"PFCommandRunnerWillSendURLRequestNotification";
-NSString *const PFCommandRunnerDidReceiveURLResponseNotification = @"PFCommandRunnerDidReceiveURLResponseNotification";
-NSString *const PFCommandRunnerNotificationURLRequestUserInfoKey = @"PFCommandRunnerNotificationURLRequestUserInfoKey";
-NSString *const PFCommandRunnerNotificationURLResponseUserInfoKey = @"PFCommandRunnerNotificationURLResponseUserInfoKey";
-NSString *const PFCommandRunnerNotificationURLResponseBodyUserInfoKey = @"PFCommandRunnerNotificationURLResponseBodyUserInfoKey";

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -119,7 +119,7 @@
 - (BFTask *)runCommandAsync:(PFRESTCommand *)command
                 withOptions:(PFCommandRunningOptions)options
           cancellationToken:(BFCancellationToken *)cancellationToken {
-    return [self _performCommandRunningBlock:^id{
+    return [self _performCommandRunningBlock:^id {
         [command resolveLocalIds];
         NSURLRequest *request = [self.requestConstructor dataURLRequestForCommand:command];
         return [_session performDataURLRequestAsync:request forCommand:command cancellationToken:cancellationToken];
@@ -137,7 +137,7 @@
                     cancellationToken:(nullable BFCancellationToken *)cancellationToken
                         progressBlock:(nullable PFProgressBlock)progressBlock {
     @weakify(self);
-    return [self _performCommandRunningBlock:^id{
+    return [self _performCommandRunningBlock:^id {
         @strongify(self);
 
         [command resolveLocalIds];
@@ -157,13 +157,14 @@
                                     targetFilePath:(NSString *)filePath
                                  cancellationToken:(nullable BFCancellationToken *)cancellationToken
                                      progressBlock:(nullable PFProgressBlock)progressBlock {
-    return [self _performCommandRunningBlock:^id{
+    return [self _performCommandRunningBlock:^id {
         NSURLRequest *request = [NSURLRequest requestWithURL:url];
         return [_session performFileDownloadURLRequestAsync:request
                                                toFileAtPath:filePath
                                       withCancellationToken:cancellationToken
                                               progressBlock:progressBlock];
-    } withOptions:PFCommandRunningOptionRetryIfFailed cancellationToken:cancellationToken];
+    } withOptions:PFCommandRunningOptionRetryIfFailed
+                           cancellationToken:cancellationToken];
 }
 
 ///--------------------------------------
@@ -253,8 +254,8 @@
 - (void)urlSession:(PFURLSession *)session willPerformURLRequest:(NSURLRequest *)request {
     [[BFExecutor defaultPriorityBackgroundExecutor] execute:^{
         NSDictionary *userInfo = ([PFLogger sharedLogger].logLevel == PFLogLevelDebug ?
-                                  @{ PFCommandRunnerNotificationURLRequestUserInfoKey : request } : nil);
-        [self.notificationCenter postNotificationName:PFCommandRunnerWillSendURLRequestNotification
+                                  @{ PFNetworkNotificationURLRequestUserInfoKey : request } : nil);
+        [self.notificationCenter postNotificationName:PFNetworkWillSendURLRequestNotification
                                                object:self
                                              userInfo:userInfo];
     }];
@@ -268,15 +269,15 @@ didPerformURLRequest:(NSURLRequest *)request
         NSMutableDictionary *userInfo = nil;
         if ([PFLogger sharedLogger].logLevel == PFLogLevelDebug) {
             userInfo = [NSMutableDictionary dictionaryWithObject:request
-                                                          forKey:PFCommandRunnerNotificationURLRequestUserInfoKey];
+                                                          forKey:PFNetworkNotificationURLRequestUserInfoKey];
             if (response) {
-                userInfo[PFCommandRunnerNotificationURLResponseUserInfoKey] = response;
+                userInfo[PFNetworkNotificationURLResponseUserInfoKey] = response;
             }
             if (responseString) {
-                userInfo[PFCommandRunnerNotificationURLResponseBodyUserInfoKey] = responseString;
+                userInfo[PFNetworkNotificationURLResponseBodyUserInfoKey] = responseString;
             }
         }
-        [self.notificationCenter postNotificationName:PFCommandRunnerDidReceiveURLResponseNotification
+        [self.notificationCenter postNotificationName:PFNetworkDidReceiveURLResponseNotification
                                                object:self
                                              userInfo:userInfo];
     }];

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -386,6 +386,39 @@ typedef void (^PFIdResultBlock)(PF_NULLABLE_S id object, NSError *PF_NULLABLE_S 
 typedef void (^PFProgressBlock)(int percentDone);
 
 ///--------------------------------------
+/// @name Network Notifications
+///--------------------------------------
+
+/*!
+ @abstract The name of the notification that is going to be sent before any URL request is sent.
+ */
+extern NSString *const PF_NONNULL_S PFNetworkWillSendURLRequestNotification;
+
+/*!
+ @abstract The name of the notification that is going to be sent after any URL response is received.
+ */
+extern NSString *const PF_NONNULL_S PFNetworkDidReceiveURLResponseNotification;
+
+/*!
+ @abstract The key of request(NSURLRequest) in the userInfo dictionary of a notification.
+ @note This key is populated in userInfo, only if `PFLogLevel` on `Parse` is set to `PFLogLevelDebug`.
+ */
+extern NSString *const PF_NONNULL_S PFNetworkNotificationURLRequestUserInfoKey;
+
+/*!
+ @abstract The key of response(NSHTTPURLResponse) in the userInfo dictionary of a notification.
+ @note This key is populated in userInfo, only if `PFLogLevel` on `Parse` is set to `PFLogLevelDebug`.
+ */
+extern NSString *const PF_NONNULL_S PFNetworkNotificationURLResponseUserInfoKey;
+
+/*!
+ @abstract The key of repsonse body (usually `NSString` with JSON) in the userInfo dictionary of a notification.
+ @note This key is populated in userInfo, only if `PFLogLevel` on `Parse` is set to `PFLogLevelDebug`.
+ */
+extern NSString *const PF_NONNULL_S PFNetworkNotificationURLResponseBodyUserInfoKey;
+
+
+///--------------------------------------
 /// @name Deprecated Macros
 ///--------------------------------------
 

--- a/Parse/PFConstants.m
+++ b/Parse/PFConstants.m
@@ -20,3 +20,13 @@ NSString *const kPFDeviceType                = @"osx";
 NSString *const kPFParseServer               = @"https://api.parse.com";
 
 NSString *const PFParseErrorDomain = @"Parse";
+
+///--------------------------------------
+#pragma mark - Network Notifications
+///--------------------------------------
+
+NSString *const PFNetworkWillSendURLRequestNotification = @"PFNetworkWillSendURLRequestNotification";
+NSString *const PFNetworkDidReceiveURLResponseNotification = @"PFNetworkDidReceiveURLResponseNotification";
+NSString *const PFNetworkNotificationURLRequestUserInfoKey = @"PFNetworkNotificationURLRequestUserInfoKey";
+NSString *const PFNetworkNotificationURLResponseUserInfoKey = @"PFNetworkNotificationURLResponseUserInfoKey";
+NSString *const PFNetworkNotificationURLResponseBodyUserInfoKey = @"PFNetworkNotificationURLResponseBodyUserInfoKey";

--- a/Parse/PFNetworkActivityIndicatorManager.m
+++ b/Parse/PFNetworkActivityIndicatorManager.m
@@ -9,6 +9,8 @@
 
 #import "PFNetworkActivityIndicatorManager.h"
 
+#import <Parse/PFConstants.h>
+
 #import "PFApplication.h"
 #import "PFCommandRunningConstants.h"
 
@@ -52,11 +54,11 @@ static NSTimeInterval const PFNetworkActivityIndicatorVisibilityDelay = 0.17;
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(_handleWillSendURLRequestNotification:)
-                                                 name:PFCommandRunnerWillSendURLRequestNotification
+                                                 name:PFNetworkWillSendURLRequestNotification
                                                object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(_handleDidReceiveURLResponseNotification:)
-                                                 name:PFCommandRunnerDidReceiveURLResponseNotification
+                                                 name:PFNetworkDidReceiveURLResponseNotification
                                                object:nil];
 
     return self;


### PR DESCRIPTION
Rename these notifications and move them into `PFConstants.h`.

cc @grantland @wangmengyan95