### PR TITLE
Enable Xcode7 code-coverage collection for test schemes.

### DIFF
--- a/Parse.xcodeproj/xcshareddata/xcschemes/Parse-OSX.xcscheme
+++ b/Parse.xcodeproj/xcshareddata/xcschemes/Parse-OSX.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -73,6 +74,7 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      enableAddressSanitizer = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>

--- a/Parse.xcodeproj/xcshareddata/xcschemes/Parse-iOS.xcscheme
+++ b/Parse.xcodeproj/xcshareddata/xcschemes/Parse-iOS.xcscheme
@@ -41,6 +41,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
       enableAddressSanitizer = "YES">
       <Testables>
          <TestableReference


### PR DESCRIPTION
This allows inline code coverage in the IDE. What fun!