### PR TITLE
Convert getters/setters of public read/write access on PFACL to properties.

### DIFF
--- a/Parse/PFACL.h
+++ b/Parse/PFACL.h
@@ -45,32 +45,14 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /*!
- @abstract Set whether the public is allowed to read this object.
-
- @param allowed Whether the public can read this object.
+ @abstract Controls whether the public is allowed to read this object.
  */
-- (void)setPublicReadAccess:(BOOL)allowed;
+@property (nonatomic, assign, getter=getPublicReadAccess) BOOL publicReadAccess;
 
 /*!
- @abstract Gets whether the public is allowed to read this object.
-
- @returns `YES` if the public read access is enabled, otherwise `NO`.
+ @abstract Controls whether the public is allowed to write this object.
  */
-- (BOOL)getPublicReadAccess;
-
-/*!
- @abstract Set whether the public is allowed to write this object.
-
- @param allowed Whether the public can write this object.
- */
-- (void)setPublicWriteAccess:(BOOL)allowed;
-
-/*!
- @abstract Gets whether the public is allowed to write this object.
-
- @returns `YES` if the public write access is enabled, otherwise `NO`.
- */
-- (BOOL)getPublicWriteAccess;
+@property (nonatomic, assign, getter=getPublicWriteAccess) BOOL publicWriteAccess;
 
 ///--------------------------------------
 /// @name Controlling Access Per-User

--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
@@ -30,7 +30,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let defaultACL: PFACL = PFACL()
         // If you would like all objects to be private by default, remove this line.
-        defaultACL.setPublicReadAccess(true)
+        defaultACL.publicReadAccess = true
 
         PFACL.setDefaultACL(defaultACL, withAccessForCurrentUser: true)
 

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
@@ -49,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let defaultACL = PFACL();
 
         // If you would like all objects to be private by default, remove this line.
-        defaultACL.setPublicReadAccess(true)
+        defaultACL.publicReadAccess = true
 
         PFACL.setDefaultACL(defaultACL, withAccessForCurrentUser:true)
 


### PR DESCRIPTION
Realized that we can use properties for this, instead of having 2 distinct methods.
Maps waaaay better to Swift code.