### PR TITLE
Cleanup imports for PFAuthenticationProvider.

### DIFF
--- a/Parse/Internal/ParseInternal.h
+++ b/Parse/Internal/ParseInternal.h
@@ -12,7 +12,6 @@
 # import <Parse/Parse.h>
 
 #import "PFAssert.h"
-#import "PFAuthenticationProvider.h"
 #import "PFCommandCache.h"
 #import "PFEventuallyQueue.h"
 #import "PFFieldOperation.h"

--- a/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
+++ b/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
@@ -10,8 +10,7 @@
 #import <Foundation/Foundation.h>
 
 #import <Parse/PFConstants.h>
-
-#import "PFAuthenticationProvider.h"
+#import <Parse/PFAuthenticationProvider.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Parse/Internal/User/PFUserPrivate.h
+++ b/Parse/Internal/User/PFUserPrivate.h
@@ -11,8 +11,6 @@
 
 #import <Parse/PFUser.h>
 
-#import "PFAuthenticationProvider.h"
-
 extern NSString *const PFUserCurrentUserFileName;
 extern NSString *const PFUserCurrentUserPinName;
 extern NSString *const PFUserCurrentUserKeychainItemName;


### PR DESCRIPTION
Some of these are not required, another piece should only use public imports to avoid duplicates.