### PR TITLE
Update PFApplication to compile for watchOS.

### DIFF
--- a/Parse/Internal/PFApplication.h
+++ b/Parse/Internal/PFApplication.h
@@ -9,9 +9,13 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IPHONE
+#import <Parse/PFConstants.h>
+
+#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
-#else
+#elif TARGET_OS_WATCH
+@class UIApplication;
+#elif TARGET_OS_MAC
 #import <AppKit/AppKit.h>
 @compatibility_alias UIApplication NSApplication;
 #endif

--- a/Parse/Internal/PFApplication.m
+++ b/Parse/Internal/PFApplication.m
@@ -9,9 +9,9 @@
 
 #import "PFApplication.h"
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
-#else
+#elif !TARGET_OS_WATCH && TARGET_OS_MAC
 #import <AppKit/AppKit.h>
 #endif
 
@@ -47,9 +47,11 @@
 }
 
 - (NSInteger)iconBadgeNumber {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_WATCH
+    return 0;
+#elif TARGET_OS_IOS
     return self.systemApplication.applicationIconBadgeNumber;
-#else
+#elif TARGET_OS_MAC
     // Make sure not to use `NSApp` here, because it doesn't work sometimes,
     // `NSApplication +sharedApplication` does though.
     NSString *badgeLabel = [[NSApplication sharedApplication] dockTile].badgeLabel;
@@ -71,17 +73,21 @@
 
 - (void)setIconBadgeNumber:(NSInteger)iconBadgeNumber {
     if (self.iconBadgeNumber != iconBadgeNumber) {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
         self.systemApplication.applicationIconBadgeNumber = iconBadgeNumber;
-#else
+#elif !TARGET_OS_WATCH
         [[NSApplication sharedApplication] dockTile].badgeLabel = [@(iconBadgeNumber) stringValue];
 #endif
     }
 }
 
 - (UIApplication *)systemApplication {
+#if TARGET_OS_WATCH
+    return nil;
+#else
     // Workaround to make `sharedApplication` still be called even if compiling for App Extensions or WatchKit apps.
     return [UIApplication performSelector:@selector(sharedApplication)];
+#endif
 }
 
 @end


### PR DESCRIPTION
No-op in most places, as well as return `nil` for systemApplication.
Contributes to #179.