### PR TITLE
Refactor PFConfigController, PFCurrentConfigController to use dataSource for all providers.

### DIFF
--- a/Parse/Internal/Config/Controller/PFConfigController.h
+++ b/Parse/Internal/Config/Controller/PFConfigController.h
@@ -11,16 +11,15 @@
 
 #import <Parse/PFConstants.h>
 
+#import "PFDataProvider.h"
+
 @class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFConfig;
 @class PFCurrentConfigController;
-@class PFFileManager;
-@protocol PFCommandRunning;
 
 @interface PFConfigController : NSObject
 
-@property (nonatomic, strong, readonly) PFFileManager *fileManager;
-@property (nonatomic, strong, readonly) id<PFCommandRunning> commandRunner;
+@property (nonatomic, weak, readonly) id<PFFileManagerProvider,PFCommandRunnerProvider> dataSource;
 
 @property (nonatomic, strong, readonly) PFCurrentConfigController *currentConfigController;
 
@@ -29,8 +28,7 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithFileManager:(PFFileManager *)fileManager
-                      commandRunner:(id<PFCommandRunning>)commandRunner NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDataSource:(id<PFFileManagerProvider, PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------
 /// @name Fetch

--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.h
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.h
@@ -11,24 +11,23 @@
 
 #import <Parse/PFConstants.h>
 
-#import "PFMacros.h"
+#import "PFDataProvider.h"
 
 @class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFConfig;
-@class PFFileManager;
 
 @interface PFCurrentConfigController : NSObject
 
-@property (nonatomic, strong, readonly) PFFileManager *fileManager;
+@property (nonatomic, weak, readonly) id<PFFileManagerProvider> dataSource;
 
 ///--------------------------------------
 /// @name Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithFileManager:(PFFileManager *)fileManager NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDataSource:(id<PFFileManagerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
-+ (instancetype)controllerWithFileManager:(PFFileManager *)fileManager;
++ (instancetype)controllerWithDataSource:(id<PFFileManagerProvider>)dataSource;
 
 ///--------------------------------------
 /// @name Accessors

--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.m
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.m
@@ -38,20 +38,20 @@ static NSString *const PFConfigCurrentConfigFileName_ = @"config";
     PFNotDesignatedInitializer();
 }
 
