### PR TITLE
Add generic types to PFUser login/link methods.

### DIFF
--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -17,8 +17,8 @@
 
 PF_ASSUME_NONNULL_BEGIN
 
-typedef void(^PFUserSessionUpgradeResultBlock)(NSError *PF_NULLABLE_S error);
-typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
+typedef void (^PFUserSessionUpgradeResultBlock)(NSError *PF_NULLABLE_S error);
+typedef void (^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
 
 @class PFQuery PF_GENERIC(PFGenericObject : PFObject *);
 @protocol PFUserAuthenticationDelegate;
@@ -475,7 +475,8 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
 
  @returns A `BFTask` that is resolved to `PFUser` when logging in completes.
  */
-+ (BFTask PF_GENERIC(PFUser *) *)logInWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
++ (BFTask PF_GENERIC(PFUser *)*)logInWithAuthTypeInBackground:(NSString *)authType
+                                                     authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;
 
 /*!
  @abstract Links this user to a third party authentication library.
@@ -488,7 +489,8 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
 
  @returns A `BFTask` that is resolved to `@YES` if linking succeeds.
  */
-- (BFTask PF_GENERIC(NSNumber *) *)linkWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData;
+- (BFTask PF_GENERIC(NSNumber *)*)linkWithAuthTypeInBackground:(NSString *)authType
+                                                      authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;
 
 /*!
  @abstract Unlinks this user from a third party authentication library.
@@ -500,7 +502,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *PF_NULLABLE_S error);
 
  @returns A `BFTask` that is resolved to `@YES` if unlinking succeeds.
  */
-- (BFTask PF_GENERIC(NSNumber *) *)unlinkWithAuthTypeInBackground:(NSString *)authType;
+- (BFTask PF_GENERIC(NSNumber *)*)unlinkWithAuthTypeInBackground:(NSString *)authType;
 
 /*!
  @abstract Indicates whether this user is linked with a third party authentication library of a specific type.

--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -133,7 +133,7 @@ static BOOL revocableSessionEnabled_;
 
 // Checks the properties on the object before saving.
 - (void)_checkSaveParametersWithCurrentUser:(PFUser *)currentUser {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         PFConsistencyAssert(self.objectId || self.isLazy,
                             @"User cannot be saved unless they are already signed up. Call signUp first.");
 
@@ -145,7 +145,7 @@ static BOOL revocableSessionEnabled_;
 
 // Checks the properties on the object before signUp.
 - (BFTask *)_validateSignUpAsync {
-    return [BFTask taskFromExecutor:[BFExecutor defaultExecutor] withBlock:^id{
+    return [BFTask taskFromExecutor:[BFExecutor defaultExecutor] withBlock:^id {
         NSError *error = nil;
         @synchronized (self.lock) {
             if (!self.username) {
@@ -168,7 +168,7 @@ static BOOL revocableSessionEnabled_;
 
 - (NSMutableDictionary *)_convertToDictionaryForSaving:(PFOperationSet *)changes
                                      withObjectEncoder:(PFEncoder *)encoder {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         NSMutableDictionary *serialized = [super _convertToDictionaryForSaving:changes withObjectEncoder:encoder];
         if ([self.authData count] > 0) {
             serialized[PFUserAuthDataRESTKey] = [self.authData copy];
@@ -195,7 +195,7 @@ static BOOL revocableSessionEnabled_;
 ///--------------------------------------
 
 - (PFRESTCommand *)_currentSignUpCommandForChanges:(PFOperationSet *)changes {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         NSDictionary *parameters = [self _convertToDictionaryForSaving:changes
                                                      withObjectEncoder:[PFPointerObjectEncoder objectEncoder]];
         return [PFRESTUserCommand signUpUserCommandWithParameters:parameters
@@ -210,7 +210,7 @@ static BOOL revocableSessionEnabled_;
 
 // Constructs the command for user_signup_or_login. This is used for Facebook, Twitter, and other linking services.
 - (PFRESTCommand *)_currentServiceLoginCommandForChanges:(PFOperationSet *)changes {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         NSDictionary *parameters = [self _convertToDictionaryForSaving:changes
                                                      withObjectEncoder:[PFPointerObjectEncoder objectEncoder]];
         return [PFRESTUserCommand serviceLoginUserCommandWithParameters:parameters
@@ -220,7 +220,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (BFTask *)_handleServiceLoginCommandResult:(PFCommandResult *)result {
-    return [BFTask taskFromExecutor:[BFExecutor defaultExecutor] withBlock:^id{
+    return [BFTask taskFromExecutor:[BFExecutor defaultExecutor] withBlock:^id {
         NSDictionary *resultDictionary = result.result;
         return [[self handleSaveResultAsync:resultDictionary] continueWithBlock:^id(BFTask *task) {
             BOOL new = (result.httpResponse.statusCode == 201); // 201 means Created
@@ -248,7 +248,7 @@ static BOOL revocableSessionEnabled_;
 
 // Override the save result handling with custom user functionality
 - (BFTask *)handleSignUpResultAsync:(BFTask *)task {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         PFCommandResult *commandResult = task.result;
         NSDictionary *result = commandResult.result;
         BFTask *signUpTask = task;
@@ -281,7 +281,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (void)cleanUpAuthData {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         for (NSString *key in [self.authData copy]) {
             id linkData = [self.authData objectForKey:key];
             if (!linkData || linkData == [NSNull null]) {
@@ -299,7 +299,7 @@ static BOOL revocableSessionEnabled_;
  Copies special PFUser fields from another user.
  */
 - (PFObject *)mergeFromObject:(PFUser *)other {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         [super mergeFromObject:other];
 
         if (self == other) {
@@ -337,7 +337,7 @@ static BOOL revocableSessionEnabled_;
  }
  */
 - (void)_mergeFromServerWithResult:(NSDictionary *)result decoder:(PFDecoder *)decoder completeData:(BOOL)completeData {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         // save the session token
 
         PFMutableUserState *state = [self._state mutableCopy];
@@ -379,7 +379,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (void)synchronizeAuthDataWithAuthType:(NSString *)authType {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         if (!self.isCurrentUser) {
             return;
         }
@@ -395,7 +395,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (void)synchronizeAllAuthData {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         // Ensures that all auth providers have auth data (e.g. access tokens, etc.) that matches this user.
         if (self.authData) {
             [self.authData enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
@@ -406,7 +406,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (BFTask *)resolveLazinessAsync:(BFTask *)toAwait {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         if (!self.isLazy) {
             return [BFTask taskWithResult:self];
         }
@@ -457,7 +457,7 @@ static BOOL revocableSessionEnabled_;
 
 + (instancetype)logInLazyUserWithAuthType:(NSString *)authType authData:(NSDictionary *)authData {
     PFUser *user = [self user];
-    @synchronized ([user lock]) {
+    @synchronized([user lock]) {
         [user setIsCurrentUser:YES];
         user.isLazy = YES;
         [user.authData setObject:authData forKey:authType];
@@ -469,7 +469,7 @@ static BOOL revocableSessionEnabled_;
 - (BFTask *)signUpAsync:(BFTask *)toAwait {
     PFUser *currentUser = [[self class] currentUser];
     NSString *token = currentUser.sessionToken;
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         if (self.objectId) {
             // For anonymous users, there may be an objectId.  Setting the userName
             // will have removed the anonymous link and set the value in the authData
@@ -568,7 +568,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (void)stripAnonymity {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         if ([PFAnonymousUtils isLinkedWithUser:self]) {
             NSString *authType = PFAnonymousUserAuthenticationType;
 
@@ -585,7 +585,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (void)restoreAnonymity:(id)anonymousData {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         if (anonymousData && anonymousData != [NSNull null]) {
             NSString *authType = PFAnonymousUserAuthenticationType;
             [self.linkedServiceNames addObject:authType];
@@ -616,7 +616,7 @@ static BOOL revocableSessionEnabled_;
 ///--------------------------------------
 
 - (void)mergeFromRESTDictionary:(NSDictionary *)object withDecoder:(PFDecoder *)decoder {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         NSMutableDictionary *restDictionary = [object mutableCopy];
 
         PFMutableUserState *state = [self._state mutableCopy];
@@ -784,13 +784,13 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (BOOL)isCurrentUser {
-    @synchronized (self.lock) {
+    @synchronized(self.lock) {
         return isCurrentUser;
     }
 }
 
 - (void)setIsCurrentUser:(BOOL)aBool {
-    @synchronized (self.lock) {
+    @synchronized(self.lock) {
         isCurrentUser = aBool;
     }
 }
@@ -838,25 +838,29 @@ static BOOL revocableSessionEnabled_;
 
 #pragma mark Log In
 
-+ (BFTask *)logInWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)authData {
++ (BFTask PF_GENERIC(PFUser *)*)logInWithAuthTypeInBackground:(NSString *)authType
+                                                     authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)authData {
     PFParameterAssert(authType, @"Can't log in without `authType`.");
     PFParameterAssert(authData, @"Can't log in without `authData`.");
     PFUserAuthenticationController *controller = [self authenticationController];
     PFConsistencyAssert([controller authenticationDelegateForAuthType:authType],
                         @"No registered authentication delegate found for `%@` authentication type. "
-                        @"Register a delegate first via PFUser.registerAuthenticationDelegate(delegate, forAuthType:)", authType);
+                        @"Register a delegate first via PFUser.registerAuthenticationDelegate(delegate, forAuthType:)",
+                        authType);
     return [[self authenticationController] logInUserAsyncWithAuthType:authType authData:authData];
 }
 
 #pragma mark Link
 
-- (BFTask *)linkWithAuthTypeInBackground:(NSString *)authType authData:(NSDictionary *)newAuthData {
+- (BFTask PF_GENERIC(NSNumber *)*)linkWithAuthTypeInBackground:(NSString *)authType
+                                                      authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)newAuthData {
     PFParameterAssert(authType, @"Can't link without `authType`.");
-    PFParameterAssert(authData, @"Can't link without `authData`.");
+    PFParameterAssert(newAuthData, @"Can't link without `authData`.");
     PFUserAuthenticationController *controller = [[self class] authenticationController];
     PFConsistencyAssert([controller authenticationDelegateForAuthType:authType],
                         @"No registered authentication delegate found for `%@` authentication type. "
-                        @"Register a delegate first via PFUser.registerAuthenticationDelegate(delegate, forAuthType:)", authType);
+                        @"Register a delegate first via PFUser.registerAuthenticationDelegate(delegate, forAuthType:)",
+                        authType);
 
     @weakify(self);
     return [self.taskQueue enqueue:^BFTask *(BFTask *toAwait) {
@@ -894,7 +898,7 @@ static BOOL revocableSessionEnabled_;
 #pragma mark Unlink
 
 - (BFTask *)unlinkWithAuthTypeInBackground:(NSString *)authType {
-    return [BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
+    return [BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id {
         @synchronized (self.lock) {
             if (self.authData[authType]) {
                 self.authData[authType] = [NSNull null];
@@ -1064,7 +1068,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (NSMutableDictionary *)authData {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         if (!authData) {
             authData = [[NSMutableDictionary alloc] init];
         }
@@ -1073,7 +1077,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (NSMutableSet *)linkedServiceNames {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         if (!linkedServiceNames) {
             linkedServiceNames = [[NSMutableSet alloc] init];
         }
@@ -1169,7 +1173,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (BOOL)_isAuthenticatedWithCurrentUser:(PFUser *)currentUser {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         BOOL authenticated = self.isLazy || self.sessionToken;
         if (!authenticated && currentUser != nil) {
             authenticated = [self.objectId isEqualToString:currentUser.objectId];
@@ -1189,7 +1193,7 @@ static BOOL revocableSessionEnabled_;
 }
 
 - (void)signUpInBackgroundWithBlock:(PFBooleanResultBlock)block {
-    @synchronized ([self lock]) {
+    @synchronized([self lock]) {
         if (self.objectId) {
             // For anonymous users, there may be an objectId.  Setting the userName
             // will have removed the anonymous link and set the value in the authData

--- a/Parse/PFUserAuthenticationDelegate.h
+++ b/Parse/PFUserAuthenticationDelegate.h
@@ -19,17 +19,17 @@ PF_ASSUME_NONNULL_BEGIN
 @protocol PFUserAuthenticationDelegate <NSObject>
 
 /*!
- @abstract Called when restoring third party authentication credentials that have been serialized, 
+ @abstract Called when restoring third party authentication credentials that have been serialized,
  such as session keys, user id, etc.
- 
+
  @note This method will be executed on a background thread.
 
  @param authData The auth data for the provider. This value may be `nil` when unlinking an account.
 
- @returns `YES` - if the `authData` was succesfully synchronized, 
+ @returns `YES` - if the `authData` was succesfully synchronized,
  or `NO` if user should not longer be associated because of bad `authData`.
  */
-- (BOOL)restoreAuthenticationWithAuthData:(PF_NULLABLE NSDictionary PF_GENERIC(NSString *, NSString *) *)authData;
+- (BOOL)restoreAuthenticationWithAuthData:(PF_NULLABLE NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;
 
 @end
 


### PR DESCRIPTION
These were missing - add them. As well as run clang-format on entire PFUser.