### PR TITLE
Fix warnings in AnalyticsTests when building with Xcode 7.

### DIFF
--- a/Tests/Unit/AnalyticsUnitTests.m
+++ b/Tests/Unit/AnalyticsUnitTests.m
@@ -101,6 +101,8 @@
 }
 
 - (void)testTrackEventDimensionsValidation {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-literal-conversion"
     PFAssertThrowsInvalidArgumentException([PFAnalytics trackEvent:@"a" dimensions:@{ @2 : @"yolo" }]);
     PFAssertThrowsInvalidArgumentException([PFAnalytics trackEvent:@"a" dimensions:@{ @"yolo" : @2 }]);
     PFAssertThrowsInvalidArgumentException([PFAnalytics trackEventInBackground:@"a"
@@ -109,6 +111,7 @@
     PFAssertThrowsInvalidArgumentException([PFAnalytics trackEventInBackground:@"a"
                                                                     dimensions:@{ @2 : @"yolo" }
                                                                          block:nil]);
+#pragma clang diagnostic pop
 }
 
 - (void)testTrackAppOpenedWithLaunchOptionsViaTask {


### PR DESCRIPTION
Simply ignore the warnings, since these are checking that we have an extra validation logic for incompatible types.