### PR TITLE
Update few imports to unbreak watchOS target.

### DIFF
--- a/Parse/Internal/PFInternalUtils.h
+++ b/Parse/Internal/PFInternalUtils.h
@@ -10,7 +10,6 @@
 #import <Foundation/Foundation.h>
 
 #import <Parse/PFConstants.h>
-#import "PFPushPrivate.h"
 
 #import "PFEncoder.h"
 

--- a/Parse/Internal/PFInternalUtils.m
+++ b/Parse/Internal/PFInternalUtils.m
@@ -34,7 +34,7 @@
 #import "PFMultiProcessFileLockController.h"
 #import "PFHash.h"
 
-#if PARSE_IOS_ONLY
+#if TARGET_OS_IOS
 #import "PFProduct.h"
 #endif
 

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -18,7 +18,6 @@
 #import "PFConfig.h"
 #import "PFCoreManager.h"
 #import "PFFileManager.h"
-#import "PFInstallation.h"
 #import "PFInstallationIdentifierStore.h"
 #import "PFKeyValueCache.h"
 #import "PFKeychainStore.h"
@@ -28,6 +27,10 @@
 #import "PFPushManager.h"
 #import "PFUser.h"
 #import "PFURLSessionCommandRunner.h"
+
+#if !TARGET_OS_WATCH
+#import "PFInstallation.h"
+#endif
 
 #if TARGET_OS_IOS
 #import "PFPurchaseController.h"

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -26,9 +26,14 @@
 #import <Parse/PFSubclassing.h>
 #import <Parse/PFUser.h>
 #import <Parse/PFUserAuthenticationDelegate.h>
-#import <Parse/PFInstallation.h>
 #import <Parse/PFNullability.h>
+
+#if !TARGET_OS_WATCH
+
+#import <Parse/PFInstallation.h>
 #import <Parse/PFPush.h>
+
+#endif
 
 #if TARGET_OS_IOS
 

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -23,11 +23,13 @@
 #import "PFApplication.h"
 #import "PFKeychainStore.h"
 #import "PFLogging.h"
-#import "PFInstallationPrivate.h"
 #import "PFObjectSubclassingController.h"
 
-#if PARSE_IOS_ONLY
+#if !TARGET_OS_WATCH
+#import "PFInstallationPrivate.h"
+#if TARGET_OS_IOS
 #import "PFProduct+Private.h"
+#endif
 #endif
 
 #import "PFCategoryLoader.h"


### PR DESCRIPTION
No PFInstallation, PFProduct, PFPush on watchOS.
Contributes to #179