### PR TITLE
Add missing backward compatibility to generic type in PFInstallation.

### DIFF
--- a/Parse/PFInstallation.m
+++ b/Parse/PFInstallation.m
@@ -52,7 +52,7 @@ static NSSet *protectedKeys;
     [super removeObjectForKey:PFInstallationKeyDeviceToken];
 }
 
-- (BFTask<PFVoid> *)_validateDeleteAsync {
+- (BFTask PF_GENERIC(PFVoid) *)_validateDeleteAsync {
     return [[super _validateDeleteAsync] continueWithSuccessBlock:^id(BFTask PF_GENERIC(PFVoid) *task) {
         NSError *error = [PFErrorUtilities errorWithCode:kPFErrorCommandUnavailable
                                                  message:@"Installation cannot be deleted"];


### PR DESCRIPTION
Fixes #285 on Xcode 6.4