### PR TITLE
Fix decoding of updatedAt/createdAt on PFObject if dates are already decoded.

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -1365,9 +1365,21 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
             if ([key isEqualToString:PFObjectObjectIdRESTKey]) {
                 state.objectId = obj;
             } else if ([key isEqualToString:PFObjectCreatedAtRESTKey]) {
-                [state setCreatedAtFromString:obj];
+                // These dates can be passed in as NSDate or as NSString,
+                // depending on whether they were wrapped inside JSONObject with __type: Date or not.
+                if ([obj isKindOfClass:[NSDate class]]) {
+                    state.createdAt = obj;
+                } else {
+                    [state setCreatedAtFromString:obj];
+                }
             } else if ([key isEqualToString:PFObjectUpdatedAtRESTKey]) {
-                [state setUpdatedAtFromString:obj];
+                // These dates can be passed in as NSDate or as NSString,
+                // depending on whether they were wrapped inside JSONObject with __type: Date or not.
+                if ([obj isKindOfClass:[NSDate class]]) {
+                    state.updatedAt = obj;
+                } else {
+                    [state setUpdatedAtFromString:obj];
+                }
             } else if ([key isEqualToString:PFObjectACLRESTKey]) {
                 PFACL *acl = [PFACL ACLWithDictionary:obj];
                 [state setServerDataObject:acl forKey:key];

--- a/Tests/Unit/DecoderTests.m
+++ b/Tests/Unit/DecoderTests.m
@@ -165,6 +165,31 @@
     XCTAssertEqualObjects(object.objectId, @"123");
 }
 
+- (void)testDecodingObjectsWithDates {
+    PFDecoder *decoder = [[PFDecoder alloc] init];
+
+    NSDictionary *decoded = [decoder decodeObject:@{ @"object" : @{@"__type" : @"Object",
+                                                                   @"className" : @"Yolo",
+                                                                   @"objectId" : @"123",
+                                                                   @"updatedAt" : @"1970-01-01T00:00:01.000Z",
+                                                                   @"createdAt" : @"1970-01-01T00:00:02.000Z"} }];
+    PFObject *object = decoded[@"object"];
+
+    XCTAssertEqualObjects(object.updatedAt, [NSDate dateWithTimeIntervalSince1970:1.0]);
+    XCTAssertEqualObjects(object.createdAt, [NSDate dateWithTimeIntervalSince1970:2.0]);
+
+    decoded = [decoder decodeObject:@{ @"object" : @{@"__type" : @"Object",
+                                                     @"className" : @"Yolo",
+                                                     @"objectId" : @"123",
+                                                     @"updatedAt" : @{@"__type" : @"Date",
+                                                                      @"iso" : @"1970-01-01T00:00:01.000Z"},
+                                                     @"createdAt" : @{@"__type" : @"Date",
+                                                                      @"iso" : @"1970-01-01T00:00:02.000Z"}} }];
+    object = decoded[@"object"];
+    XCTAssertEqualObjects(object.updatedAt, [NSDate dateWithTimeIntervalSince1970:1.0]);
+    XCTAssertEqualObjects(object.createdAt, [NSDate dateWithTimeIntervalSince1970:2.0]);
+}
+
 - (void)testDecodingUnknownType {
     PFDecoder *decoder = [[PFDecoder alloc] init];
 


### PR DESCRIPTION
These dates can come in as NSDates, not just as NSStrings, if they were incapsulated into JSON Object with __type:Date before, like in Cloud Code.
Updated the decoding logic for that.
Fixes #243.