### PR TITLE
    Fixed deadlock in -collectDirtyChildren:

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -263,6 +263,7 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
 
     } else if ([node isKindOfClass:[PFObject class]]) {
         PFObject *object = (PFObject *)node;
+        NSDictionary *toSearch = nil;
 
         @synchronized ([object lock]) {
             // Check for cycles of new objects.  Any such cycle means it will be
@@ -288,18 +289,19 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
             // Recurse into this object's children looking for dirty children.
             // We only need to look at the child object's current estimated data,
             // because that's the only data that might need to be saved now.
-            [self collectDirtyChildren:object->_estimatedData.dictionaryRepresentation
-                              children:dirtyChildren
-                                 files:dirtyFiles
-                                  seen:seen
-                               seenNew:seenNew
-                           currentUser:currentUser];
-
-            if ([object isDirty:NO]) {
-                [dirtyChildren addObject:object];
-            }
+            toSearch = [object->_estimatedData.dictionaryRepresentation copy];
         }
 
+        [self collectDirtyChildren:toSearch
+                          children:dirtyChildren
+                             files:dirtyFiles
+                              seen:seen
+                           seenNew:seenNew
+                       currentUser:currentUser];
+
+        if ([object isDirty:NO]) {
+            [dirtyChildren addObject:object];
+        }
     } else if ([node isKindOfClass:[PFFile class]]) {
         PFFile *file = (PFFile *)node;
         if (!file.url) {


### PR DESCRIPTION
By no longer holding a lock while recursing, we allow other threads who may be waiting on the current object to progress before iterating to children of the object, solving some of the deadlocks that we've seen in issues #11, #61, and #299.

This does not necessarily fix the above issues, as we probably still have similar deadlocks elsewhere in the codebase.

This is based on the mutable containers branch until the time comes to land this, as we want some of our users to be able to test this, and mutable containers also contains deadlocks.

cc @grantland