### PR TITLE
Fix copy/paste error in retrieving userController.

### DIFF
--- a/Parse/Internal/PFCoreManager.m
+++ b/Parse/Internal/PFCoreManager.m
@@ -421,7 +421,7 @@
 - (PFUserController *)userController {
     __block PFUserController *controller = nil;
     dispatch_sync(_controllerAccessQueue, ^{
-        if (!_installationController) {
+        if (!_userController) {
             _userController = [PFUserController controllerWithCommonDataSource:self.dataSource
                                                                 coreDataSource:self];
         }


### PR DESCRIPTION
I run into an issue where then `becomeInBackground` function returned neither a user object nor an error after a login/logout cycle. I tracked the error down to the `PFUserController` returning `nil` for the `userController` because of what seems to be a copy/paste error when checking for an existing controller.