-- (instancetype)initWithFileManager:(PFFileManager *)fileManager {
+- (instancetype)initWithDataSource:(id<PFFileManagerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;
 
     _dataQueue = dispatch_queue_create("com.parse.config.current", DISPATCH_QUEUE_SERIAL);
     _dataExecutor = [BFExecutor executorWithDispatchQueue:_dataQueue];
 
-    _fileManager = fileManager;
+    _dataSource = dataSource;
 
     return self;
 }
 
-+ (instancetype)controllerWithFileManager:(PFFileManager *)fileManager {
-    return [[self alloc] initWithFileManager:fileManager];
++ (instancetype)controllerWithDataSource:(id<PFFileManagerProvider>)dataSource {
+    return [[self alloc] initWithDataSource:dataSource];
 }
 
 ///--------------------------------------
@@ -103,7 +103,7 @@ static NSString *const PFConfigCurrentConfigFileName_ = @"config";
 }
 
 - (NSString *)configFilePath {
-    return [self.fileManager parseDataItemPathForPathComponent:PFConfigCurrentConfigFileName_];
+    return [self.dataSource.fileManager parseDataItemPathForPathComponent:PFConfigCurrentConfigFileName_];
 }
 
 @end

--- a/Parse/Internal/PFCoreManager.m
+++ b/Parse/Internal/PFCoreManager.m
@@ -179,9 +179,7 @@
     __block PFConfigController *controller = nil;
     dispatch_sync(_controllerAccessQueue, ^{
         if (!_configController) {
-            id<PFCoreManagerDataSource> dataSource = self.dataSource;
-            _configController = [[PFConfigController alloc] initWithFileManager:dataSource.fileManager
-                                                                  commandRunner:dataSource.commandRunner];
+            _configController = [[PFConfigController alloc] initWithDataSource:self.dataSource];
         }
         controller = _configController;
     });

--- a/Tests/Unit/ConfigControllerTests.m
+++ b/Tests/Unit/ConfigControllerTests.m
@@ -30,38 +30,31 @@
 ///--------------------------------------
 
 - (void)testConstructor {
-    id mockedFileManager = PFClassMock([PFFileManager class]);
-    id mockedCommandRunner = PFStrictProtocolMock(@protocol(PFCommandRunning));
+    id dataSource = PFStrictProtocolMock(@protocol(PFCommandRunnerProvider));
 
-    PFConfigController *controller = [[PFConfigController alloc] initWithFileManager:mockedFileManager
-                                                                       commandRunner:mockedCommandRunner];
-
+    PFConfigController *controller = [[PFConfigController alloc] initWithDataSource:dataSource];
     XCTAssertNotNil(controller);
-    XCTAssertEqual(mockedFileManager, controller.fileManager);
-    XCTAssertEqual(mockedCommandRunner, controller.commandRunner);
+    XCTAssertEqual(dataSource, (id)controller.dataSource);
 }
 
 - (void)testCurrentConfigController {
-    id fileManager = PFClassMock([PFFileManager class]);
-    id commandRunner = PFStrictProtocolMock(@protocol(PFCommandRunning));
+    id dataSource = PFStrictProtocolMock(@protocol(PFCommandRunnerProvider));
 
-    PFConfigController *configController = [[PFConfigController alloc] initWithFileManager:fileManager
-                                                                             commandRunner:commandRunner];
+    PFConfigController *configController = [[PFConfigController alloc] initWithDataSource:dataSource];
 
     XCTAssertNotNil([configController currentConfigController]);
 }
 
 - (void)testFetch {
-    id fileManager = PFClassMock([PFFileManager class]);;
-
     id commandRunner = PFStrictProtocolMock(@protocol(PFCommandRunning));
     [commandRunner mockCommandResult:@{ @"params" : @{@"testKey" : @"testValue"} }
               forCommandsPassingTest:^BOOL(id obj) {
                   return YES;
               }];
+    id dataSource = PFStrictProtocolMock(@protocol(PFCommandRunnerProvider));
+    OCMStub([dataSource commandRunner]).andReturn(commandRunner);
 
-    PFConfigController *configController = [[PFConfigController alloc] initWithFileManager:fileManager
-                                                                             commandRunner:commandRunner];
+    PFConfigController *configController = [[PFConfigController alloc] initWithDataSource:dataSource];
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
 

--- a/Tests/Unit/CurrentConfigControllerTests.m
+++ b/Tests/Unit/CurrentConfigControllerTests.m
@@ -55,12 +55,15 @@
 ///--------------------------------------
 
 - (void)testConstructor {
-    id mockedFileManager = PFClassMock([PFFileManager class]);
+    id dataSource = PFStrictProtocolMock(@protocol(PFFileManagerProvider));
 
-    PFCurrentConfigController *controller = [[PFCurrentConfigController alloc] initWithFileManager:mockedFileManager];
-
+    PFCurrentConfigController *controller = [[PFCurrentConfigController alloc] initWithDataSource:dataSource];
     XCTAssertNotNil(controller);
-    XCTAssertEqual(controller.fileManager, mockedFileManager);
+    XCTAssertEqual((id)controller.dataSource, dataSource);
+
+    controller = [PFCurrentConfigController controllerWithDataSource:dataSource];
+    XCTAssertNotNil(controller);
+    XCTAssertEqual((id)controller.dataSource, dataSource);
 }
 
 - (void)testGetCurrentConfig {
@@ -79,7 +82,10 @@
     XCTAssertNil(error);
 
     PFFileManager *fileManager = [self mockedFileManagerWithConfigPath:configPath];
-    PFCurrentConfigController *currentController = [PFCurrentConfigController controllerWithFileManager:fileManager];
+    id dataSource = PFStrictProtocolMock(@protocol(PFFileManagerProvider));
+    OCMStub([dataSource fileManager]).andReturn(fileManager);
+
+    PFCurrentConfigController *currentController = [PFCurrentConfigController controllerWithDataSource:dataSource];
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
 
     [[currentController getCurrentConfigAsync] continueWithBlock:^id(BFTask *task) {
@@ -99,7 +105,10 @@
     PFConfig *testConfig = [[PFConfig alloc] initWithFetchedConfig:[self testConfigDictionary]];
 
     PFFileManager *fileManager = [self mockedFileManagerWithConfigPath:configPath];
-    PFCurrentConfigController *currentController = [PFCurrentConfigController controllerWithFileManager:fileManager];
+    id dataSource = PFStrictProtocolMock(@protocol(PFFileManagerProvider));
+    OCMStub([dataSource fileManager]).andReturn(fileManager);
+
+    PFCurrentConfigController *currentController = [PFCurrentConfigController controllerWithDataSource:dataSource];
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
 
     [[currentController setCurrentConfigAsync:testConfig] continueWithBlock:^id(BFTask *task) {
@@ -125,7 +134,10 @@
     PFConfig *testConfig = [[PFConfig alloc] initWithFetchedConfig:[self testConfigDictionary]];
 
     PFFileManager *fileManager = [self mockedFileManagerWithConfigPath:configPath];
-    PFCurrentConfigController *currentController = [PFCurrentConfigController controllerWithFileManager:fileManager];
+    id dataSource = PFStrictProtocolMock(@protocol(PFFileManagerProvider));
+    OCMStub([dataSource fileManager]).andReturn(fileManager);
+
+    PFCurrentConfigController *currentController = [PFCurrentConfigController controllerWithDataSource:dataSource];
     XCTestExpectation *saveExpectation = [self expectationWithDescription:@"Save"];
 
     [[currentController setCurrentConfigAsync:testConfig] continueWithBlock:^id(BFTask *task) {
@@ -157,7 +169,10 @@
     PFConfig *testConfig = [[PFConfig alloc] initWithFetchedConfig:[self testConfigDictionary]];
 
     PFFileManager *fileManager = [self mockedFileManagerWithConfigPath:configPath];
-    PFCurrentConfigController *currentController = [PFCurrentConfigController controllerWithFileManager:fileManager];
+    id dataSource = PFStrictProtocolMock(@protocol(PFFileManagerProvider));
+    OCMStub([dataSource fileManager]).andReturn(fileManager);
+
+    PFCurrentConfigController *currentController = [PFCurrentConfigController controllerWithDataSource:dataSource];
     XCTestExpectation *saveExpectation = [self expectationWithDescription:@"Save"];
 
     [[currentController setCurrentConfigAsync:testConfig] continueWithBlock:^id(BFTask *task) {


### PR DESCRIPTION
Unifying architecture.