### PR TITLE
Disable PFNetworkActivityIndicatorManager on tvOS.

### DIFF
--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -722,7 +722,6 @@
 		815F22DD1BD04D150054659F /* PFFieldOperationDecoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 81A245921B1E99EA006A6953 /* PFFieldOperationDecoder.m */; };
 		815F22DE1BD04D150054659F /* PFObjectState.m in Sources */ = {isa = PBXBuildFile; fileRef = 81CB7F6E1B166FE500DC601D /* PFObjectState.m */; };
 		815F22DF1BD04D150054659F /* PFKeyValueCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 814881431B795C63008763BF /* PFKeyValueCache.m */; };
-		815F22E01BD04D150054659F /* PFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF08A199D555800D86A21 /* PFNetworkActivityIndicatorManager.m */; };
 		815F22E11BD04D150054659F /* PFObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 0925ABEE13D791770095FEFA /* PFObject.m */; };
 		815F22E21BD04D150054659F /* PFFileStagingController.m in Sources */ = {isa = PBXBuildFile; fileRef = F50E486D1B83ED270055094D /* PFFileStagingController.m */; };
 		815F22E31BD04D150054659F /* PFSQLiteDatabaseController.m in Sources */ = {isa = PBXBuildFile; fileRef = F51D06331B792CF10044539E /* PFSQLiteDatabaseController.m */; };
@@ -922,7 +921,6 @@
 		815F23B01BD04D150054659F /* PFFileState_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C7F49D1AF421FF007B5418 /* PFFileState_Private.h */; };
 		815F23B11BD04D150054659F /* PFCachedQueryController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8143E6611AFC1C7D008C4E06 /* PFCachedQueryController.h */; };
 		815F23B21BD04D150054659F /* PFMutableACLState.h in Headers */ = {isa = PBXBuildFile; fileRef = F51534FB1B571E9100C49F56 /* PFMutableACLState.h */; };
-		815F23B31BD04D150054659F /* PFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 81DEF089199D555800D86A21 /* PFNetworkActivityIndicatorManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		815F23B41BD04D150054659F /* PFObjectController_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 8166FC6D1B50376D003841A2 /* PFObjectController_Private.h */; };
 		815F23B51BD04D150054659F /* PFEventuallyQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF24901A09BA7600CFC7D4 /* PFEventuallyQueue.h */; };
 		815F23B61BD04D150054659F /* PFRESTUserCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 81AFE0E51A1FDB7900AB6CB3 /* PFRESTUserCommand.h */; };
@@ -4082,7 +4080,6 @@
 				815F23B01BD04D150054659F /* PFFileState_Private.h in Headers */,
 				815F23B11BD04D150054659F /* PFCachedQueryController.h in Headers */,
 				815F23B21BD04D150054659F /* PFMutableACLState.h in Headers */,
-				815F23B31BD04D150054659F /* PFNetworkActivityIndicatorManager.h in Headers */,
 				815F23B41BD04D150054659F /* PFObjectController_Private.h in Headers */,
 				815F23B51BD04D150054659F /* PFEventuallyQueue.h in Headers */,
 				815F23B61BD04D150054659F /* PFRESTUserCommand.h in Headers */,
@@ -5135,7 +5132,6 @@
 				815F22DD1BD04D150054659F /* PFFieldOperationDecoder.m in Sources */,
 				815F22DE1BD04D150054659F /* PFObjectState.m in Sources */,
 				815F22DF1BD04D150054659F /* PFKeyValueCache.m in Sources */,
-				815F22E01BD04D150054659F /* PFNetworkActivityIndicatorManager.m in Sources */,
 				815F22E11BD04D150054659F /* PFObject.m in Sources */,
 				815F22E21BD04D150054659F /* PFFileStagingController.m in Sources */,
 				815F22E31BD04D150054659F /* PFSQLiteDatabaseController.m in Sources */,

--- a/Parse/PFNetworkActivityIndicatorManager.h
+++ b/Parse/PFNetworkActivityIndicatorManager.h
@@ -10,6 +10,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#import <Parse/PFConstants.h>
 #import <Parse/PFNullability.h>
 
 PF_ASSUME_NONNULL_BEGIN
@@ -22,7 +23,7 @@ PF_ASSUME_NONNULL_BEGIN
  The number of active requests is incremented or decremented like a stack or a semaphore,
  the activity indicator will animate, as long as the number is greater than zero.
  */
-@interface PFNetworkActivityIndicatorManager : NSObject
+PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFNetworkActivityIndicatorManager : NSObject
 
 /*!
  A Boolean value indicating whether the manager is enabled.

--- a/Parse/PFNetworkActivityIndicatorManager.m
+++ b/Parse/PFNetworkActivityIndicatorManager.m
@@ -9,8 +9,6 @@
 
 #import "PFNetworkActivityIndicatorManager.h"
 
-#import <Parse/PFConstants.h>
-
 #import "PFApplication.h"
 #import "PFCommandRunningConstants.h"
 


### PR DESCRIPTION
Depends on #440 
Contributes to #250 