### PR TITLE
Properly annotate pinningObjectStore provider property.

### DIFF
--- a/Parse/Internal/PFDataProvider.h
+++ b/Parse/Internal/PFDataProvider.h
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol PFPinningObjectStoreProvider <NSObject>
 
-@property (nonatomic, strong) PFPinningObjectStore *pinningObjectStore;
+@property (null_resettable, nonatomic, strong) PFPinningObjectStore *pinningObjectStore;
 
 @end
 


### PR DESCRIPTION
This one should be annotated with `null_resettable`, as we will always load it if it's nil.