### PR TITLE
Fix URL construction on iOS 7.

### DIFF
--- a/Parse/Internal/HTTPRequest/PFURLConstructor.m
+++ b/Parse/Internal/HTTPRequest/PFURLConstructor.m
@@ -21,7 +21,7 @@
                             path:(nullable NSString *)path
                            query:(nullable NSString *)query {
     NSURLComponents *components = [NSURLComponents componentsWithString:string];
-    if (components.path) {
+    if (path) {
         components.path = path;
     }
     if (query) {


### PR DESCRIPTION
This looks like a typo, and we didn't catch it in testing, since iOS 8/9 reports empty string instead of `nil`, whilst iOS 7 - reports `nil`.
Fixes #388 