### PR TITLE
Fix late initialization of NetworkActivityIndicatorManager.

### DIFF
--- a/Parse/Internal/PFInternalUtils.m
+++ b/Parse/Internal/PFInternalUtils.m
@@ -35,7 +35,6 @@
 #import "PFHash.h"
 
 #if PARSE_IOS_ONLY
-#import "PFNetworkActivityIndicatorManager.h"
 #import "PFProduct.h"
 #endif
 
@@ -46,10 +45,6 @@ static NSString *parseServer_;
 + (void)initialize {
     if (self == [PFInternalUtils class]) {
         [self setParseServer:kPFParseServer];
-
-#if PARSE_IOS_ONLY
-        [PFNetworkActivityIndicatorManager sharedManager].enabled = YES;
-#endif
     }
 }
 

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -83,6 +83,10 @@ static NSString *containingApplicationBundleIdentifier_;
 #endif
 #endif
 
+#if TARGET_OS_IOS
+    [PFNetworkActivityIndicatorManager sharedManager].enabled = YES;
+#endif
+
     [currentParseManager_ preloadDiskObjectsToMemoryAsync];
 
     [[self parseModulesCollection] parseDidInitializeWithApplicationId:applicationId clientKey:clientKey];


### PR DESCRIPTION
If `PFInternalUtils` is initialized after the first call to `PFNetworkActivityIndicatorManager.sharedManager()` - potentially we are going to force-enable the manager once again.
This fixes it by moving enabling of the indicator straight after Parse is initialized.
Fixes #366