### PR TITLE
Fixed currentUser not restoring authentication on load from disk.

### DIFF
--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
@@ -125,7 +125,6 @@
                 user.isLazy = YES;
                 [user _setDirty:YES];
             }
-            [user setIsCurrentUser:YES];
             return user;
         }] continueWithBlock:^id(BFTask *task) {
             dispatch_barrier_sync(_dataQueue, ^{
@@ -249,6 +248,7 @@
     }
     return [task continueWithSuccessBlock:^id(BFTask *task) {
         PFUser *user = task.result;
+        [user setIsCurrentUser:YES];
         return [[self _loadSensitiveUserDataAsync:user
                          fromKeychainItemWithName:PFUserCurrentUserKeychainItemName] continueWithSuccessResult:user];
     }];


### PR DESCRIPTION
We have few checks on auth restoration, which happens on loading the sensitive user data from keychain.
These checks rely on the fact that the receiver (instance of PFUser) responds `YES` to `isCurrentUser`.
Basically - move the `isCurrentUser` change to one step closer. Doesn't change the flow, but fixes a potential bug with third party authentication.