### PR TITLE
Convert isDataAvailable, isDirty, allKeys methods in PFObject to properties.

### DIFF
--- a/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.m
+++ b/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.m
@@ -90,7 +90,7 @@ NSString *const PFCurrentInstallationPinName = @"_currentInstallation";
                         // If there is no objectId, but there is some data
                         // it means that the data wasn't yet saved to the server
                         // so we should mark everything as dirty
-                        if (!installation.objectId && [[installation allKeys] count]) {
+                        if (!installation.objectId && installation.allKeys.count) {
                             [installation _markAllFieldsDirty];
                         }
                     }

--- a/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
+++ b/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
@@ -133,7 +133,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
         PFObject *object = (PFObject *)container;
 
         // The object needs to have been fetched already if we are going to sort by one of its field.
-        PFParameterAssert(object.isDataAvailable, @"Bad key %@", key);
+        PFParameterAssert(object.dataAvailable, @"Bad key %@", key);
 
         // Handle special keys for PFObject.
         if ([key isEqualToString:@"objectId"]) {

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -376,7 +376,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
 - (BFTask *)saveObjectLocallyAsync:(PFObject *)object
                                key:(NSString *)key
                           database:(PFSQLiteDatabase *)database {
-    if ([object objectId] != nil && ![object isDataAvailable] &&
+    if ([object objectId] != nil && !object.dataAvailable &&
         ![object _hasChanges] && ![object _hasOutstandingOperations]) {
         return [BFTask taskWithResult:nil];
     }
@@ -530,7 +530,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
                 object = task.result;
                 return [self fetchObjectLocallyAsync:object database:database];
             }] continueWithSuccessBlock:^id(BFTask *task) {
-                if (!object.isDataAvailable) {
+                if (!object.dataAvailable) {
                     return [BFTask taskWithResult:@NO];
                 }
                 return matcherBlock(object, database);

--- a/Parse/Internal/Object/BatchController/PFObjectBatchController.m
+++ b/Parse/Internal/Object/BatchController/PFObjectBatchController.m
@@ -190,7 +190,7 @@
     NSString *className = [objects.firstObject parseClassName];
     for (PFObject *object in objects) {
         @synchronized (object.lock) {
-            if (omitFetched && [object isDataAvailable]) {
+            if (omitFetched && object.dataAvailable) {
                 continue;
             }
 

--- a/Parse/Internal/PFInternalUtils.m
+++ b/Parse/Internal/PFInternalUtils.m
@@ -202,7 +202,7 @@ static NSString *parseServer_;
         }
         [seen addObject:object];
 
-        for (NSString *key in [(PFObject *)object allKeys]) {
+        for (NSString *key in ((PFObject *)object).allKeys) {
             [self traverseObject:object[key] usingBlock:block seenObjects:seen];
         }
 

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -838,7 +838,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @returns Returns whether this object has been altered and not saved yet.
  */
-- (BOOL)isDirty;
+@property (nonatomic, assign, readonly, getter=isDirty) BOOL dirty;
 
 /*!
  @abstract Get whether a value associated with a key has been added/updated/removed and not saved yet.

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -495,7 +495,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @returns `YES` if the PFObject is new or has been fetched or refreshed, otherwise `NO`.
  */
-- (BOOL)isDataAvailable;
+@property (nonatomic, assign, readonly, getter=isDataAvailable) BOOL dataAvailable;
 
 #if PARSE_IOS_ONLY
 

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -125,7 +125,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @discussion This does not include `createdAt`, `updatedAt`, `authData`, or `objectId`.
  It does include things like username and ACL.
  */
-- (NSArray PF_GENERIC(NSString *)*)allKeys;
+@property (nonatomic, copy, readonly) NSArray PF_GENERIC(NSString *)*allKeys;
 
 ///--------------------------------------
 /// @name Accessors

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -2199,7 +2199,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (void)revert {
     @synchronized (self.lock) {
-        if ([self isDirty]) {
+        if (self.dirty) {
             NSMutableSet *persistentKeys = [NSMutableSet setWithArray:[self._state.serverData allKeys]];
 
             PFOperationSet *unsavedChanges = [self unsavedChanges];

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -709,7 +709,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }
 
     @synchronized (lock) {
-        if ([self isDataAvailable]) {
+        if (self.dataAvailable) {
             return YES;
         }
         return [_availableKeys containsObject:key];
@@ -1563,7 +1563,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
             if ([obj isKindOfClass:[PFObject class]]) {
                 PFObject *object = obj;
                 NSString *objectId = object.objectId;
-                if (objectId && [object isDataAvailable]) {
+                if (objectId && object.dataAvailable) {
                     fetchedObjects[objectId] = object;
                 }
             }
@@ -2035,7 +2035,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 }
 
 - (BFTask *)fetchIfNeededInBackground {
-    if ([self isDataAvailable]) {
+    if (self.dataAvailable) {
         return [BFTask taskWithResult:self];
     }
     return [self fetchInBackground];

--- a/Parse/PFSubclassing.h
+++ b/Parse/PFSubclassing.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  @abstract Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
- @discussion Calling <[PFObject isDataAvailable]> on this object will return `NO`
+ @discussion Calling <PFObject.dataAvailable> on this object will return `NO`
  until <[PFObject fetchIfNeeded]> has been called. No network request will be made.
  A default implementation is provided by PFObject which should always be sufficient.
 

--- a/Tests/Unit/ObjectBatchControllerTests.m
+++ b/Tests/Unit/ObjectBatchControllerTests.m
@@ -85,7 +85,7 @@
     [self waitForTestExpectations];
 
     XCTAssertEqualObjects(object[@"a"], @"b");
-    XCTAssertTrue([object isDataAvailable]);
+    XCTAssertTrue(object.dataAvailable);
     OCMVerifyAll(commandRunner);
 }
 
@@ -128,7 +128,7 @@
     [self waitForTestExpectations];
 
     XCTAssertEqualObjects(object[@"a"], @"b");
-    XCTAssertTrue([object isDataAvailable]);
+    XCTAssertTrue(object.dataAvailable);
     OCMVerifyAll(commandRunner);
 }
 

--- a/Tests/Unit/ObjectFileCoderTests.m
+++ b/Tests/Unit/ObjectFileCoderTests.m
@@ -41,7 +41,7 @@
     XCTAssertEqualObjects(object.parseClassName, @"Yolo");
     XCTAssertEqualObjects(object.objectId, @"100500");
     XCTAssertEqualObjects(object[@"yarr"], @"pff");
-    XCTAssertFalse(object.isDirty);
+    XCTAssertFalse(object.dirty);
 }
 
 @end

--- a/Tests/Unit/ObjectFileCodingLogicTests.m
+++ b/Tests/Unit/ObjectFileCodingLogicTests.m
@@ -40,7 +40,7 @@
     XCTAssertNotNil(object);
     XCTAssertEqualObjects(object.objectId, @"100500");
     XCTAssertEqualObjects(object[@"slogan"], @"yarr");
-    XCTAssertTrue(object.isDataAvailable);
+    XCTAssertTrue(object.dataAvailable);
 }
 
 - (void)testUpdateObjectWithLegacyKeys {
@@ -60,12 +60,12 @@
     XCTAssertEqualObjects(object.createdAt, [[PFDateFormatter sharedFormatter] dateFromString:dictionary[@"created_at"]]);
     XCTAssertEqualObjects(object.updatedAt, [[PFDateFormatter sharedFormatter] dateFromString:dictionary[@"updated_at"]]);
     XCTAssertEqualObjects(object[@"a"], @"b");
-    XCTAssertTrue(object.isDataAvailable);
+    XCTAssertTrue(object.dataAvailable);
 
     PFObject *pointer = object[@"yarr"];
     XCTAssertEqualObjects(pointer.parseClassName, @"Pirate");
     XCTAssertEqualObjects(pointer.objectId, @"pff");
-    XCTAssertFalse(pointer.isDataAvailable);
+    XCTAssertFalse(pointer.dataAvailable);
 }
 
 @end

--- a/Tests/Unit/ObjectSubclassPropertiesTests.m
+++ b/Tests/Unit/ObjectSubclassPropertiesTests.m
@@ -287,9 +287,9 @@
 - (void)testObjectPropertiesAreRemovedWhenNilled {
     PFTestObject *object = [[PFTestObject alloc] initWithClassName:@"Test"];
     object.stringCopyProperty = @"Hello, world!";
-    XCTAssertTrue([[object allKeys] containsObject:@"stringCopyProperty"]);
+    XCTAssertTrue([object.allKeys containsObject:@"stringCopyProperty"]);
     object.stringCopyProperty = nil;
-    XCTAssertFalse([[object allKeys] containsObject:@"stringCopyProperty"]);
+    XCTAssertFalse([object.allKeys containsObject:@"stringCopyProperty"]);
 }
 
 // I'm not so sure the mutator is a good idea, but it'd be good to ensure that at least the
@@ -297,10 +297,10 @@
 - (void)testObjectPropertiesDontChokeOnNSNull {
     PFTestObject *object = [[PFTestObject alloc] initWithClassName:@"Test"];
     object.stringCopyProperty = (NSString *)[NSNull null];
-    XCTAssertTrue([[object allKeys] containsObject:@"stringCopyProperty"]);
+    XCTAssertTrue([object.allKeys containsObject:@"stringCopyProperty"]);
     XCTAssertEqual((NSString *)nil, object.stringCopyProperty);
     object.stringCopyProperty = nil;
-    XCTAssertFalse([[object allKeys] containsObject:@"stringCopyProperty"]);
+    XCTAssertFalse([object.allKeys containsObject:@"stringCopyProperty"]);
 }
 
 - (void)testBoxedPropertiesDontChokeOnNSNull {

--- a/Tests/Unit/ObjectUnitTests.m
+++ b/Tests/Unit/ObjectUnitTests.m
@@ -268,7 +268,7 @@
                                           @"A" : objectA }
                                decoder:[PFDecoder objectDecoder]];
 
-    XCTAssertFalse([objectA isDirty]);
+    XCTAssertFalse(objectA.dirty);
 }
 
 @end

--- a/Tests/Unit/UserFileCodingLogicTests.m
+++ b/Tests/Unit/UserFileCodingLogicTests.m
@@ -43,7 +43,7 @@
     XCTAssertNotNil(user);
     XCTAssertEqualObjects(user.objectId, @"100500");
     XCTAssertEqualObjects(user[@"slogan"], @"yarr");
-    XCTAssertTrue(user.isDataAvailable);
+    XCTAssertTrue(user.dataAvailable);
 
     XCTAssertEqualObjects(user.authData, @{ @"a" : @"b" });
     XCTAssertEqualObjects(user.linkedServiceNames, [NSSet setWithObject:@"a"]);
@@ -61,7 +61,7 @@
     [logic updateObject:user fromDictionary:dictionary usingDecoder:[PFDecoder objectDecoder]];
 
     XCTAssertNotNil(user);
-    XCTAssertTrue(user.isDataAvailable);
+    XCTAssertTrue(user.dataAvailable);
 
     XCTAssertEqualObjects(user.authData, @{ @"a" : @"b" });
     XCTAssertEqualObjects(user.linkedServiceNames, [NSSet setWithObject:@"a"]);


### PR DESCRIPTION
Convert to a property with custom getter for backward compatability.