### PR TITLE
Fix a potential deadlock that could occur when encoding for REST.

### DIFF
--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -220,7 +220,8 @@
 - (NSDictionary *)RESTDictionaryWithObjectEncoder:(PFEncoder *)objectEncoder
                                 operationSetUUIDs:(NSArray **)operationSetUUIDs
                                             state:(PFObjectState *)state
-                                operationSetQueue:(NSArray *)operationSetQueue;
+                                operationSetQueue:(NSArray *)queue
+                               deletingEventually:(BOOL)isDeletingEventually;
 
 - (void)mergeFromRESTDictionary:(NSDictionary *)object
                     withDecoder:(PFDecoder *)decoder;

--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -650,7 +650,8 @@ static BOOL revocableSessionEnabled_;
 - (NSDictionary *)RESTDictionaryWithObjectEncoder:(PFEncoder *)objectEncoder
                                 operationSetUUIDs:(NSArray **)operationSetUUIDs
                                             state:(PFObjectState *)state
-                                operationSetQueue:(NSArray *)queue {
+                                operationSetQueue:(NSArray *)queue
+                               deletingEventually:(BOOL)isDeletingEventually {
     @synchronized (self.lock) {
         NSMutableArray *cleanQueue = [queue mutableCopy];
         [queue enumerateObjectsUsingBlock:^(PFOperationSet *operationSet, NSUInteger idx, BOOL *stop) {
@@ -665,7 +666,8 @@ static BOOL revocableSessionEnabled_;
         return [super RESTDictionaryWithObjectEncoder:objectEncoder
                                     operationSetUUIDs:operationSetUUIDs
                                                 state:state
-                                    operationSetQueue:cleanQueue];
+                                    operationSetQueue:cleanQueue
+                                   deletingEventually:isDeletingEventually];
     }
 }
 


### PR DESCRIPTION
We didn't actually need to hold the lock here, and if we did, another thread could have acquired these locks in another order, causing a deadlock.

Should help to fix #398, #11, and a few others.