### PR TITLE
Move PFConfig to use persistence groups.

### DIFF
--- a/Parse/Internal/Config/Controller/PFConfigController.h
+++ b/Parse/Internal/Config/Controller/PFConfigController.h
@@ -19,7 +19,7 @@
 
 @interface PFConfigController : NSObject
 
-@property (nonatomic, weak, readonly) id<PFFileManagerProvider,PFCommandRunnerProvider> dataSource;
+@property (nonatomic, weak, readonly) id<PFPersistenceControllerProvider, PFCommandRunnerProvider> dataSource;
 
 @property (nonatomic, strong, readonly) PFCurrentConfigController *currentConfigController;
 
@@ -28,7 +28,7 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithDataSource:(id<PFFileManagerProvider, PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider, PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------
 /// @name Fetch

--- a/Parse/Internal/Config/Controller/PFConfigController.m
+++ b/Parse/Internal/Config/Controller/PFConfigController.m
@@ -18,8 +18,7 @@
 #import "PFDecoder.h"
 #import "PFRESTConfigCommand.h"
 
-@interface PFConfigController ()
-{
+@interface PFConfigController () {
     dispatch_queue_t _dataAccessQueue;
     dispatch_queue_t _networkQueue;
     BFExecutor *_networkExecutor;
@@ -39,7 +38,7 @@
     PFNotDesignatedInitializer();
 }
 
-- (instancetype)initWithDataSource:(id<PFFileManagerProvider,PFCommandRunnerProvider>)dataSource {
+- (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider, PFCommandRunnerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;
 
@@ -59,7 +58,7 @@
 
 - (BFTask *)fetchConfigAsyncWithSessionToken:(NSString *)sessionToken {
     @weakify(self);
-    return [BFTask taskFromExecutor:_networkExecutor withBlock:^id{
+    return [BFTask taskFromExecutor:_networkExecutor withBlock:^id {
         @strongify(self);
         PFRESTCommand *command = [PFRESTConfigCommand configFetchCommandWithSessionToken:sessionToken];
         return [[[self.dataSource.commandRunner runCommandAsync:command

--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.h
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.h
@@ -18,16 +18,16 @@
 
 @interface PFCurrentConfigController : NSObject
 
-@property (nonatomic, weak, readonly) id<PFFileManagerProvider> dataSource;
+@property (nonatomic, weak, readonly) id<PFPersistenceControllerProvider> dataSource;
 
 ///--------------------------------------
 /// @name Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithDataSource:(id<PFFileManagerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
-+ (instancetype)controllerWithDataSource:(id<PFFileManagerProvider>)dataSource;
++ (instancetype)controllerWithDataSource:(id<PFPersistenceControllerProvider>)dataSource;
 
 ///--------------------------------------
 /// @name Accessors

--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.m
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.m
@@ -13,14 +13,14 @@
 #import "PFAssert.h"
 #import "PFConfig_Private.h"
 #import "PFDecoder.h"
-#import "PFFileManager.h"
+#import "PFPersistenceController.h"
 #import "PFJSONSerialization.h"
+#import "PFAsyncTaskQueue.h"
 
 static NSString *const PFConfigCurrentConfigFileName_ = @"config";
 
 @interface PFCurrentConfigController () {
-    dispatch_queue_t _dataQueue;
-    BFExecutor *_dataExecutor;
+    PFAsyncTaskQueue *_dataTaskQueue;
     PFConfig *_currentConfig;
 }
 
@@ -38,19 +38,18 @@ static NSString *const PFConfigCurrentConfigFileName_ = @"config";
     PFNotDesignatedInitializer();
 }
 
-- (instancetype)initWithDataSource:(id<PFFileManagerProvider>)dataSource {
+- (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;
 
-    _dataQueue = dispatch_queue_create("com.parse.config.current", DISPATCH_QUEUE_SERIAL);
-    _dataExecutor = [BFExecutor executorWithDispatchQueue:_dataQueue];
+    _dataTaskQueue = [[PFAsyncTaskQueue alloc] init];
 
     _dataSource = dataSource;
 
     return self;
 }
 
-+ (instancetype)controllerWithDataSource:(id<PFFileManagerProvider>)dataSource {
++ (instancetype)controllerWithDataSource:(id<PFPersistenceControllerProvider>)dataSource {
     return [[self alloc] initWithDataSource:dataSource];
 }
 
@@ -59,15 +58,12 @@ static NSString *const PFConfigCurrentConfigFileName_ = @"config";
 ///--------------------------------------
 
 - (BFTask *)getCurrentConfigAsync {
-    return [BFTask taskFromExecutor:_dataExecutor withBlock:^id{
+    return [_dataTaskQueue enqueue:^id(BFTask *_) {
         if (!_currentConfig) {
-            NSDictionary *dictionary = [PFJSONSerialization JSONObjectFromFileAtPath:self.configFilePath];
-            if (dictionary) {
-                NSDictionary *decodedDictionary = [[PFDecoder objectDecoder] decodeObject:dictionary];
-                _currentConfig = [[PFConfig alloc] initWithFetchedConfig:decodedDictionary];
-            } else {
-                _currentConfig = [[PFConfig alloc] init];
-            }
+            return [[self _loadConfigAsync] continueWithSuccessBlock:^id(BFTask PF_GENERIC(PFConfig *)*task) {
+                _currentConfig = task.result;
+                return _currentConfig;
+            }];
         }
         return _currentConfig;
     }];
@@ -75,35 +71,62 @@ static NSString *const PFConfigCurrentConfigFileName_ = @"config";
 
 - (BFTask *)setCurrentConfigAsync:(PFConfig *)config {
     @weakify(self);
-    return [BFTask taskFromExecutor:_dataExecutor withBlock:^id{
+    return [_dataTaskQueue enqueue:^id(BFTask *_) {
         @strongify(self);
         _currentConfig = config;
 
         NSDictionary *configParameters = @{ PFConfigParametersRESTKey : (config.parametersDictionary ?: @{}) };
         id encodedObject = [[PFPointerObjectEncoder objectEncoder] encodeObject:configParameters];
         NSData *jsonData = [PFJSONSerialization dataFromJSONObject:encodedObject];
-        return [PFFileManager writeDataAsync:jsonData toFile:self.configFilePath];
+        return [[self _getPersistenceGroupAsync] continueWithSuccessBlock:^id(BFTask<id<PFPersistenceGroup>> *task) {
+            return [task.result setDataAsync:jsonData forKey:PFConfigCurrentConfigFileName_];
+        }];
     }];
 }
 
 - (BFTask *)clearCurrentConfigAsync {
     @weakify(self);
-    return [BFTask taskFromExecutor:_dataExecutor withBlock:^id{
+    return [_dataTaskQueue enqueue:^id(BFTask *_) {
         @strongify(self);
         _currentConfig = nil;
-        return [PFFileManager removeItemAtPathAsync:self.configFilePath];
+        return [[self.dataSource.persistenceController getPersistenceGroupAsync] continueWithSuccessBlock:^id(BFTask<id<PFPersistenceGroup>> *task) {
+            return [task.result removeDataAsyncForKey:PFConfigCurrentConfigFileName_];
+        }];
     }];
 }
 
 - (BFTask *)clearMemoryCachedCurrentConfigAsync {
-    return [BFTask taskFromExecutor:_dataExecutor withBlock:^id{
+    return [_dataTaskQueue enqueue:^id(BFTask *_) {
         _currentConfig = nil;
         return nil;
     }];
 }
 
-- (NSString *)configFilePath {
-    return [self.dataSource.fileManager parseDataItemPathForPathComponent:PFConfigCurrentConfigFileName_];
+///--------------------------------------
+#pragma mark - Data
+///--------------------------------------
+
+- (BFTask PF_GENERIC(PFConfig *)*)_loadConfigAsync {
+    return [[[self _getPersistenceGroupAsync] continueWithSuccessBlock:^id(BFTask<id<PFPersistenceGroup>> *task) {
+        return [task.result getDataAsyncForKey:PFConfigCurrentConfigFileName_];
+    }] continueWithSuccessBlock:^id(BFTask *task) {
+        if (task.result) {
+            NSDictionary *dictionary = [PFJSONSerialization JSONObjectFromData:task.result];
+            if (dictionary) {
+                NSDictionary *decodedDictionary = [[PFDecoder objectDecoder] decodeObject:dictionary];
+                return [[PFConfig alloc] initWithFetchedConfig:decodedDictionary];
+            }
+        }
+        return [[PFConfig alloc] init];
+    }];
+}
+
+///--------------------------------------
+#pragma mark - Convenience
+///--------------------------------------
+
+- (BFTask PF_GENERIC(id<PFPersistenceGroup>)*)_getPersistenceGroupAsync {
+    return [self.dataSource.persistenceController getPersistenceGroupAsync];
 }
 
 @end

--- a/Parse/Internal/PFCoreManager.h
+++ b/Parse/Internal/PFCoreManager.h
@@ -22,7 +22,8 @@ PFKeychainStoreProvider,
 PFFileManagerProvider,
 PFOfflineStoreProvider,
 PFKeyValueCacheProvider,
-PFInstallationIdentifierStoreProvider>
+PFInstallationIdentifierStoreProvider,
+PFPersistenceControllerProvider>
 
 @property (nonatomic, strong, readonly) PFInstallationIdentifierStore *installationIdentifierStore;
 


### PR DESCRIPTION
This moves all PFConfig related code to use persistence groups instead of file manager APIs.
Including PFCurrentConfigController, PFConfigController.

Depends on #492.