### PR TITLE
Fixed crash when using PFObject.deleteAll() with empty array.

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -2432,10 +2432,10 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
     return [[[self deleteAllInBackground:objects] waitForResult:error] boolValue];
 }
 
-+ (BFTask *)deleteAllInBackground:(NSArray *)objects {
++ (BFTask PF_GENERIC(NSNumber *) *)deleteAllInBackground:(NSArray *)objects {
     NSArray *deleteObjects = [objects copy]; // Snapshot the objects.
     if (deleteObjects.count == 0) {
-        return [BFTask taskWithResult:objects];
+        return [BFTask PF_GENERIC(NSNumber *) taskWithResult:@YES];
     }
     return [[[[self currentUserController] getCurrentUserSessionTokenAsync] continueWithBlock:^id(BFTask *task) {
         NSString *sessionToken = task.result;

--- a/Tests/Unit/ObjectUnitTests.m
+++ b/Tests/Unit/ObjectUnitTests.m
@@ -11,6 +11,7 @@
 #import "PFUnitTestCase.h"
 #import "Parse_Private.h"
 #import "PFObjectPrivate.h"
+#import "BFTask+Private.h"
 
 @interface ObjectUnitTests : PFUnitTestCase
 
@@ -195,6 +196,30 @@
         XCTAssertEqual(task.error.code, kPFErrorMissingObjectId);
         [expectation fulfill];
         return nil;
+    }];
+    [self waitForTestExpectations];
+}
+
+#pragma mark DeleteAll
+
+- (void)testDeleteAllWithoutObjects {
+    XCTAssertTrue([PFObject deleteAll:nil]);
+    XCTAssertTrue([PFObject deleteAll:@[]]);
+
+    NSError *error = nil;
+    XCTAssertTrue([PFObject deleteAll:nil error:&error]);
+    XCTAssertNil(error);
+    XCTAssertTrue([PFObject deleteAll:@[] error:&error]);
+    XCTAssertNil(error);
+
+    XCTAssertTrue([[[PFObject deleteAllInBackground:nil] waitForResult:nil] boolValue]);
+    XCTAssertTrue([[[PFObject deleteAllInBackground:@[]] waitForResult:nil] boolValue]);
+
+    XCTestExpectation *expectation = [self currentSelectorTestExpectation];
+    [PFObject deleteAllInBackground:nil block:^(BOOL succeeded, NSError * _Nullable error) {
+        XCTAssertTrue(succeeded);
+        XCTAssertNil(error);
+        [expectation fulfill];
     }];
     [self waitForTestExpectations];
 }


### PR DESCRIPTION
- Fixed wrong return type for `deleteInBackground:` if objects array is empty.
- Added tests for all of this.
Fixes #253