### PR TITLE
Fixed PFInstallation not updating automatic fields when using PFObject.saveAll().

### DIFF
--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -38,6 +38,8 @@
 
 @protocol PFObjectPrivateSubclass <NSObject>
 
+@required
+
 ///--------------------------------------
 /// @name State
 ///--------------------------------------
@@ -57,6 +59,18 @@
  @returns Task that encapsulates the validtion.
  */
 - (BFTask *)_validateSaveEventuallyAsync;
+
+@optional
+
+///--------------------------------------
+/// @name Before Save
+///--------------------------------------
+
+/*!
+ Called before an object is going to be saved. Called in a context of object lock.
+ Subclasses can override this method to do any custom updates before an object gets saved.
+ */
+- (void)_objectWillSave;
 
 @end
 

--- a/Parse/PFInstallation.m
+++ b/Parse/PFInstallation.m
@@ -214,21 +214,6 @@ static NSSet *protectedKeys;
 #pragma mark - PFObject
 ///--------------------------------------
 
-- (BFTask *)saveInBackground {
-    [self _updateAutomaticInfo];
-    return [super saveInBackground];
-}
-
-- (BFTask *)_enqueueSaveEventuallyWithChildren:(BOOL)saveChildren {
-    [self _updateAutomaticInfo];
-    return [super _enqueueSaveEventuallyWithChildren:saveChildren];
-}
-
-- (BFTask *)saveEventually {
-    [self _updateAutomaticInfo];
-    return [super saveEventually];
-}
-
 - (BFTask *)saveAsync:(BFTask *)toAwait {
     return [[super saveAsync:toAwait] continueWithBlock:^id(BFTask *task) {
         // Do not attempt to resave an object if LDS is enabled, since changing objectId is not allowed.
@@ -257,7 +242,7 @@ static NSSet *protectedKeys;
 #pragma mark - Automatic Info
 ///--------------------------------------
 
-- (void)_updateAutomaticInfo {
+- (void)_objectWillSave {
     if ([self _isCurrentInstallation]) {
         @synchronized(self.lock) {
             [self _updateTimeZoneFromDevice];

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -476,6 +476,7 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
                         for (PFObject *object in objectBatch) {
                             PFRESTCommand *command = nil;
                             @synchronized ([object lock]) {
+                                [object _objectWillSave];
                                 [object _checkSaveParametersWithCurrentUser:currentUser];
                                 command = [object _constructSaveCommandForChanges:[object unsavedChanges]
                                                                      sessionToken:sessionToken
@@ -1148,6 +1149,7 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
             return [self _validateSaveEventuallyAsync];
         }] continueWithSuccessBlock:^id(BFTask *task) {
             @synchronized (lock) {
+                [self _objectWillSave];
                 if (![self isDirty:NO]) {
                     return [BFTask taskWithResult:@YES];
                 }
@@ -1484,6 +1486,8 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
                     return [BFTask taskWithResult:@YES];
                 }
 
+                [self _objectWillSave];
+
                 // Snapshot the current set of changes, and push a new changeset into the queue.
                 PFOperationSet *changes = [self unsavedChanges];
 
@@ -1797,6 +1801,12 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
 
 - (BFTask *)_validateSaveEventuallyAsync {
     return [BFTask taskWithResult:nil];
+}
+
+#pragma mark Object Will Save
+
+- (void)_objectWillSave {
+    // Do nothing.
 }
 
 ///--------------------------------------


### PR DESCRIPTION
Not coverable with unit tests just yet...

Fixes #261