### PR TITLE
Improve PFConfig loading from disc performance by using JSON stream from file.

### DIFF
--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.m
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.m
@@ -61,12 +61,8 @@ static NSString *const PFConfigCurrentConfigFileName_ = @"config";
 - (BFTask *)getCurrentConfigAsync {
     return [BFTask taskFromExecutor:_dataExecutor withBlock:^id{
         if (!_currentConfig) {
-            NSError *error = nil;
-            NSData *jsonData = [NSData dataWithContentsOfFile:self.configFilePath
-                                                      options:NSDataReadingMappedIfSafe
-                                                        error:&error];
-            if (error == nil && [jsonData length] != 0) {
-                NSDictionary *dictionary = [PFJSONSerialization JSONObjectFromData:jsonData];
+            NSDictionary *dictionary = [PFJSONSerialization JSONObjectFromFileAtPath:self.configFilePath];
+            if (dictionary) {
                 NSDictionary *decodedDictionary = [[PFDecoder objectDecoder] decodeObject:dictionary];
                 _currentConfig = [[PFConfig alloc] initWithFetchedConfig:decodedDictionary];
             } else {

--- a/Parse/Internal/PFJSONSerialization.h
+++ b/Parse/Internal/PFJSONSerialization.h
@@ -9,6 +9,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PFJSONSerialization : NSObject
 
 /*!
@@ -21,7 +23,7 @@
 
  @returns NSData of JSON representing the passed in object.
  */
-+ (NSData *)dataFromJSONObject:(id)object;
++ (nullable NSData *)dataFromJSONObject:(id)object;
 
 /*!
  The object passed in must be one of:
@@ -33,18 +35,31 @@
 
  @returns NSString of JSON representing the passed in object.
  */
-+ (NSString *)stringFromJSONObject:(id)object;
++ (nullable NSString *)stringFromJSONObject:(id)object;
 
 /*!
  Takes a JSON string and returns the NSDictionaries and NSArrays in it.
  You should still call decodeObject if you want Parse types.
  */
-+ (id)JSONObjectFromData:(NSData *)data;
++ (nullable id)JSONObjectFromData:(NSData *)data;
 
 /*!
  Takes a JSON string and returns the NSDictionaries and NSArrays in it.
  You should still call decodeObject if you want Parse types.
  */
-+ (id)JSONObjectFromString:(NSString *)string;
++ (nullable id)JSONObjectFromString:(NSString *)string;
+
+/*!
+ @abstract Takes a file path to json file and returns the NSDictionaries and NSArrays in it.
+
+ @description You should still call decodeObject if you want Parse types.
+
+ @param filePath File path to a file.
+
+ @return Decoded object.
+ */
++ (nullable id)JSONObjectFromFileAtPath:(NSString *)filePath;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/Internal/PFJSONSerialization.m
+++ b/Parse/Internal/PFJSONSerialization.m
@@ -43,4 +43,23 @@
     return [self JSONObjectFromData:[string dataUsingEncoding:NSUTF8StringEncoding]];
 }
 
++ (id)JSONObjectFromFileAtPath:(NSString *)filePath {
+    NSInputStream *stream = [NSInputStream inputStreamWithFileAtPath:filePath];
+    if (!stream) {
+        return nil;
+    }
+
+    [stream open];
+
+    NSError *error = nil;
+    id object = [NSJSONSerialization JSONObjectWithStream:stream options:0 error:&error];
+    if (!object || error) {
+        PFLogError(PFLoggingTagCommon, @"JSON deserialization failed with error: %@", error.description);
+    }
+
+    [stream close];
+
+    return object;
+}
+
 @end


### PR DESCRIPTION
Don't load into `NSData`, then decode, but rather decode from stream directly.
Should improve performance of loading `PFConfig` from disc.