### PR TITLE
Mark extension-specific APIs as unavailable for watchOS.

### DIFF
--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -103,7 +103,7 @@ PF_ASSUME_NONNULL_BEGIN
 
  @param groupIdentifier Application Group Identifier to share data with.
  */
-+ (void)enableDataSharingWithApplicationGroupIdentifier:(NSString *)groupIdentifier PF_EXTENSION_UNAVAILABLE("Use `enableDataSharingWithApplicationGroupIdentifier:containingApplication:`.");
++ (void)enableDataSharingWithApplicationGroupIdentifier:(NSString *)groupIdentifier PF_EXTENSION_UNAVAILABLE("Use `enableDataSharingWithApplicationGroupIdentifier:containingApplication:`.") PF_WATCH_UNAVAILABLE;
 
 /*!
  @abstract Enables data sharing with an application group identifier.
@@ -118,21 +118,21 @@ PF_ASSUME_NONNULL_BEGIN
  @param bundleIdentifier Bundle identifier of the containing application.
  */
 + (void)enableDataSharingWithApplicationGroupIdentifier:(NSString *)groupIdentifier
-                                  containingApplication:(NSString *)bundleIdentifier;
+                                  containingApplication:(NSString *)bundleIdentifier PF_WATCH_UNAVAILABLE;
 
 /*!
  @abstract Application Group Identifier for Data Sharing
 
  @returns `NSString` value if data sharing is enabled, otherwise `nil`.
  */
-+ (NSString *)applicationGroupIdentifierForDataSharing;
++ (NSString *)applicationGroupIdentifierForDataSharing PF_WATCH_UNAVAILABLE;
 
 /*!
  @abstract Containing application bundle identifier.
 
  @returns `NSString` value if data sharing is enabled, otherwise `nil`.
  */
-+ (NSString *)containingApplicationBundleIdentifierForDataSharing;
++ (NSString *)containingApplicationBundleIdentifierForDataSharing PF_WATCH_UNAVAILABLE;
 
 #if PARSE_IOS_ONLY
 


### PR DESCRIPTION
This APIs don't quite make sense on watchOS, since there is no ability to use main app + extensions on watchOS.
Contributes to #179.