### PR TITLE
Rewrite InstallationIdentifierStore to use Persistence groups and be fully async.

### DIFF
--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
@@ -9,8 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 #import "PFDataProvider.h"
 
+@class BFTask PF_GENERIC(BFGenericType);
 @class PFRESTCommand;
 
 @interface PFCommandURLRequestConstructor : NSObject
@@ -29,15 +32,15 @@
 /// @name Data
 ///--------------------------------------
 
-- (NSURLRequest *)dataURLRequestForCommand:(PFRESTCommand *)command;
+- (BFTask PF_GENERIC(NSURLRequest *)*)getDataURLRequestAsyncForCommand:(PFRESTCommand *)command;
 
 ///--------------------------------------
 /// @name File Upload
 ///--------------------------------------
 
-- (NSURLRequest *)fileUploadURLRequestForCommand:(PFRESTCommand *)command
-                                 withContentType:(NSString *)contentType
-                           contentSourceFilePath:(NSString *)contentFilePath;
+- (BFTask PF_GENERIC(NSURLRequest *)*)getFileUploadURLRequestAsyncForCommand:(PFRESTCommand *)command
+                                                             withContentType:(NSString *)contentType
+                                                       contentSourceFilePath:(NSString *)contentFilePath;
 
 ///--------------------------------------
 /// @name Headers

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -121,8 +121,9 @@
                                        cancellationToken:(BFCancellationToken *)cancellationToken {
     return [self _performCommandRunningBlock:^id {
         [command resolveLocalIds];
-        NSURLRequest *request = [self.requestConstructor dataURLRequestForCommand:command];
-        return [_session performDataURLRequestAsync:request forCommand:command cancellationToken:cancellationToken];
+        return [[self.requestConstructor getDataURLRequestAsyncForCommand:command] continueWithSuccessBlock:^id(BFTask PF_GENERIC(NSURLRequest *)*task) {
+            return [_session performDataURLRequestAsync:task.result forCommand:command cancellationToken:cancellationToken];
+        }];
     } withOptions:options cancellationToken:cancellationToken];
 }
 
@@ -141,15 +142,15 @@
         @strongify(self);
 
         [command resolveLocalIds];
-        NSURLRequest *request = [self.requestConstructor fileUploadURLRequestForCommand:command
-                                                                        withContentType:contentType
-                                                                  contentSourceFilePath:sourceFilePath];
-        return [_session performFileUploadURLRequestAsync:request
-                                               forCommand:command
-                                withContentSourceFilePath:sourceFilePath
-                                        cancellationToken:cancellationToken
-                                            progressBlock:progressBlock];
-
+        return [[self.requestConstructor getFileUploadURLRequestAsyncForCommand:command
+                                                               withContentType:contentType
+                                                          contentSourceFilePath:sourceFilePath] continueWithSuccessBlock:^id(BFTask PF_GENERIC(NSURLRequest *)*task) {
+            return [_session performFileUploadURLRequestAsync:task.result
+                                                   forCommand:command
+                                    withContentSourceFilePath:sourceFilePath
+                                            cancellationToken:cancellationToken
+                                                progressBlock:progressBlock];
+        }];
     } withOptions:options cancellationToken:cancellationToken];
 }
 

--- a/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.m
+++ b/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.m
@@ -106,7 +106,8 @@ NSString *const PFCurrentInstallationPinName = @"_currentInstallation";
             }
 
             PFInstallation *installation = task.result;
