### PR TITLE
Cleanup PFUser third party authentication.

### DIFF
--- a/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
+++ b/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class BFTask;
+@class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFUser;
 
 @interface PFUserAuthenticationController : NSObject
@@ -33,8 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (BFTask PF_GENERIC(NSNumber *) *)restoreAuthenticationAsyncWithAuthData:(nullable NSDictionary *)authData
-                                       forProviderWithAuthType:(NSString *)authType;
-- (BFTask PF_GENERIC(NSNumber *) *)deauthenticateAsyncWithProviderForAuthType:(NSString *)authType;
+                                                              forAuthType:(NSString *)authType;
+- (BFTask PF_GENERIC(NSNumber *) *)deauthenticateAsyncWithAuthType:(NSString *)authType;
 
 ///--------------------------------------
 /// @name Log In

--- a/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
+++ b/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
@@ -20,7 +20,7 @@
 
 @interface PFUserAuthenticationController () {
     dispatch_queue_t _dataAccessQueue;
-    NSMutableDictionary *_authenticationProviders;
+    NSMutableDictionary PF_GENERIC(NSString *, id<PFUserAuthenticationDelegate>) *_authenticationDelegates;
 }
 
 @end
@@ -36,7 +36,7 @@
     if (!self) return nil;
 
     _dataAccessQueue = dispatch_queue_create("com.parse.user.authenticationManager", DISPATCH_QUEUE_SERIAL);
-    _authenticationProviders = [NSMutableDictionary dictionary];
+    _authenticationDelegates = [NSMutableDictionary dictionary];
 
     return self;
 }
@@ -47,16 +47,16 @@
 
 - (void)registerAuthenticationDelegate:(id<PFUserAuthenticationDelegate>)delegate forAuthType:(NSString *)authType {
     PFParameterAssert(delegate, @"Authentication delegate can't be `nil`.");
-    PFParameterAssert(authType, @"Authentication provider's `authType` can't be `nil`.");
+    PFParameterAssert(authType, @"`authType` can't be `nil`.");
     PFConsistencyAssert(![self authenticationDelegateForAuthType:authType],
-                        @"Authentication provider already registered for authType `%@`.", authType);
+                        @"Authentication delegate already registered for authType `%@`.", authType);
 
     dispatch_sync(_dataAccessQueue, ^{
-        _authenticationProviders[authType] = delegate;
+        _authenticationDelegates[authType] = delegate;
     });
 
     // TODO: (nlutsenko) Decouple this further.
-    if (![authType isEqualToString:@"anonymous"]) {
+    if (![authType isEqualToString:PFAnonymousUserAuthenticationType]) {
         [[PFUser currentUser] synchronizeAuthDataWithAuthType:authType];
     }
 }
@@ -66,7 +66,7 @@
         return;
     }
     dispatch_sync(_dataAccessQueue, ^{
-        [_authenticationProviders removeObjectForKey:authType];
+        [_authenticationDelegates removeObjectForKey:authType];
     });
 }
 
@@ -75,23 +75,19 @@
         return nil;
     }
 
-    __block id<PFUserAuthenticationDelegate> provider = nil;
+    __block id<PFUserAuthenticationDelegate> delegate = nil;
     dispatch_sync(_dataAccessQueue, ^{
-        provider = _authenticationProviders[authType];
+        delegate = _authenticationDelegates[authType];
     });
-    return provider;
+    return delegate;
 }
 
 ///--------------------------------------
 #pragma mark - Authentication
 ///--------------------------------------
 
-- (BFTask PF_GENERIC(NSNumber *)*)deauthenticateAsyncWithProviderForAuthType:(NSString *)authType {
-    return [self restoreAuthenticationAsyncWithAuthData:nil forProviderWithAuthType:authType];
-}
-
 - (BFTask PF_GENERIC(NSNumber *)*)restoreAuthenticationAsyncWithAuthData:(nullable NSDictionary *)authData
