### PR TITLE
Safeguard and remove imports for private headers of PFPush, PFInstallation for watchOS, tvOS.

### DIFF
--- a/Parse/Internal/Installation/PFInstallationPrivate.h
+++ b/Parse/Internal/Installation/PFInstallationPrivate.h
@@ -11,6 +11,9 @@
 
 #import <Parse/PFInstallation.h>
 
+PF_TV_UNAVAILABLE_WARNING
+PF_WATCH_UNAVAILABLE_WARNING
+
 @interface PFInstallation (Private)
 
 - (void)_clearDeviceToken;

--- a/Parse/Internal/Push/PFPushPrivate.h
+++ b/Parse/Internal/Push/PFPushPrivate.h
@@ -13,6 +13,9 @@
 
 #import "PFMacros.h"
 
+PF_TV_UNAVAILABLE_WARNING
+PF_WATCH_UNAVAILABLE_WARNING
+
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol PFPushInternalUtils <NSObject>

--- a/Parse/PFInstallation.h
+++ b/Parse/PFInstallation.h
@@ -12,6 +12,7 @@
 #import <Parse/PFObject.h>
 #import <Parse/PFSubclassing.h>
 
+PF_TV_UNAVAILABLE_WARNING
 PF_WATCH_UNAVAILABLE_WARNING
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -25,11 +25,8 @@
 #import "PFLogging.h"
 #import "PFObjectSubclassingController.h"
 
-#if !TARGET_OS_WATCH
+#if !TARGET_OS_WATCH && !TARGET_OS_TV
 #import "PFInstallationPrivate.h"
-#if TARGET_OS_IOS
-#import "PFProduct+Private.h"
-#endif
 #endif
 
 #import "PFCategoryLoader.h"


### PR DESCRIPTION
Contributes to #179, #250.