-            NSString *installationId = self.installationIdentifierStore.installationIdentifier;
+            //TODO: (nlutsenko) Make it not terrible aka actually use task chaining here.
+            NSString *installationId = [[self.installationIdentifierStore getInstallationIdentifierAsync] waitForResult:nil];
             installationId = [installationId  lowercaseString];
             if (!installation || ![installationId isEqualToString:installation.installationId]) {
                 // If there's no installation object, or the object's installation

--- a/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.h
+++ b/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.h
@@ -9,23 +9,31 @@
 
 #import <Foundation/Foundation.h>
 
-@class PFFileManager;
+#import "PFDataProvider.h"
+
+#import <Parse/PFConstants.h>
+
+@class BFTask PF_GENERIC(BFGenericType);
 
 @interface PFInstallationIdentifierStore : NSObject
 
-/*!
- Returns a cached installationId or creates a new one, saves it to disk and returns it.
-
- @returns `NSString` representation of current installationId.
- */
-@property (nonatomic, copy, readonly) NSString *installationIdentifier;
+@property (nonatomic, weak, readonly) id<PFPersistenceControllerProvider> dataSource;
 
 ///--------------------------------------
 /// @name Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithFileManager:(PFFileManager *)fileManager NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
+
+///--------------------------------------
+/// @name Accessors
+///--------------------------------------
+
+/*!
+ Returns a cached installationId or creates a new one, saves it to disk and returns it.
+ */
+- (BFTask PF_GENERIC(NSString *)*)getInstallationIdentifierAsync;
 
 ///--------------------------------------
 /// @name Clear
@@ -34,6 +42,6 @@
 /*!
  Clears installation identifier on disk and in-memory.
  */
-- (void)clearInstallationIdentifier;
+- (BFTask *)clearInstallationIdentifierAsync;
 
 @end

--- a/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore_Private.h
+++ b/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore_Private.h
@@ -14,6 +14,6 @@
 /*!
  Clears in-memory cached installation identifier, if any.
  */
-- (void)_clearCachedInstallationIdentifier;
+- (BFTask *)_clearCachedInstallationIdentifierAsync;
 
 @end

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -299,7 +299,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
     __block PFInstallationIdentifierStore *store = nil;
     dispatch_sync(_installationIdentifierStoreAccessQueue, ^{
         if (!_installationIdentifierStore) {
-            _installationIdentifierStore = [[PFInstallationIdentifierStore alloc] initWithFileManager:self.fileManager];
+            _installationIdentifierStore = [[PFInstallationIdentifierStore alloc] initWithDataSource:self];
         }
         store = _installationIdentifierStore;
     });

--- a/Tests/Unit/ConfigControllerTests.m
+++ b/Tests/Unit/ConfigControllerTests.m
@@ -16,7 +16,6 @@
 #import "PFCommandRunning.h"
 #import "PFConfig.h"
 #import "PFConfigController.h"
-#import "PFFileManager.h"
 #import "PFTestCase.h"
 
 @interface ConfigControllerTests : PFTestCase

--- a/Tests/Unit/FileUnitTests.m
+++ b/Tests/Unit/FileUnitTests.m
@@ -13,7 +13,6 @@
 
 #import "PFCoreManager.h"
 #import "PFFileController.h"
-#import "PFFileManager.h"
 #import "PFFileStagingController.h"
 #import "PFFileState.h"
 #import "PFFile_Private.h"

--- a/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -63,7 +63,7 @@
 
     OCMStub([mockedCommand resolveLocalIds]);
 
-    OCMStub([mockedRequestConstructor dataURLRequestForCommand:mockedCommand]).andReturn(urlRequest);
+    OCMStub([mockedRequestConstructor getDataURLRequestAsyncForCommand:mockedCommand]).andReturn([BFTask taskWithResult:urlRequest]);
     [OCMExpect([mockedSession performDataURLRequestAsync:urlRequest
                                               forCommand:mockedCommand
                                        cancellationToken:nil]) andReturn:[BFTask taskWithResult:mockedCommandResult]];
@@ -133,7 +133,7 @@
     __block int performDataURLRequestCount = 0;
 
     OCMStub([mockedCommand resolveLocalIds]);
-    OCMStub([mockedRequestConstructor dataURLRequestForCommand:mockedCommand]).andReturn(urlRequest);
+    OCMStub([mockedRequestConstructor getDataURLRequestAsyncForCommand:mockedCommand]).andReturn([BFTask taskWithResult:urlRequest]);
 
     [OCMStub([mockedSession performDataURLRequestAsync:urlRequest
                                             forCommand:mockedCommand
@@ -183,9 +183,9 @@
 
     OCMStub([mockedCommand resolveLocalIds]);
 
-    OCMExpect([mockedRequestConstructor fileUploadURLRequestForCommand:mockedCommand
-                                                       withContentType:@"content-type"
-                                                 contentSourceFilePath:@"content-path"]).andReturn(urlRequest);
+    OCMExpect([mockedRequestConstructor getFileUploadURLRequestAsyncForCommand:mockedCommand
+                                                               withContentType:@"content-type"
+                                                         contentSourceFilePath:@"content-path"]).andReturn([BFTask taskWithResult:urlRequest]);
 
     [OCMExpect([mockedSession performFileUploadURLRequestAsync:urlRequest
                                                     forCommand:mockedCommand
@@ -230,7 +230,7 @@
 
     OCMExpect([mockedCommand resolveLocalIds]);
 
-    OCMStub([mockedRequestConstructor dataURLRequestForCommand:mockedCommand]).andReturn(urlRequest);
+    OCMStub([mockedRequestConstructor getDataURLRequestAsyncForCommand:mockedCommand]).andReturn([BFTask taskWithResult:urlRequest]);
     [OCMStub([mockedSession performDataURLRequestAsync:urlRequest
                                             forCommand:mockedCommand
                                      cancellationToken:nil]) andReturn:[BFTask taskWithResult:mockedCommandResult]];


### PR DESCRIPTION
- Rewrite InstallationIdentifierStore to use persistence groups and use tasks.
- Update CommandURLRequestContructor accommodating the change, also convert to task-based system.
- Update CurrentInstallationController accommodating the change.
- Update all the tests.

Contributes to #250