### PR TITLE
Use NSURLComponents to construct URLs instead of CFURL.

### DIFF
--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
@@ -48,8 +48,9 @@
 ///--------------------------------------
 
 - (NSURLRequest *)dataURLRequestForCommand:(PFRESTCommand *)command {
-    NSURL *url = [PFURLConstructor URLFromBaseURL:[NSURL URLWithString:[PFInternalUtils parseServerURLString]]
-                                             path:[NSString stringWithFormat:@"/1/%@", command.httpPath]];
+    NSURL *url = [PFURLConstructor URLFromAbsoluteString:[PFInternalUtils parseServerURLString]
+                                                    path:[NSString stringWithFormat:@"/1/%@", command.httpPath]
+                                                   query:nil];
     NSDictionary *headers = [self _URLRequestHeadersForCommand:command];
 
     NSString *requestMethod = command.httpMethod;

--- a/Parse/Internal/HTTPRequest/PFURLConstructor.h
+++ b/Parse/Internal/HTTPRequest/PFURLConstructor.h
@@ -9,30 +9,14 @@
 
 #import <Foundation/Foundation.h>
 
-/*!
- This enum is being used to distinguish and encode different types of URL Components.
- Things like Path or Query.
-
- @warning It currently lacks support for scheme, login, password, fragment
- Whenever new enum type is added - make sure you add support for it to relevant methods.
- */
-typedef NS_ENUM(uint8_t, PFURLComponentType)
-{
-    PFURLComponentTypePath,
-    PFURLComponentTypeQuery
-};
+NS_ASSUME_NONNULL_BEGIN
 
 @interface PFURLConstructor : NSObject
 
-+ (NSURL *)URLFromBaseURL:(NSURL *)baseURL
-                     path:(NSString *)path;
-+ (NSURL *)URLFromBaseURL:(NSURL *)baseURL
-          queryParameters:(NSDictionary *)queryParameters;
-+ (NSURL *)URLFromBaseURL:(NSURL *)baseURL
-                     path:(NSString *)path
-          queryParameters:(NSDictionary *)queryParameters;
-
-+ (NSString *)stringByAddingPercentEscapesToString:(NSString *)string
-                               forURLComponentType:(PFURLComponentType)type;
++ (NSURL *)URLFromAbsoluteString:(NSString *)string
+                            path:(nullable NSString *)path
+                           query:(nullable NSString *)query;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/Internal/HTTPRequest/PFURLConstructor.m
+++ b/Parse/Internal/HTTPRequest/PFURLConstructor.m
@@ -17,114 +17,17 @@
 #pragma mark - Basic
 ///--------------------------------------
 
-+ (NSURL *)URLFromBaseURL:(NSURL *)baseURL
-                     path:(NSString *)path {
-    return [self URLFromBaseURL:baseURL path:path queryParameters:nil];
-}
-
-+ (NSURL *)URLFromBaseURL:(NSURL *)baseURL
-          queryParameters:(NSDictionary *)queryParameters {
-    return [self URLFromBaseURL:baseURL path:nil queryParameters:queryParameters];
-}
-
-+ (NSURL *)URLFromBaseURL:(NSURL *)baseURL
-                     path:(NSString *)path
-          queryParameters:(NSDictionary *)queryParameters {
-    if (!baseURL) {
-        return nil;
++ (NSURL *)URLFromAbsoluteString:(NSString *)string
+                            path:(nullable NSString *)path
+                           query:(nullable NSString *)query {
+    NSURLComponents *components = [NSURLComponents componentsWithString:string];
+    if (components.path) {
+        components.path = path;
     }
-
-    NSString *escapedPath = [self stringByAddingPercentEscapesToString:path
-                                                   forURLComponentType:PFURLComponentTypePath];
-    NSString *escapedQuery = [self _URLQueryStringFromQueryParameters:queryParameters];
-
-    NSMutableString *relativeString = (escapedPath ? [escapedPath mutableCopy] : [NSMutableString string]);
-    if (escapedQuery) {
-        [relativeString appendFormat:@"?%@", escapedQuery];
+    if (query) {
+        components.query = query;
     }
-
-    return [NSURL URLWithString:relativeString relativeToURL:baseURL];
-}
-
-///--------------------------------------
-#pragma mark - Escaping
-///--------------------------------------
-
-+ (NSString *)stringByAddingPercentEscapesToString:(NSString *)string
-                               forURLComponentType:(PFURLComponentType)type {
-    PFParameterAssert(type <= PFURLComponentTypeQuery, @"`type` should only be of PFURLComponentType");
-
-    if (!string) {
-        return nil;
-    }
-
-    static NSString *reservedCharacters = @"!*'();:@&=+$,/?%#[]";
-    NSString *escapedString = nil;
-
-    switch (type) {
-        case PFURLComponentTypePath:
-        {
-            static NSString *pathSeparator = @"/";
-
-            NSArray *components = [string componentsSeparatedByString:pathSeparator];
-            if ([components count]) {
-                NSMutableArray *escapedComponents = [NSMutableArray arrayWithCapacity:[components count]];
-                for (NSString *component in components) {
-                    NSString *escapedComponent = [self _stringByAddingPercentEscapesToString:component
-                                                                      withReservedCharacters:reservedCharacters];
-                    [escapedComponents addObject:escapedComponent];
-                }
-                escapedString = [escapedComponents componentsJoinedByString:pathSeparator];
-            } else {
-                escapedString = [self _stringByAddingPercentEscapesToString:string
-                                                     withReservedCharacters:reservedCharacters];
-            }
-        }
-            break;
-        case PFURLComponentTypeQuery:
-        {
-            escapedString = [self _stringByAddingPercentEscapesToString:string
-                                                 withReservedCharacters:reservedCharacters];
-        }
-            break;
-        default:break;
-    }
-
-    return escapedString;
-}
-
-+ (NSString *)_stringByAddingPercentEscapesToString:(NSString *)string
-                                 withReservedCharacters:(NSString *)reservedCharacters {
-    CFStringRef escapedString = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault,
-                                                                        (__bridge CFStringRef)string,
-                                                                        NULL, // Allowed characters
-                                                                        (__bridge CFStringRef)reservedCharacters,
-                                                                        kCFStringEncodingUTF8);
-    return CFBridgingRelease(escapedString);
-}
-
-///--------------------------------------
-#pragma mark - URLQuery
-///--------------------------------------
-
-+ (NSString *)_URLQueryStringFromQueryParameters:(NSDictionary *)parameters {
-    if ([parameters count] == 0) {
-        return nil;
-    }
-
-    NSMutableArray *encodedParameters = [NSMutableArray array];
-    [parameters enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        [encodedParameters addObject:[self _URLQueryParameterWithKey:key value:obj]];
-    }];
-    return [encodedParameters componentsJoinedByString:@"&"];
-
-}
-
-+ (NSString *)_URLQueryParameterWithKey:(NSString *)key value:(NSString *)value {
-    NSString *string = [NSString stringWithFormat:@"%@=%@",
-                        [self stringByAddingPercentEscapesToString:key forURLComponentType:PFURLComponentTypeQuery],
-                        [self stringByAddingPercentEscapesToString:value forURLComponentType:PFURLComponentTypeQuery]];
-    return string;
+    return components.URL;
 }
 
 @end


### PR DESCRIPTION
Since we are not targeting iOS <7.0 and OS X <10.9 - use `NSURLComponents` instead of our own implementation of that.
Fixes #284