### PR TITLE
Use clang modules for imports of all external modules in tests.

### DIFF
--- a/Tests/Unit/AlertViewTests.m
+++ b/Tests/Unit/AlertViewTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 #import <OCMock/OCMock.h>
 

--- a/Tests/Unit/AnalyticsUnitTests.m
+++ b/Tests/Unit/AnalyticsUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFAnalyticsController.h"
 #import "PFUnitTestCase.h"

--- a/Tests/Unit/AnonymousAuthenticationProviderTests.m
+++ b/Tests/Unit/AnonymousAuthenticationProviderTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFAnonymousAuthenticationProvider.h"
 #import "PFTestCase.h"

--- a/Tests/Unit/BaseStateTests.m
+++ b/Tests/Unit/BaseStateTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <libkern/OSAtomic.h>
+@import Darwin.libkern.OSAtomic;
 
 #import "PFBaseState.h"
 #import "PFTestCase.h"

--- a/Tests/Unit/CloudCodeControllerTests.m
+++ b/Tests/Unit/CloudCodeControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "OCMock+Parse.h"
 #import "PFCloudCodeController.h"

--- a/Tests/Unit/ConfigControllerTests.m
+++ b/Tests/Unit/ConfigControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "OCMock+Parse.h"
 #import "PFCommandResult.h"

--- a/Tests/Unit/ConfigUnitTests.m
+++ b/Tests/Unit/ConfigUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFConfigController.h"
 #import "PFConfig_Private.h"

--- a/Tests/Unit/CurrentConfigControllerTests.m
+++ b/Tests/Unit/CurrentConfigControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFCommandResult.h"
 #import "PFConfig.h"

--- a/Tests/Unit/DefaultACLControllerTests.m
+++ b/Tests/Unit/DefaultACLControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFACLPrivate.h"
 #import "PFCoreManager.h"

--- a/Tests/Unit/ExtensionDataSharingTests.m
+++ b/Tests/Unit/ExtensionDataSharingTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFExtensionDataSharingTestHelper.h"
 #import "PFFileManager.h"

--- a/Tests/Unit/FileControllerTests.m
+++ b/Tests/Unit/FileControllerTests.m
@@ -9,9 +9,9 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFCancellationTokenSource.h>
-#import <Bolts/BFTask.h>
-#import <Bolts/BFTaskCompletionSource.h>
+@import Bolts.BFCancellationTokenSource;
+@import Bolts.BFTask;
+@import Bolts.BFTaskCompletionSource;
 
 #import "PFCommandResult.h"
 #import "PFCommandRunning.h"

--- a/Tests/Unit/FileUnitTests.m
+++ b/Tests/Unit/FileUnitTests.m
@@ -9,10 +9,9 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFCoreManager.h"
-#import "PFFile.h"
 #import "PFFileController.h"
 #import "PFFileManager.h"
 #import "PFFileStagingController.h"

--- a/Tests/Unit/GeoPointUnitTests.m
+++ b/Tests/Unit/GeoPointUnitTests.m
@@ -7,12 +7,11 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <CoreLocation/CoreLocation.h>
+@import CoreLocation.CLLocation;
 
 #import "PFGeoPoint.h"
 #import "PFGeoPointPrivate.h"
 #import "PFTestCase.h"
-
 
 @interface GeoPointUnitTests : PFTestCase
 

--- a/Tests/Unit/LocationManagerMobileTests.m
+++ b/Tests/Unit/LocationManagerMobileTests.m
@@ -7,8 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <CoreLocation/CoreLocation.h>
-#import <UIKit/UIKit.h>
+@import CoreLocation;
+@import UIKit;
 
 #import <OCMock/OCMock.h>
 

--- a/Tests/Unit/LocationManagerTests.m
+++ b/Tests/Unit/LocationManagerTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <CoreLocation/CoreLocation.h>
+@import CoreLocation;
 
 #import <OCMock/OCMock.h>
 

--- a/Tests/Unit/ObjectFilePersistenceControllerTests.m
+++ b/Tests/Unit/ObjectFilePersistenceControllerTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFFileManager.h"
 #import "PFObject.h"

--- a/Tests/Unit/ObjectOfflineTests.m
+++ b/Tests/Unit/ObjectOfflineTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFObject.h"
 #import "PFOfflineStore.h"

--- a/Tests/Unit/OfflineQueryControllerTests.m
+++ b/Tests/Unit/OfflineQueryControllerTests.m
@@ -9,8 +9,8 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFCancellationTokenSource.h>
-#import <Bolts/BFTask.h>
+@import Bolts.BFCancellationTokenSource;
+@import Bolts.BFTask;
 
 #import "OCMock+Parse.h"
 #import "PFCommandResult.h"

