### PR TITLE
Made all accesses to PFSQLiteDatabaseResult & Statement thread-safe.

### DIFF
--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PFSQLiteDatabaseResult : NSObject
 
-- (instancetype)initWithStatement:(PFSQLiteStatement *)statement;
+- (instancetype)initWithStatement:(PFSQLiteStatement *)statement queue:(dispatch_queue_t)queue;
 
 /*!
  Move current result to next row. Returns true if next result exists. False if current result

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.m
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.m
@@ -12,11 +12,13 @@
 #import <sqlite3.h>
 
 #import "PFSQLiteStatement.h"
+#import "PFThreadsafety.h"
 
 @interface PFSQLiteDatabaseResult ()
 
 @property (nonatomic, copy, readonly) NSDictionary *columnNameToIndexMap;
 @property (nonatomic, strong, readonly) PFSQLiteStatement *statement;
+@property (nonatomic, strong, readonly) dispatch_queue_t databaseQueue;
 
 @end
 
@@ -24,9 +26,10 @@
 
 @synthesize columnNameToIndexMap = _columnNameToIndexMap;
 
-- (instancetype)initWithStatement:(PFSQLiteStatement *)stmt {
+- (instancetype)initWithStatement:(PFSQLiteStatement *)stmt queue:(dispatch_queue_t)queue {
     if ((self = [super init])) {
         _statement = stmt;
+        _databaseQueue = queue;
     }
     return self;
 }
@@ -36,7 +39,9 @@
 }
 
 - (int)step {
-    return sqlite3_step([self.statement sqliteStatement]);
+    return PFThreadSafetyPerform(_databaseQueue, ^{
+        return sqlite3_step([self.statement sqliteStatement]);
+    });
 }
 
 - (BOOL)close {
@@ -48,7 +53,9 @@
 }
 
 - (int)intForColumnIndex:(int)columnIndex {
-    return sqlite3_column_int([self.statement sqliteStatement], columnIndex);
+    return PFThreadSafetyPerform(_databaseQueue, ^{
+        return sqlite3_column_int([self.statement sqliteStatement], columnIndex);
+    });
 }
 
 - (long)longForColumn:(NSString *)columnName {
@@ -56,7 +63,9 @@
 }
 
 - (long)longForColumnIndex:(int)columnIndex {
-    return (long)sqlite3_column_int64([self.statement sqliteStatement], columnIndex);
+    return PFThreadSafetyPerform(_databaseQueue, ^{
+        return (long)sqlite3_column_int64([self.statement sqliteStatement], columnIndex);
+    });
 }
 
 - (BOOL)boolForColumn:(NSString *)columnName {
@@ -64,7 +73,9 @@
 }
 
 - (BOOL)boolForColumnIndex:(int)columnIndex {
-    return ([self intForColumnIndex:columnIndex] != 0);
+    return PFThreadSafetyPerform(_databaseQueue, ^{
+        return ([self intForColumnIndex:columnIndex] != 0);
+    });
 }
 
 - (double)doubleForColumn:(NSString *)columnName {
@@ -72,7 +83,9 @@
 }
 
 - (double)doubleForColumnIndex:(int)columnIndex {
-    return sqlite3_column_double([self.statement sqliteStatement], columnIndex);
+    return PFThreadSafetyPerform(_databaseQueue, ^{
+        return sqlite3_column_double([self.statement sqliteStatement], columnIndex);
+    });
 }
 
 - (NSString *)stringForColumn:(NSString *)columnName {
@@ -80,15 +93,17 @@
 }
 
 - (NSString *)stringForColumnIndex:(int)columnIndex {
-    if ([self columnIndexIsNull:columnIndex]) {
-        return nil;
-    }
+    return PFThreadSafetyPerform(_databaseQueue, ^NSString *{
+        if ([self columnIndexIsNull:columnIndex]) {
+            return nil;
+        }
 
-    const char *str = (const char *)sqlite3_column_text([self.statement sqliteStatement], columnIndex);
-    if (!str) {
-        return nil;
-    }
-    return [NSString stringWithUTF8String:str];
+        const char *str = (const char *)sqlite3_column_text([self.statement sqliteStatement], columnIndex);
+        if (!str) {
+            return nil;
+        }
+        return [NSString stringWithUTF8String:str];
+    });
 }
 
 - (NSDate *)dateForColumn:(NSString *)columnName {
@@ -105,16 +120,18 @@
 }
 
 - (NSData *)dataForColumnIndex:(int)columnIndex {
-    if ([self columnIndexIsNull:columnIndex]) {
-        return nil;
-    }
+    return PFThreadSafetyPerform(_databaseQueue, ^NSData *{
+        if ([self columnIndexIsNull:columnIndex]) {
+            return nil;
+        }
 
-    int size = sqlite3_column_bytes([self.statement sqliteStatement], columnIndex);
-    const char *buffer = sqlite3_column_blob([self.statement sqliteStatement], columnIndex);
-    if (buffer == nil) {
-        return nil;
-    }
-    return [NSData dataWithBytes:buffer length:size];
+        int size = sqlite3_column_bytes([self.statement sqliteStatement], columnIndex);
+        const char *buffer = sqlite3_column_blob([self.statement sqliteStatement], columnIndex);
+        if (buffer == nil) {
+            return nil;
+        }
+        return [NSData dataWithBytes:buffer length:size];
+    });
 }
 
 - (id)objectForColumn:(NSString *)columnName {
@@ -122,17 +139,19 @@
 }
 
 - (id)objectForColumnIndex:(int)columnIndex {
-    int columnType = sqlite3_column_type([self.statement sqliteStatement], columnIndex);
-    switch (columnType) {
-        case SQLITE_INTEGER:
-            return @([self longForColumnIndex:columnIndex]);
-        case SQLITE_FLOAT:
-            return @([self doubleForColumnIndex:columnIndex]);
-        case SQLITE_BLOB:
-            return [self dataForColumnIndex:columnIndex];
-        default:
-            return [self stringForColumnIndex:columnIndex];
-    }
+    return PFThreadSafetyPerform(_databaseQueue, ^id{
+        int columnType = sqlite3_column_type([self.statement sqliteStatement], columnIndex);
+        switch (columnType) {
+            case SQLITE_INTEGER:
+                return @([self longForColumnIndex:columnIndex]);
+            case SQLITE_FLOAT:
+                return @([self doubleForColumnIndex:columnIndex]);
+            case SQLITE_BLOB:
+                return [self dataForColumnIndex:columnIndex];
+            default:
+                return [self stringForColumnIndex:columnIndex];
+        }
+    });
 }
 
 - (BOOL)columnIsNull:(NSString *)columnName {
@@ -140,7 +159,9 @@
 }
 
 - (BOOL)columnIndexIsNull:(int)columnIndex {
-    return (sqlite3_column_type([self.statement sqliteStatement], columnIndex) == SQLITE_NULL);
+    return PFThreadSafetyPerform(_databaseQueue, ^{
+        return (sqlite3_column_type([self.statement sqliteStatement], columnIndex) == SQLITE_NULL);
+    });
 }
 
 - (int)columnIndexForName:(NSString *)columnName {
@@ -154,13 +175,15 @@
 
 - (NSDictionary *)columnNameToIndexMap {
     if (!_columnNameToIndexMap) {
-        int columnCount = sqlite3_column_count([self.statement sqliteStatement]);
-        NSMutableDictionary *mutableColumnNameToIndexMap = [[NSMutableDictionary alloc] initWithCapacity:columnCount];
-        for (int i = 0; i < columnCount; ++i) {
-            NSString *key = [NSString stringWithUTF8String:sqlite3_column_name([self.statement sqliteStatement], i)];
-            mutableColumnNameToIndexMap[[key lowercaseString]] = @(i);
-        }
-        _columnNameToIndexMap = mutableColumnNameToIndexMap;
+        PFThreadsafetySafeDispatchSync(_databaseQueue, ^{
+            int columnCount = sqlite3_column_count([self.statement sqliteStatement]);
+            NSMutableDictionary *mutableColumnNameToIndexMap = [[NSMutableDictionary alloc] initWithCapacity:columnCount];
+            for (int i = 0; i < columnCount; ++i) {
+                NSString *key = [NSString stringWithUTF8String:sqlite3_column_name([self.statement sqliteStatement], i)];
+                mutableColumnNameToIndexMap[[key lowercaseString]] = @(i);
+            }
+            _columnNameToIndexMap = mutableColumnNameToIndexMap;
+        });
     }
     return _columnNameToIndexMap;
 }

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteStatement.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteStatement.h
@@ -18,9 +18,10 @@ typedef struct sqlite3_stmt sqlite3_stmt;
 
 @interface PFSQLiteStatement : NSObject
 
-@property (atomic, assign, readonly) sqlite3_stmt *sqliteStatement;
+@property (nonatomic, assign, readonly) sqlite3_stmt *sqliteStatement;
+@property (nonatomic, strong, readonly) dispatch_queue_t databaseQueue;
 
-- (instancetype)initWithStatement:(sqlite3_stmt *)stmt;
+- (instancetype)initWithStatement:(sqlite3_stmt *)stmt queue:(dispatch_queue_t)databaseQueue;
 
 - (BOOL)close;
 - (BOOL)reset;

--- a/Parse/Internal/ThreadSafety/PFThreadsafety.h
+++ b/Parse/Internal/ThreadSafety/PFThreadsafety.h
@@ -11,3 +11,11 @@
 
 extern dispatch_queue_t PFThreadsafetyCreateQueueForObject(id object);
 extern void PFThreadsafetySafeDispatchSync(dispatch_queue_t queue, dispatch_block_t block);
+
+
+// PFThreadsafetySafeDispatchSync, but with a return type.
+#define PFThreadSafetyPerform(queue, block) ({                      \
+    __block typeof((block())) result;                              \
+    PFThreadsafetySafeDispatchSync(queue, ^{ result = block(); }); \
+    result;                                                        \
+})


### PR DESCRIPTION
I think this is what was causing the crashes seen in #290, but I'm not 100% sure.

At the very least, accessing them this way was in violation of the SQLite spec.