### PR TITLE
Update all NSNull generic types to use NSNumber instead.

### DIFF
--- a/Parse/PFCloud.h
+++ b/Parse/PFCloud.h
@@ -54,8 +54,8 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The task, that encapsulates the work being done.
  */
-+ (BFTask *)callFunctionInBackground:(NSString *)function
-                      withParameters:(PF_NULLABLE NSDictionary *)parameters;
++ (BFTask PF_GENERIC(id) *)callFunctionInBackground:(NSString *)function
+                                     withParameters:(PF_NULLABLE NSDictionary *)parameters;
 
 /*!
  @abstract Calls the given cloud function *asynchronously* with the parameters provided

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -824,7 +824,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @returns The task that encapsulates the work being done.
  */
-- (BFTask PF_GENERIC(NSNull *)*)deleteEventually;
+- (BFTask PF_GENERIC(NSNumber *)*)deleteEventually;
 
 ///--------------------------------------
 /// @name Dirtiness

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -335,10 +335,10 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
  and you application's 'Require Revocable Session' setting is turned off on `http://parse.com` app settings.
  After returned `BFTask` completes - <PFSession> class and APIs will be available for use.
 
- @returns An instance of `BFTask` that is completed when
- revocable sessions are enabled and currentUser token is migrated.
+ @returns An instance of `BFTask` that is completed when revocable
+ sessions are enabled and currentUser token is migrated.
  */
-+ (BFTask PF_GENERIC(NSNull *)*)enableRevocableSessionInBackground;
++ (BFTask *)enableRevocableSessionInBackground;
 
 /*!
  @abstract Enables revocable sessions and upgrades the currentUser session token to use revocable session if needed.
@@ -369,7 +369,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
 
  @returns An instance of `BFTask`, that is resolved with `nil` result when logging out completes.
  */
-+ (BFTask PF_GENERIC(NSNull *)*)logOutInBackground;
++ (BFTask *)logOutInBackground;
 
 /*!
  @abstract *Asynchronously* logs out the currently logged in user.


### PR DESCRIPTION
- `deleteEventually` return NSNumber*
- `enableRevocableSessions` and `logOutInBackground` now don't specify a return type since they are not useful at all (the contract there is to yield `nil`)

cc @grantland