### PR TITLE
Add ObjC generics to collections/queries in PFPush public header.

### DIFF
--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -12,8 +12,9 @@
 #import <Bolts/BFTask.h>
 
 #import <Parse/PFConstants.h>
+#import <Parse/PFInstallation.h>
 
-@class PFQuery;
+@class PFQuery PF_GENERIC(PFGenericObject : PFObject *);
 
 PF_ASSUME_NONNULL_BEGIN
 
@@ -49,7 +50,7 @@ PF_ASSUME_NONNULL_BEGIN
  @param channels The array of channels to set for this push.
  Each channel name must start with a letter and contain only letters, numbers, dashes, and underscores.
  */
-- (void)setChannels:(PF_NULLABLE NSArray *)channels;
+- (void)setChannels:(PF_NULLABLE NSArray PF_GENERIC(NSString *) *)channels;
 
 /*!
  @abstract Sets an installation query to which this push notification will be sent.
@@ -58,7 +59,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @param query The installation query to set for this push.
  */
-- (void)setQuery:(PF_NULLABLE PFQuery *)query;
+- (void)setQuery:(PF_NULLABLE PFQuery PF_GENERIC(PFInstallation *) *)query;
 
 /*!
  @abstract Sets an alert message for this push notification.
@@ -199,7 +200,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns whether the send succeeded.
  */
-+ (BOOL)sendPushMessageToQuery:(PFQuery *)query
++ (BOOL)sendPushMessageToQuery:(PFQuery PF_GENERIC(PFInstallation *) *)query
                    withMessage:(NSString *)message
                          error:(NSError **)error;
 
@@ -211,7 +212,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The task, that encapsulates the work being done.
  */
-+ (BFTask PF_GENERIC(NSNumber *)*)sendPushMessageToQueryInBackground:(PFQuery *)query
++ (BFTask PF_GENERIC(NSNumber *)*)sendPushMessageToQueryInBackground:(PFQuery PF_GENERIC(PFInstallation *) *)query
                                                          withMessage:(NSString *)message;
 
 /*!
@@ -223,7 +224,7 @@ PF_ASSUME_NONNULL_BEGIN
  @param block The block to execute.
  It should have the following argument signature: `^(BOOL succeeded, NSError *error)`
  */
-+ (void)sendPushMessageToQueryInBackground:(PFQuery *)query
++ (void)sendPushMessageToQueryInBackground:(PFQuery PF_GENERIC(PFInstallation *) *)query
                                withMessage:(NSString *)message
                                      block:(PF_NULLABLE PFBooleanResultBlock)block;
 
@@ -337,7 +338,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns Returns whether the send succeeded.
  */
-+ (BOOL)sendPushDataToQuery:(PFQuery *)query
++ (BOOL)sendPushDataToQuery:(PFQuery PF_GENERIC(PFInstallation *) *)query
                    withData:(NSDictionary *)data
                       error:(NSError **)error;
 
@@ -352,7 +353,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @returns The task, that encapsulates the work being done.
  */
-+ (BFTask PF_GENERIC(NSNumber *)*)sendPushDataToQueryInBackground:(PFQuery *)query
++ (BFTask PF_GENERIC(NSNumber *)*)sendPushDataToQueryInBackground:(PFQuery PF_GENERIC(PFInstallation *) *)query
                                                          withData:(NSDictionary *)data;
 
 /*!
@@ -366,7 +367,7 @@ PF_ASSUME_NONNULL_BEGIN
  @param block The block to execute.
  It should have the following argument signature: `^(BOOL succeeded, NSError *error)`.
  */
-+ (void)sendPushDataToQueryInBackground:(PFQuery *)query
++ (void)sendPushDataToQueryInBackground:(PFQuery PF_GENERIC(PFInstallation *) *)query
                                withData:(NSDictionary *)data
                                   block:(PF_NULLABLE PFBooleanResultBlock)block;
 

--- a/Parse/PFPush.m
+++ b/Parse/PFPush.m
@@ -34,7 +34,7 @@ static Class _pushInternalUtilClass = nil;
 @interface PFPush ()
 
 @property (nonatomic, strong) PFMutablePushState *state;
-@property (nonatomic, strong) PFQuery *query;
+@property (nonatomic, strong) PFQuery PF_GENERIC(PFInstallation *) *query;
 
 @end
 


### PR DESCRIPTION
Push supports only Installation queries, so make sure we specify that in header.
Also added generic type to `channels`, since that one can be only strings.