--- a/Tests/Unit/PurchaseControllerTests.m
+++ b/Tests/Unit/PurchaseControllerTests.m
@@ -7,12 +7,12 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <StoreKit/StoreKit.h>
+@import StoreKit;
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFExecutor.h>
-#import <Bolts/BFTask.h>
+@import Bolts.BFExecutor;
+@import Bolts.BFTask;
 
 #import "PFCommandResult.h"
 #import "PFCommandRunning.h"

--- a/Tests/Unit/PurchaseUnitTests.m
+++ b/Tests/Unit/PurchaseUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFCommandRunning.h"
 #import "PFFileManager.h"

--- a/Tests/Unit/PushChannelsControllerTests.m
+++ b/Tests/Unit/PushChannelsControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFCurrentInstallationController.h"
 #import "PFInstallation.h"

--- a/Tests/Unit/PushControllerTests.m
+++ b/Tests/Unit/PushControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFCommandResult.h"
 #import "PFCommandRunning.h"

--- a/Tests/Unit/PushUnitTests.m
+++ b/Tests/Unit/PushUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.H>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFCoreManager.h"
 #import "PFCurrentInstallationController.h"

--- a/Tests/Unit/QueryCachedControllerTests.m
+++ b/Tests/Unit/QueryCachedControllerTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFCachedQueryController.h"
 #import "PFCommandResult.h"

--- a/Tests/Unit/QueryControllerUnitTests.m
+++ b/Tests/Unit/QueryControllerUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFCancellationTokenSource.h>
+@import Bolts.BFCancellationTokenSource;
 
 #import "BFTask+Private.h"
 #import "PFCommandResult.h"

--- a/Tests/Unit/QueryUnitTests.m
+++ b/Tests/Unit/QueryUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFCoreManager.h"
 #import "PFMacros.h"

--- a/Tests/Unit/RelationUnitTests.m
+++ b/Tests/Unit/RelationUnitTests.m
@@ -9,7 +9,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import <libkern/OSAtomic.h>
+@import Darwin.libkern.OSAtomic;
 
 #import "PFDecoder.h"
 #import "PFQueryPrivate.h"

--- a/Tests/Unit/RoleUnitTests.m
+++ b/Tests/Unit/RoleUnitTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "PFMockURLProtocol.h"
 #import "PFRelation.h"

--- a/Tests/Unit/SQLiteDatabaseTest.m
+++ b/Tests/Unit/SQLiteDatabaseTest.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Bolts/Bolts.h>
+@import Bolts.BFTask;
 
 #import "BFTask+Private.h"
 #import "PFFileManager.h"

--- a/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -9,8 +9,8 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFCancellationTokenSource.h>
-#import <Bolts/BFTask.h>
+@import Bolts.BFCancellationTokenSource;
+@import Bolts.BFTask;
 
 #import "PFCommandResult.h"
 #import "PFCommandRunningConstants.h"

--- a/Tests/Unit/URLSessionDataTaskDelegateTests.m
+++ b/Tests/Unit/URLSessionDataTaskDelegateTests.m
@@ -9,8 +9,8 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFCancellationTokenSource.h>
-#import <Bolts/BFTask.h>
+@import Bolts.BFCancellationTokenSource;
+@import Bolts.BFTask;
 
 #import "PFCommandResult.h"
 #import "PFConstants.h"

--- a/Tests/Unit/URLSessionTests.m
+++ b/Tests/Unit/URLSessionTests.m
@@ -9,8 +9,8 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFCancellationTokenSource.h>
-#import <Bolts/BFTask.h>
+@import Bolts.BFCancellationTokenSource;
+@import Bolts.BFTask;
 
 #import "PFCommandResult.h"
 #import "PFMacros.h"

--- a/Tests/Unit/URLSessionUploadTaskDelegateTests.m
+++ b/Tests/Unit/URLSessionUploadTaskDelegateTests.m
@@ -9,8 +9,8 @@
 
 #import <OCMock/OCMock.h>
 
-#import <Bolts/BFCancellationTokenSource.h>
-#import <Bolts/BFTask.h>
+@import Bolts.BFCancellationTokenSource;
+@import Bolts.BFTask;
 
 #import "PFCommandResult.h"
 #import "PFTestCase.h"

--- a/Tests/Unit/UserControllerTests.m
+++ b/Tests/Unit/UserControllerTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Bolts/BFTask.h>
+@import Bolts.BFTask;
 
 #import "OCMock+Parse.h"
 #import "PFCommandResult.h"


### PR DESCRIPTION
This doesn't yet import Parse in a modular way - but we'll get there.
Depends on #356 