-                                                 forProviderWithAuthType:(NSString *)authType {
+                                                             forAuthType:(NSString *)authType {
     id<PFUserAuthenticationDelegate> provider = [self authenticationDelegateForAuthType:authType];
     if (!provider) {
         return [BFTask taskWithResult:@YES];
@@ -99,6 +95,10 @@
     return [BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id {
         return [BFTask taskWithResult:@([provider restoreAuthenticationWithAuthData:authData])];
     }];
+}
+
+- (BFTask PF_GENERIC(NSNumber *)*)deauthenticateAsyncWithAuthType:(NSString *)authType {
+    return [self restoreAuthenticationAsyncWithAuthData:nil forAuthType:authType];
 }
 
 ///--------------------------------------
@@ -115,7 +115,7 @@
             BFTask *resolveLaziness = nil;
             NSDictionary *oldAnonymousData = nil;
             @synchronized(user.lock) {
-                oldAnonymousData = user.authData[PFUserAnonymousAuthenticationType];
+                oldAnonymousData = user.authData[PFAnonymousUserAuthenticationType];
 
                 // Replace any anonymity with the new linked authData
                 [user stripAnonymity];

--- a/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.h
+++ b/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.h
@@ -13,7 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const PFUserAnonymousAuthenticationType;
+extern NSString *const PFAnonymousUserAuthenticationType;
 
 @interface PFAnonymousAuthenticationProvider : NSObject <PFUserAuthenticationDelegate>
 

--- a/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.m
+++ b/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.m
@@ -11,7 +11,7 @@
 
 #import <Bolts/BFTask.h>
 
-NSString *const PFUserAnonymousAuthenticationType = @"anonymous";
+NSString *const PFAnonymousUserAuthenticationType = @"anonymous";
 
 @implementation PFAnonymousAuthenticationProvider
 

--- a/Parse/PFAnonymousUtils.m
+++ b/Parse/PFAnonymousUtils.m
@@ -23,7 +23,7 @@
 
 + (BFTask *)logInInBackground {
     PFAnonymousAuthenticationProvider *provider = [self _authenticationProvider];
-    return [PFUser logInWithAuthTypeInBackground:PFUserAnonymousAuthenticationType authData:provider.authData];
+    return [PFUser logInWithAuthTypeInBackground:PFAnonymousUserAuthenticationType authData:provider.authData];
 }
 
 + (void)logInWithBlock:(PFUserResultBlock)block {
@@ -41,7 +41,7 @@
 ///--------------------------------------
 
 + (BOOL)isLinkedWithUser:(PFUser *)user {
-    return [user isLinkedWithAuthType:PFUserAnonymousAuthenticationType];
+    return [user isLinkedWithAuthType:PFAnonymousUserAuthenticationType];
 }
 
 ///--------------------------------------
@@ -65,7 +65,7 @@ static PFAnonymousAuthenticationProvider *authenticationProvider_;
         provider = authenticationProvider_;
         if (!provider) {
             provider = [[PFAnonymousAuthenticationProvider alloc] init];
-            [PFUser registerAuthenticationDelegate:provider forAuthType:PFUserAnonymousAuthenticationType];
+            [PFUser registerAuthenticationDelegate:provider forAuthType:PFAnonymousUserAuthenticationType];
             authenticationProvider_ = provider;
         }
     });
@@ -73,7 +73,7 @@ static PFAnonymousAuthenticationProvider *authenticationProvider_;
 }
 
 + (void)_clearAuthenticationProvider {
-    [PFUser _unregisterAuthenticationDelegateForAuthType:PFUserAnonymousAuthenticationType];
+    [PFUser _unregisterAuthenticationDelegateForAuthType:PFAnonymousUserAuthenticationType];
     dispatch_sync([self _providerAccessQueue], ^{
         authenticationProvider_ = nil;
     });
@@ -85,7 +85,7 @@ static PFAnonymousAuthenticationProvider *authenticationProvider_;
 
 + (PFUser *)_lazyLogIn {
     PFAnonymousAuthenticationProvider *provider = [self _authenticationProvider];
-    return [PFUser logInLazyUserWithAuthType:PFUserAnonymousAuthenticationType authData:provider.authData];
+    return [PFUser logInLazyUserWithAuthType:PFAnonymousUserAuthenticationType authData:provider.authData];
 }
 
 @end

--- a/Parse/PFUserAuthenticationDelegate.h
+++ b/Parse/PFUserAuthenticationDelegate.h
@@ -9,8 +9,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFTask.h>
-
 #import <Parse/PFConstants.h>
 
 PF_ASSUME_NONNULL_BEGIN
@@ -31,7 +29,7 @@ PF_ASSUME_NONNULL_BEGIN
  @returns `YES` - if the `authData` was succesfully synchronized, 
  or `NO` if user should not longer be associated because of bad `authData`.
  */
-- (BOOL)restoreAuthenticationWithAuthData:(PF_NULLABLE NSDictionary PF_GENERIC(NSString *,NSString *) *)authData;
+- (BOOL)restoreAuthenticationWithAuthData:(PF_NULLABLE NSDictionary PF_GENERIC(NSString *, NSString *) *)authData;
 
 @end
 


### PR DESCRIPTION
- Added more generic types
- Cleaned up assertion messages
- Updated constant name to be consistent
- Renamed few methods to be consistent