### PR TITLE
Move PFUser.logOut() to use persistence groups.

### DIFF
--- a/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
+++ b/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
@@ -40,7 +40,7 @@
 
  @returns `BFTask` with `PFObject` or `nil` result.
  */
-- (BFTask *)loadPersistentObjectAsyncForKey:(NSString *)key;
+- (BFTask PF_GENERIC(PFObject *)*)loadPersistentObjectAsyncForKey:(NSString *)key;
 
 /*!
  Saves a given object to a file with name.
@@ -51,5 +51,14 @@
  @returns `BFTask` with `nil` result.
  */
 - (BFTask *)persistObjectAsync:(PFObject *)object forKey:(NSString *)key;
+
+/*!
+ Removes a given object.
+
+ @param key Key to use.
+
+ @return `BFTask` with `nil` result.
+ */
+- (BFTask *)removePersistentObjectAsyncForKey:(NSString *)key;
 
 @end

--- a/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.m
+++ b/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.m
@@ -44,7 +44,7 @@
 #pragma mark - Objects
 ///--------------------------------------
 
-- (BFTask *)loadPersistentObjectAsyncForKey:(NSString *)key {
+- (BFTask PF_GENERIC(PFObject *)*)loadPersistentObjectAsyncForKey:(NSString *)key {
     return [[self _getPersistenceGroupAsync] continueWithSuccessBlock:^id(BFTask PF_GENERIC(id<PFPersistenceGroup>)*task) {
         id<PFPersistenceGroup> group = task.result;
         __block PFObject *object = nil;
@@ -72,6 +72,17 @@
             NSData *data = [PFObjectFileCoder dataFromObject:object usingEncoder:[PFPointerObjectEncoder objectEncoder]];
             return [group setDataAsync:data forKey:key];
         }] continueWithBlock:^id(BFTask *task) {
+            return [group endLockedContentAccessAsyncToDataForKey:key];
+        }];
+    }];
+}
+
+- (BFTask *)removePersistentObjectAsyncForKey:(NSString *)key {
+    return [[self _getPersistenceGroupAsync] continueWithSuccessBlock:^id(BFTask PF_GENERIC(id<PFPersistenceGroup>)*task) {
+        id<PFPersistenceGroup> group = task.result;
+        return [[[group beginLockedContentAccessAsyncToDataForKey:key] continueWithSuccessBlock:^id(BFTask *_) {
+            return [group removeDataAsyncForKey:key];
+        }] continueWithBlock:^id(BFTask *_) {
             return [group endLockedContentAccessAsyncToDataForKey:key];
         }];
     }];

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
@@ -25,7 +25,7 @@ typedef NS_OPTIONS(NSUInteger, PFCurrentUserLoadingOptions) {
 
 @interface PFCurrentUserController : NSObject <PFCurrentObjectControlling>
 
-@property (nonatomic, weak, readonly) id<PFKeychainStoreProvider, PFFileManagerProvider> commonDataSource;
+@property (nonatomic, weak, readonly) id<PFKeychainStoreProvider> commonDataSource;
 @property (nonatomic, weak, readonly) id<PFObjectFilePersistenceControllerProvider> coreDataSource;
 
 @property (atomic, assign) BOOL automaticUsersEnabled;
@@ -36,10 +36,10 @@ typedef NS_OPTIONS(NSUInteger, PFCurrentUserLoadingOptions) {
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithStorageType:(PFCurrentObjectStorageType)storageType
-                   commonDataSource:(id<PFKeychainStoreProvider, PFFileManagerProvider>)commonDataSource
+                   commonDataSource:(id<PFKeychainStoreProvider>)commonDataSource
                      coreDataSource:(id<PFObjectFilePersistenceControllerProvider>)coreDataSource NS_DESIGNATED_INITIALIZER;
 + (instancetype)controllerWithStorageType:(PFCurrentObjectStorageType)storageType
-                         commonDataSource:(id<PFKeychainStoreProvider, PFFileManagerProvider>)commonDataSource
+                         commonDataSource:(id<PFKeychainStoreProvider>)commonDataSource
                            coreDataSource:(id<PFObjectFilePersistenceControllerProvider>)coreDataSource;
 
 ///--------------------------------------

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
@@ -15,7 +15,6 @@
 #import "PFAnonymousUtils_Private.h"
 #import "PFAssert.h"
 #import "PFAsyncTaskQueue.h"
-#import "PFFileManager.h"
 #import "PFKeychainStore.h"
 #import "PFMutableUserState.h"
 #import "PFObjectFilePersistenceController.h"
@@ -47,7 +46,7 @@
 }
 
 - (instancetype)initWithStorageType:(PFCurrentObjectStorageType)storageType
-                   commonDataSource:(id<PFKeychainStoreProvider, PFFileManagerProvider>)commonDataSource
+                   commonDataSource:(id<PFKeychainStoreProvider>)commonDataSource
                      coreDataSource:(id<PFObjectFilePersistenceControllerProvider>)coreDataSource {
     self = [super init];
     if (!self) return nil;
@@ -63,7 +62,7 @@
 }
 
 + (instancetype)controllerWithStorageType:(PFCurrentObjectStorageType)dataStorageType
-                         commonDataSource:(id<PFKeychainStoreProvider, PFFileManagerProvider>)commonDataSource
+                         commonDataSource:(id<PFKeychainStoreProvider>)commonDataSource
                            coreDataSource:(id<PFObjectFilePersistenceControllerProvider>)coreDataSource {
     return [[self alloc] initWithStorageType:dataStorageType
                             commonDataSource:commonDataSource
@@ -185,8 +184,7 @@
                 userLogoutTask = [BFTask taskWithResult:nil];
             }
 
-            NSString *filePath = [self.commonDataSource.fileManager parseDataItemPathForPathComponent:PFUserCurrentUserFileName];
-            BFTask *fileTask = [PFFileManager removeItemAtPathAsync:filePath];
+            BFTask *fileTask = [self.coreDataSource.objectFilePersistenceController removePersistentObjectAsyncForKey:PFUserCurrentUserFileName];
             BFTask *unpinTask = nil;
 
             if (self.storageType == PFCurrentObjectStorageTypeOfflineStore) {

--- a/Tests/Unit/ObjectFilePersistenceControllerTests.m
+++ b/Tests/Unit/ObjectFilePersistenceControllerTests.m
@@ -121,4 +121,25 @@
     OCMVerifyAll(group);
 }
 
+- (void)testRemovePersistenceObjectForKey {
+    id dataSource = [self mockedDataSource];
+    id group = [[[dataSource persistenceController] getPersistenceGroupAsync] waitForResult:nil];
+
+    OCMExpect([group beginLockedContentAccessAsyncToDataForKey:@"object"]).andReturn([BFTask taskWithResult:nil]);
+    OCMExpect([group removeDataAsyncForKey:@"object"]).andReturn([BFTask taskWithResult:nil]);
+    OCMExpect([group endLockedContentAccessAsyncToDataForKey:@"object"]).andReturn([BFTask taskWithResult:nil]);
+
+    PFObjectFilePersistenceController *controller = [PFObjectFilePersistenceController controllerWithDataSource:dataSource];
+
+    XCTestExpectation *expectation = [self currentSelectorTestExpectation];
+    [[controller removePersistentObjectAsyncForKey:@"object"] continueWithSuccessBlock:^id(BFTask *task) {
+        XCTAssertNil(task.result);
+        [expectation fulfill];
+        return nil;
+    }];
+    [self waitForTestExpectations];
+
+    OCMVerifyAll(group);
+}
+
 @end


### PR DESCRIPTION
- PFUser.logOut() now uses persistence groups
- Added method for removing object to PFObjectFilePersistenceController
- Added test for new method
- Removed requirement for PFFileManager from PFCurrentUserController

Contributes to #250.