### PR TITLE
Store staged PFFiles in cache directory.

### DIFF
--- a/Parse/Internal/File/Controller/PFFileStagingController.m
+++ b/Parse/Internal/File/Controller/PFFileStagingController.m
@@ -51,8 +51,7 @@ static NSString *const PFFileStagingControllerDirectoryName_ = @"PFFileStaging";
 ///--------------------------------------
 
 - (NSString *)stagedFilesDirectoryPath {
-    NSString *folderPath = [self.dataSource.fileManager parseLocalSandboxDataDirectoryPath];
-    return [folderPath stringByAppendingPathComponent:PFFileStagingControllerDirectoryName_];
+    return [self.dataSource.fileManager parseCacheItemPathForPathComponent:PFFileStagingControllerDirectoryName_];
 }
 
 ///--------------------------------------
@@ -89,7 +88,7 @@ static NSString *const PFFileStagingControllerDirectoryName_ = @"PFFileStaging";
 - (BFTask *)_clearStagedFilesAsync {
     return [_taskQueue enqueue:^id(BFTask *task) {
         NSString *stagedFilesDirectoryPath = [self stagedFilesDirectoryPath];
-        return [PFFileManager removeItemAtPathAsync:stagedFilesDirectoryPath];
+        return [PFFileManager removeItemAtPathAsync:stagedFilesDirectoryPath withFileLock:NO];
     }];
 }
 


### PR DESCRIPTION
There is a guarantee that files are not going to be deleted in caches folder if the app is running, and since these files don't quite make sense after app restart (they hold a pointer) - let's move them to caches folder.
Also, this contributes to #250, since data is not persistent on tvOS and we can now store it properly in Caches folder.