### PR TITLE
Fix default content type for JSON URL Requests.

### DIFF
--- a/Parse/Internal/HTTPRequest/PFHTTPURLRequestConstructor.m
+++ b/Parse/Internal/HTTPRequest/PFHTTPURLRequestConstructor.m
@@ -13,7 +13,7 @@
 #import "PFHTTPRequest.h"
 #import "PFURLConstructor.h"
 
-static NSString *const PFHTTPURLRequestContentTypeJSON = @"application/json; charset=utf8";
+static NSString *const PFHTTPURLRequestContentTypeJSON = @"application/json; charset=utf-8";
 
 @implementation PFHTTPURLRequestConstructor
 

--- a/Tests/Unit/CommandURLRequestConstructorTests.m
+++ b/Tests/Unit/CommandURLRequestConstructorTests.m
@@ -62,7 +62,7 @@
     XCTAssertTrue([[request.URL absoluteString] containsString:@"/1/yolo"]);
     XCTAssertEqualObjects(request.allHTTPHeaderFields, (@{ PFCommandHeaderNameInstallationId : @"installationId",
                                                            PFCommandHeaderNameSessionToken : @"yarr",
-                                                           PFHTTPRequestHeaderNameContentType : @"application/json; charset=utf8",
+                                                           PFHTTPRequestHeaderNameContentType : @"application/json; charset=utf-8",
                                                            @"CustomHeader" : @"CustomValue" }));
     XCTAssertEqualObjects(request.HTTPMethod, @"POST");
     XCTAssertNotNil(request.HTTPBody);


### PR DESCRIPTION
THere is no `utf8` charset, only `utf-8`. Thanks to @gfosco for catching this.