### PR TITLE
Remove any migration of data from old deprecated location.

### DIFF
--- a/Parse/Internal/PFFileManager.h
+++ b/Parse/Internal/PFFileManager.h
@@ -63,7 +63,6 @@ typedef NS_OPTIONS(uint8_t, PFFileManagerOptions) {
  */
 - (NSString *)parseDefaultDataDirectoryPath;
 - (NSString *)parseLocalSandboxDataDirectoryPath;
-- (NSString *)parseDataDirectoryPath_DEPRECATED;
 
 /*!
  The path including directories that we save data to for a given filename.

--- a/Parse/Internal/PFFileManager.m
+++ b/Parse/Internal/PFFileManager.m
@@ -290,43 +290,8 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
 #endif
 }
 
-- (NSString *)parseDataDirectoryPath_DEPRECATED {
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString *documentsDirectory = [paths objectAtIndex:0]; // Get documents folder
-    NSString *parseDirPath = [documentsDirectory stringByAppendingPathComponent:_PFFileManagerParseDirectoryName];
-
-    // If this old directory is still on disk, but empty, delete it.
-    if ([[NSFileManager defaultManager] fileExistsAtPath:parseDirPath]) {
-        NSError *error = nil;
-        NSArray *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:parseDirPath error:&error];
-        if (error == nil && [contents count] == 0) {
-            [[NSFileManager defaultManager] removeItemAtPath:parseDirPath error:nil];
-        }
-    }
-
-    return parseDirPath;
-}
-
 - (NSString *)parseDataItemPathForPathComponent:(NSString *)pathComponent {
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-
-    NSString *currentLocation = [[self parseDefaultDataDirectoryPath] stringByAppendingPathComponent:pathComponent];
-    if (![fileManager fileExistsAtPath:currentLocation]) {
-        NSString *deprecatedDir = [self parseDataDirectoryPath_DEPRECATED];
-        NSString *deprecatedLocation = [deprecatedDir stringByAppendingPathComponent:pathComponent];
-        if ([fileManager fileExistsAtPath:deprecatedLocation]) {
-            [fileManager moveItemAtPath:deprecatedLocation toPath:currentLocation error:nil];
-            // If the deprecated dir is still on disk, delete it.
-            if ([fileManager fileExistsAtPath:deprecatedDir]) {
-                NSError *error = nil;
-                NSArray *contents = [fileManager contentsOfDirectoryAtPath:deprecatedDir error:&error];
-                if (!error && [contents count] == 0) {
-                    [fileManager removeItemAtPath:deprecatedDir error:nil];
-                }
-            }
-        }
-    }
-    return currentLocation;
+    return [[self parseDefaultDataDirectoryPath] stringByAppendingPathComponent:pathComponent];
 }
 
 - (NSString *)parseCacheItemPathForPathComponent:(NSString *)component {

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -278,9 +278,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
                 [self.keychainStore removeAllObjects];
                 [self.keyValueCache removeAllObjects];
             }
-            NSArray *tasks = @[ [group removeAllDataAsync],
-                                [PFFileManager removeItemAtPathAsync:[self.fileManager parseDataDirectoryPath_DEPRECATED]] ];
-            return [[BFTask taskForCompletionOfAllTasks:tasks] continueWithSuccessBlock:^id(BFTask *task) {
+            return [[group removeAllDataAsync] continueWithSuccessBlock:^id(BFTask *task) {
                 NSData *applicationIdData = [self.applicationId dataUsingEncoding:NSUTF8StringEncoding];
                 return [group setDataAsync:applicationIdData forKey:_ParseApplicationIdFileName];
             }];


### PR DESCRIPTION
This migration was first implemented in version 0.4.38 of the iOS SDK, according to the version notes and was released around Feb 2012.
We are going to remove this code, so any application upgrading from a version < 0.4.38 will not migrate the data any more.

Since 0.4.38 and 1.10.0 (next version) has at least one major version difference, I feel we should make this call.
Please note that this is going to improve the performance of reading anything from disk, as we are not going to hit the lookup of deprecated path anymore.
Plus, it's going to get so much easier to maintain, as we move to Persistence Groups (disk/UserDefaults for tvOS).

cc @grantland @stanleyw @hallucinogen