### PR TITLE
Remove potential deadlock from encoding PFUser.

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -979,12 +979,12 @@ static BOOL PFObjectValueIsKindOfMutableContainerClass(id object) {
                                 operationSetUUIDs:(NSArray **)operationSetUUIDs
                                             state:(PFObjectState *)state
                                 operationSetQueue:(NSArray *)queue
-                          deletingEventuallyCount:(NSUInteger)deleteingEventuallyCount {
+                          deletingEventuallyCount:(NSUInteger)deletingEventuallyCount {
     NSMutableDictionary *result = [[state dictionaryRepresentationWithObjectEncoder:objectEncoder] mutableCopy];
     result[PFObjectClassNameRESTKey] = state.parseClassName;
     result[PFObjectCompleteRESTKey] = @(state.complete);
 
-    result[PFObjectIsDeletingEventuallyRESTKey] = @(deleteingEventuallyCount);
+    result[PFObjectIsDeletingEventuallyRESTKey] = @(deletingEventuallyCount);
 
     // TODO (hallucinogen): based on some note from Android's toRest, we'll need to put this
     // stuff somewhere else

--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -652,23 +652,21 @@ static BOOL revocableSessionEnabled_;
                                             state:(PFObjectState *)state
                                 operationSetQueue:(NSArray *)queue
                           deletingEventuallyCount:(NSUInteger)deletingEventuallyCount {
-    @synchronized (self.lock) {
-        NSMutableArray *cleanQueue = [queue mutableCopy];
-        [queue enumerateObjectsUsingBlock:^(PFOperationSet *operationSet, NSUInteger idx, BOOL *stop) {
-            // Remove operations for `password` field, to not let it persist to LDS.
-            if (operationSet[PFUserPasswordRESTKey]) {
-                operationSet = [operationSet copy];
-                [operationSet removeObjectForKey:PFUserPasswordRESTKey];
+    NSMutableArray *cleanQueue = [queue mutableCopy];
+    [queue enumerateObjectsUsingBlock:^(PFOperationSet *operationSet, NSUInteger idx, BOOL *stop) {
+        // Remove operations for `password` field, to not let it persist to LDS.
+        if (operationSet[PFUserPasswordRESTKey]) {
+            operationSet = [operationSet copy];
+            [operationSet removeObjectForKey:PFUserPasswordRESTKey];
 
-                cleanQueue[idx] = operationSet;
-            }
-        }];
-        return [super RESTDictionaryWithObjectEncoder:objectEncoder
-                                    operationSetUUIDs:operationSetUUIDs
-                                                state:state
-                                    operationSetQueue:cleanQueue
-                              deletingEventuallyCount:deletingEventuallyCount];
-    }
+            cleanQueue[idx] = operationSet;
+        }
+    }];
+    return [super RESTDictionaryWithObjectEncoder:objectEncoder
+                                operationSetUUIDs:operationSetUUIDs
+                                            state:state
+                                operationSetQueue:cleanQueue
+                          deletingEventuallyCount:deletingEventuallyCount];
 }
 
 ///--------------------------------------


### PR DESCRIPTION
No need for user.lock here, since we removed the super class one as well and we are guaranteed to be passed in a copy of opSetQueue.
Has a potential to resolve yet another deadlock specifically when using users.