### PR TITLE
Add generics to all instances of class forwarded PFQuery.

### DIFF
--- a/Parse/PFObject+Subclass.h
+++ b/Parse/PFObject+Subclass.h
@@ -12,9 +12,9 @@
 #import <Parse/PFNullability.h>
 #import <Parse/PFObject.h>
 
-PF_ASSUME_NONNULL_BEGIN
+@class PFQuery PF_GENERIC(PFGenericObject : PFObject *);
 
-@class PFQuery;
+PF_ASSUME_NONNULL_BEGIN
 
 /*!
  ### Subclassing Notes

--- a/Parse/PFSubclassing.h
+++ b/Parse/PFSubclassing.h
@@ -11,7 +11,7 @@
 
 #import <Parse/PFNullability.h>
 
-@class PFQuery;
+@class PFQuery PF_GENERIC(PFGenericObject : PFObject *);
 
 PF_ASSUME_NONNULL_BEGIN
 

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -20,7 +20,7 @@ PF_ASSUME_NONNULL_BEGIN
 typedef void(^PFUserSessionUpgradeResultBlock)(NSError *PF_NULLABLE_S error);
 typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
 
-@class PFQuery;
+@class PFQuery PF_GENERIC(PFGenericObject : PFObject *);
 @protocol PFUserAuthenticationDelegate;
 
 /*!


### PR DESCRIPTION
In case someone imports this without a query - this should have generics.