### PR TITLE
Improved fetch and delete PFObject validation logic.

### DIFF
--- a/Parse/Internal/Object/BatchController/PFObjectBatchController.m
+++ b/Parse/Internal/Object/BatchController/PFObjectBatchController.m
@@ -150,7 +150,6 @@
 - (PFRESTCommand *)_deleteCommandForObjects:(NSArray *)objects withSessionToken:(NSString *)sessionToken {
     NSMutableArray *commands = [NSMutableArray arrayWithCapacity:objects.count];
     for (PFObject *object in objects) {
-        [object checkDeleteParams];
         PFRESTCommand *deleteCommand = [PFRESTObjectCommand deleteObjectCommandForObjectState:object._state
                                                                              withSessionToken:sessionToken];
         [commands addObject:deleteCommand];

--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -48,18 +48,6 @@
                                             objectId:(NSString *)objectId
                                           isComplete:(BOOL)complete;
 
-///--------------------------------------
-/// @name Validation
-///--------------------------------------
-
-/*!
- Validate the save eventually operation with the current state.
- The result of this task is ignored. The error/cancellation/exception will prevent `saveEventually`.
-
- @returns Task that encapsulates the validtion.
- */
-- (BFTask *)_validateSaveEventuallyAsync;
-
 @optional
 
 ///--------------------------------------
@@ -106,6 +94,21 @@
 - (void)refreshInBackgroundWithTarget:(id)target selector:(SEL)selector;
 
 #endif
+
+///--------------------------------------
+/// @name Validation
+///--------------------------------------
+
+- (BFTask PF_GENERIC(PFVoid) *)_validateFetchAsync NS_REQUIRES_SUPER;
+- (BFTask PF_GENERIC(PFVoid) *)_validateDeleteAsync NS_REQUIRES_SUPER;
+
+/*!
+ Validate the save eventually operation with the current state.
+ The result of this task is ignored. The error/cancellation/exception will prevent `saveEventually`.
+
+ @returns Task that encapsulates the validation.
+ */
+- (BFTask PF_GENERIC(PFVoid) *)_validateSaveEventuallyAsync NS_REQUIRES_SUPER;
 
 ///--------------------------------------
 /// @name Pin
@@ -177,7 +180,6 @@
 ///--------------------------------------
 #pragma mark - Validations
 ///--------------------------------------
-- (void)checkDeleteParams;
 - (void)_checkSaveParametersWithCurrentUser:(PFUser *)currentUser;
 /*!
  Checks if Parse class name could be used to initialize a given instance of PFObject or it's subclass.

--- a/Parse/PFInstallation.m
+++ b/Parse/PFInstallation.m
@@ -27,6 +27,7 @@
 #import "PFPushPrivate.h"
 #import "PFQueryPrivate.h"
 #import "Parse_Private.h"
+#import "PFErrorUtilities.h"
 
 @implementation PFInstallation (Private)
 
@@ -51,9 +52,12 @@ static NSSet *protectedKeys;
     [super removeObjectForKey:PFInstallationKeyDeviceToken];
 }
 
-// Check security on delete.
-- (void)checkDeleteParams {
-    PFConsistencyAssert(NO, @"Installations cannot be deleted.");
+- (BFTask<PFVoid> *)_validateDeleteAsync {
+    return [[super _validateDeleteAsync] continueWithSuccessBlock:^id(BFTask PF_GENERIC(PFVoid) *task) {
+        NSError *error = [PFErrorUtilities errorWithCode:kPFErrorCommandUnavailable
+                                                 message:@"Installation cannot be deleted"];
+        return [BFTask taskWithError:error];
+    }];
 }
 
 // Validates a class name. We override this to only allow the installation class name.

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -798,11 +798,6 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
 #pragma mark - Validations
 ///--------------------------------------
 
-// Validations that are done on delete. For now, there is nothing.
-- (void)checkDeleteParams {
-    return;
-}
-
 // Validations that are done on save. For now, there is nothing.
 - (void)_checkSaveParametersWithCurrentUser:(PFUser *)currentUser {
     return;
@@ -1531,8 +1526,6 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
 }
 
 - (BFTask *)deleteAsync:(BFTask *)toAwait {
-    [self checkDeleteParams];
-
     PFCurrentUserController *controller = [[self class] currentUserController];
     return [[controller getCurrentUserSessionTokenAsync] continueWithBlock:^id(BFTask *task) {
         NSString *sessionToken = task.result;
@@ -1568,11 +1561,7 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
 }
 
 - (PFRESTCommand *)_currentDeleteCommandWithSessionToken:(NSString *)sessionToken {
-    @synchronized (lock) {
-        [self checkDeleteParams];
-        return [PFRESTObjectCommand deleteObjectCommandForObjectState:self._state
-                                                     withSessionToken:sessionToken];
-    }
+    return [PFRESTObjectCommand deleteObjectCommandForObjectState:self._state withSessionToken:sessionToken];
 }
 
 ///--------------------------------------
@@ -1797,9 +1786,24 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
     return [PFObjectState stateWithParseClassName:className objectId:objectId isComplete:complete];
 }
 
-#pragma mark Validation
+///--------------------------------------
+#pragma mark - Validation
+///--------------------------------------
 
-- (BFTask *)_validateSaveEventuallyAsync {
+- (BFTask PF_GENERIC(PFVoid) *)_validateFetchAsync {
+    if (!self._state.objectId) {
+        NSError *error = [PFErrorUtilities errorWithCode:kPFErrorMissingObjectId
+                                                 message:@"Can't fetch an object that hasn't been saved to the server."];
+        return [BFTask taskWithError:error];
+    }
+    return [BFTask taskWithResult:nil];
+}
+
+- (BFTask PF_GENERIC(PFVoid) *)_validateDeleteAsync {
+    return [BFTask taskWithResult:nil];
+}
+
+- (BFTask PF_GENERIC(PFVoid) *)_validateSaveEventuallyAsync {
     return [BFTask taskWithResult:nil];
 }
 
@@ -2012,9 +2016,10 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
 - (BFTask *)deleteEventually {
     return [[[_eventuallyTaskQueue enqueue:^BFTask *(BFTask *toAwait) {
         NSString *sessionToken = [PFUser currentSessionToken];
-        return [toAwait continueAsyncWithBlock:^id(BFTask *task) {
+        return [[toAwait continueAsyncWithBlock:^id(BFTask *task) {
+            return [self _validateDeleteAsync];
+        }] continueWithSuccessBlock:^id(BFTask *task) {
             @synchronized (lock) {
-                [self checkDeleteParams];
                 _deletingEventually += 1;
 
                 PFOfflineStore *store = [Parse _currentManager].offlineStore;
@@ -2472,12 +2477,18 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
         NSArray *uniqueObjects = [PFObjectBatchController uniqueObjectsArrayFromArray:deleteObjects usingFilter:^BOOL(PFObject *object) {
             return (object.objectId != nil);
         }];
-        [uniqueObjects makeObjectsPerformSelector:@selector(checkDeleteParams)]; // TODO: (nlutsenko) Make it async?
-        return [self _enqueue:^BFTask *(BFTask *toAwait) {
-            return [toAwait continueAsyncWithBlock:^id(BFTask *task) {
-                return [[self objectBatchController] deleteObjectsAsync:uniqueObjects withSessionToken:sessionToken];
-            }];
-        } forObjects:uniqueObjects];
+        NSMutableArray PF_GENERIC(BFTask <PFVoid> *) *validationTasks = [NSMutableArray array];
+        for (PFObject *object in uniqueObjects) {
+            [validationTasks addObject:[object _validateDeleteAsync]];
+        }
+        return [[BFTask taskForCompletionOfAllTasks:validationTasks] continueWithSuccessBlock:^id(BFTask *task) {
+            return [self _enqueue:^BFTask *(BFTask *toAwait) {
+                return [toAwait continueAsyncWithBlock:^id(BFTask *task) {
+                    return [[self objectBatchController] deleteObjectsAsync:uniqueObjects
+                                                           withSessionToken:sessionToken];
+                }];
+            } forObjects:uniqueObjects];
+        }];
     }] continueWithSuccessResult:@YES];
 }
 


### PR DESCRIPTION
- More unity with `validateFetchAsync` and `validateDeleteAsync`
- Converted assertions to errors

Contributes to #6