### PR TITLE
Fix initialization of Facebook/Twitter Utils blocking the main thread.

### DIFF
--- a/Parse/Internal/PFCoreManager.m
+++ b/Parse/Internal/PFCoreManager.m
@@ -305,7 +305,7 @@
     __block PFUserAuthenticationController *controller = nil;
     dispatch_sync(_controllerAccessQueue, ^{
         if (!_userAuthenticationController) {
-            _userAuthenticationController = [[PFUserAuthenticationController alloc] init];
+            _userAuthenticationController = [PFUserAuthenticationController controllerWithDataSource:self];
         }
         controller = _userAuthenticationController;
     });

--- a/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
+++ b/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
@@ -12,12 +12,26 @@
 #import <Parse/PFConstants.h>
 #import <Parse/PFUserAuthenticationDelegate.h>
 
+#import "PFCoreDataProvider.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFUser;
 
 @interface PFUserAuthenticationController : NSObject
+
+@property (nonatomic, weak, readonly) id<PFCurrentUserControllerProvider> dataSource;
+
+///--------------------------------------
+/// @name Init
+///--------------------------------------
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)initWithDataSource:(id<PFCurrentUserControllerProvider>)dataSource;
++ (instancetype)controllerWithDataSource:(id<PFCurrentUserControllerProvider>)dataSource;
 
 ///--------------------------------------
 /// @name Authentication Providers


### PR DESCRIPTION
This will make load of currentUser asynchronous, as well as won't create anonymous user if enabled, and will properly restore auth from a background thread.
Fixes #302