### PR TITLE
Fix an issue with persistent bad authData on failure to link a user.

### DIFF
--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -878,14 +878,19 @@ static BOOL revocableSessionEnabled_;
             return [[self saveAsync:nil] continueAsyncWithBlock:^id(BFTask *task) {
                 if (task.result) {
                     [self synchronizeAuthDataWithAuthType:authType];
-                } else {
-                    @synchronized (self.lock) {
-                        [self.authData removeObjectForKey:authType];
-                        [self.linkedServiceNames removeObject:authType];
-                        [self restoreAnonymity:oldAnonymousData];
-                    }
+                    return task;
                 }
-                return task;
+
+                @synchronized (self.lock) {
+                    [self.authData removeObjectForKey:authType];
+                    [self.linkedServiceNames removeObject:authType];
+                    [self restoreAnonymity:oldAnonymousData];
+                }
+                // Save the user to disk in case of failure, since we want the latest succeeded data persistent.
+                PFCurrentUserController *controller = [[self class] currentUserController];
+                return [[controller saveCurrentObjectAsync:self] continueWithBlock:^id(BFTask *_) {
+                    return task; // Roll-forward the result of a save to network, not local save.
+                }];
             }];
         }];
     }];


### PR DESCRIPTION
Fixes #467.

Used this piece of code to test:
```objc
- (void)testLinkWithStripsNewDataOnFail {
    id mock = PFStrictProtocolMock(@protocol(PFUserAuthenticationDelegate));
    [PFUser registerAuthenticationDelegate:mock forAuthType:@"a"];
    OCMStub([mock restoreAuthenticationWithAuthData:@{ @"a" : @"b" }]).andReturn(YES);

    PFUser *user = [PFUser user];
    user.username = @"yolo";
    user.password = @"yarr";
    XCTAssertTrue([user signUp:nil]);

    XCTestExpectation *linkExpectation = [self expectationWithDescription:@"link user"];
    [[user linkWithAuthTypeInBackground:@"a" authData:@{ @"a" : @"b" }] continueWithBlock:^id(BFTask<NSNumber *> *task) {
        XCTAssertTrue(task.faulted);
        XCTAssertNotNil(task.error);
        [linkExpectation fulfill];
        return nil;
    }];
    [self waitForTestExpectations];
    XCTAssertFalse([user isLinkedWithAuthType:@"a"]);

    [self simulateApplicationReboot];

    user = [PFUser currentUser];
    XCTAssertFalse([user isLinkedWithAuthType:@"a"]);
}
```