### PR TITLE
Use dataSource pattern to get command runner in PFCloudCodeController.

### DIFF
--- a/Parse/Internal/CloudCode/PFCloudCodeController.h
+++ b/Parse/Internal/CloudCode/PFCloudCodeController.h
@@ -10,22 +10,22 @@
 #import <Foundation/Foundation.h>
 
 #import <Parse/PFConstants.h>
+#import "PFDataProvider.h"
 
 @class BFTask PF_GENERIC(__covariant BFGenericType);
-@protocol PFCommandRunning;
 
 @interface PFCloudCodeController : NSObject
 
-@property (nonatomic, strong, readonly) id<PFCommandRunning> commandRunner;
+@property (nonatomic, strong, readonly) id<PFCommandRunnerProvider> dataSource;
 
 ///--------------------------------------
 /// @name Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithCommandRunner:(id<PFCommandRunning>)commandRunner NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
-+ (instancetype)controllerWithCommandRunner:(id<PFCommandRunning>)commandRunner;
++ (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider>)dataSource;
 
 ///--------------------------------------
 /// @name Cloud Functions

--- a/Parse/Internal/CloudCode/PFCloudCodeController.m
+++ b/Parse/Internal/CloudCode/PFCloudCodeController.m
@@ -28,17 +28,17 @@
     PFNotDesignatedInitializer();
 }
 
-- (instancetype)initWithCommandRunner:(id<PFCommandRunning>)commandRunner {
+- (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;
 
-    _commandRunner = commandRunner;
+    _dataSource = dataSource;
 
     return self;
 }
 
-+ (instancetype)controllerWithCommandRunner:(id<PFCommandRunning>)commandRunner {
-    return [[self alloc] initWithCommandRunner:commandRunner];
++ (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider>)dataSource {
+    return [[self alloc] initWithDataSource:dataSource];
 }
 
 ///--------------------------------------
@@ -55,7 +55,7 @@
         PFRESTCloudCommand *command = [PFRESTCloudCommand commandForFunction:functionName
                                                               withParameters:encodedParameters
                                                                 sessionToken:sessionToken];
-        return [self.commandRunner runCommandAsync:command withOptions:PFCommandRunningOptionRetryIfFailed];
+        return [self.dataSource.commandRunner runCommandAsync:command withOptions:PFCommandRunningOptionRetryIfFailed];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         return ((PFCommandResult *)(task.result)).result[@"result"];
     }] continueWithSuccessBlock:^id(BFTask *task) {

--- a/Parse/Internal/PFCoreManager.m
+++ b/Parse/Internal/PFCoreManager.m
@@ -158,7 +158,7 @@
     __block PFCloudCodeController *controller = nil;
     dispatch_sync(_controllerAccessQueue, ^{
         if (!_cloudCodeController) {
-            _cloudCodeController = [[PFCloudCodeController alloc] initWithCommandRunner:self.dataSource.commandRunner];
+            _cloudCodeController = [[PFCloudCodeController alloc] initWithDataSource:self.dataSource];
         }
         controller = _cloudCodeController;
     });

--- a/Tests/Unit/CloudCodeControllerTests.m
+++ b/Tests/Unit/CloudCodeControllerTests.m
@@ -29,15 +29,15 @@
 ///--------------------------------------
 
 - (void)testConstructors {
-    id runnerMock = PFStrictProtocolMock(@protocol(PFCommandRunning));
+    id dataSource = PFStrictProtocolMock(@protocol(PFCommandRunnerProvider));
 
-    PFCloudCodeController *controller = [[PFCloudCodeController alloc] initWithCommandRunner:runnerMock];
+    PFCloudCodeController *controller = [[PFCloudCodeController alloc] initWithDataSource:dataSource];
     XCTAssertNotNil(controller);
-    XCTAssertEqual(controller.commandRunner, runnerMock);
+    XCTAssertEqual(controller.dataSource, dataSource);
 
-    controller = [PFCloudCodeController controllerWithCommandRunner:runnerMock];
+    controller = [PFCloudCodeController controllerWithDataSource:dataSource];
     XCTAssertNotNil(controller);
-    XCTAssertEqual(controller.commandRunner, runnerMock);
+    XCTAssertEqual(controller.dataSource, dataSource);
 }
 
 - (void)testCallCloudFunctionParameters {
@@ -51,8 +51,10 @@
 
         return YES;
     }];
+    id dataSource = PFStrictProtocolMock(@protocol(PFCommandRunnerProvider));
+    OCMStub([dataSource commandRunner]).andReturn(runner);
 
-    PFCloudCodeController *controller = [[PFCloudCodeController alloc] initWithCommandRunner:runner];
+    PFCloudCodeController *controller = [[PFCloudCodeController alloc] initWithDataSource:dataSource];
     [[controller callCloudCodeFunctionAsync:@"yarr"
                              withParameters:@{ @"a" : @1 }
                                sessionToken:@"yolo"] waitUntilFinished];
@@ -65,8 +67,10 @@
     [runner mockCommandResult:nil forCommandsPassingTest:^BOOL(id obj) {
         return obj != nil;
     }];
+    id dataSource = PFStrictProtocolMock(@protocol(PFCommandRunnerProvider));
+    OCMStub([dataSource commandRunner]).andReturn(runner);
 
-    PFCloudCodeController *controller = [[PFCloudCodeController alloc] initWithCommandRunner:runner];
+    PFCloudCodeController *controller = [PFCloudCodeController controllerWithDataSource:dataSource];
 
     XCTestExpectation *nilResultExpectation = [self currentSelectorTestExpectation];
     [[controller callCloudCodeFunctionAsync:@"a"
@@ -84,7 +88,10 @@
     [runner mockCommandResult:@{ @"result" : @"yarr" } forCommandsPassingTest:^BOOL(id obj) {
         return YES;
     }];
-    PFCloudCodeController *controller = [[PFCloudCodeController alloc] initWithCommandRunner:runner];
+    id dataSource = PFStrictProtocolMock(@protocol(PFCommandRunnerProvider));
+    OCMStub([dataSource commandRunner]).andReturn(runner);
+
+    PFCloudCodeController *controller = [PFCloudCodeController controllerWithDataSource:dataSource];
 
     XCTestExpectation *resultExpectation = [self expectationWithDescription:@"proper result"];
     [[controller callCloudCodeFunctionAsync:@"a"


### PR DESCRIPTION
Unifying with other controllers.