### PR TITLE
Safeguard unavailable imports when building for watchOS.

### DIFF
--- a/Parse/Internal/PFCoreManager.m
+++ b/Parse/Internal/PFCoreManager.m
@@ -13,10 +13,8 @@
 #import "PFCachedQueryController.h"
 #import "PFCloudCodeController.h"
 #import "PFConfigController.h"
-#import "PFCurrentInstallationController.h"
 #import "PFCurrentUserController.h"
 #import "PFFileController.h"
-#import "PFInstallationController.h"
 #import "PFLocationManager.h"
 #import "PFMacros.h"
 #import "PFObjectBatchController.h"
@@ -30,6 +28,11 @@
 #import "PFSessionController.h"
 #import "PFUserAuthenticationController.h"
 #import "PFUserController.h"
+
+#if !TARGET_OS_WATCH
+#import "PFCurrentInstallationController.h"
+#import "PFInstallationController.h"
+#endif
 
 @interface PFCoreManager () {
     dispatch_queue_t _locationManagerAccessQueue;

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -24,11 +24,11 @@
 #import "PFLogging.h"
 #import "PFMultiProcessFileLockController.h"
 #import "PFPinningEventuallyQueue.h"
-#import "PFPushManager.h"
 #import "PFUser.h"
 #import "PFURLSessionCommandRunner.h"
 
 #if !TARGET_OS_WATCH
+#import "PFPushManager.h"
 #import "PFInstallation.h"
 #endif
 


### PR DESCRIPTION
Contributes to #179 