### PR TITLE
Fix address sanatizer being enabled for OSX release scheme.

### DIFF
--- a/Parse.xcodeproj/xcshareddata/xcschemes/Parse-OSX.xcscheme
+++ b/Parse.xcodeproj/xcshareddata/xcschemes/Parse-OSX.xcscheme
@@ -41,7 +41,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      enableAddressSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -74,7 +75,6 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      enableAddressSanitizer = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>


### PR DESCRIPTION
Probably happened during one of our scheme recreations. This makes it very difficult to link against parse for OSX.