### PR TITLE
Convert isDataAvailable, isDirty methods in PFFile to properties.

### DIFF
--- a/Parse/Internal/PFEncoder.m
+++ b/Parse/Internal/PFEncoder.m
@@ -47,7 +47,7 @@
                  };
 
     } else if ([object isKindOfClass:[PFFile class]]) {
-        if (((PFFile *)object).isDirty) {
+        if (((PFFile *)object).dirty) {
             // TODO: (nlutsenko) Figure out what to do with things like an unsaved file
             // in a mutable container, where we don't normally want to allow serializing
             // such a thing inside an object.

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -220,7 +220,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  @abstract Whether the data is available in memory or needs to be downloaded.
  */
-@property (nonatomic, assign, readonly) BOOL isDataAvailable;
+@property (nonatomic, assign, readonly, getter=isDataAvailable) BOOL dataAvailable;
 
 /*!
  @abstract *Synchronously* gets the data from cache if available or fetches its contents from the network.

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -145,7 +145,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  @abstract Whether the file has been uploaded for the first time.
  */
-@property (nonatomic, assign, readonly) BOOL isDirty;
+@property (nonatomic, assign, readonly, getter=isDirty) BOOL dirty;
 
 ///--------------------------------------
 /// @name Storing Data with Parse

--- a/Parse/PFFile.m
+++ b/Parse/PFFile.m
@@ -37,7 +37,6 @@ static const unsigned long long PFFileMaxFileSize = 10 * 1024 * 1024; // 10 MB
 
 @property (nonatomic, strong, readwrite) PFFileState *state;
 @property (nonatomic, copy, readonly) NSString *stagedFilePath;
-@property (nonatomic, assign, readonly, getter=isDirty) BOOL dirty;
 
 //
 // Private

--- a/Parse/PFFile.m
+++ b/Parse/PFFile.m
@@ -388,7 +388,7 @@ static const unsigned long long PFFileMaxFileSize = 10 * 1024 * 1024; // 10 MB
     @weakify(self);
     return [self.taskQueue enqueue:^id(BFTask *task) {
         @strongify(self);
-        if (self.isDataAvailable) {
+        if (self.dataAvailable) {
             [self _performProgressBlockAsync:progressBlock withProgress:100];
             return [BFTask taskWithResult:nil];
         }
@@ -417,7 +417,7 @@ static const unsigned long long PFFileMaxFileSize = 10 * 1024 * 1024; // 10 MB
     @weakify(self);
     return [self.taskQueue enqueue:^id(BFTask *task) {
         @strongify(self);
-        if (self.isDataAvailable) {
+        if (self.dataAvailable) {
             [self _performProgressBlockAsync:progressBlock withProgress:100];
             return [self _cachedDataStream];
         }

--- a/Tests/Unit/FileUnitTests.m
+++ b/Tests/Unit/FileUnitTests.m
@@ -141,28 +141,28 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
-    XCTAssertTrue(file.isDataAvailable);
+    XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     file = [PFFile fileWithData:[NSData data] contentType:@"content-type"];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
-    XCTAssertTrue(file.isDataAvailable);
+    XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     file = [PFFile fileWithName:@"name" data:[NSData data]];
     XCTAssertEqualObjects(file.name, @"name");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
-    XCTAssertTrue(file.isDataAvailable);
+    XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     file = [PFFile fileWithName:nil contentsAtPath:[self sampleFilePath]];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
-    XCTAssertTrue(file.isDataAvailable);
+    XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     NSError *error = nil;
@@ -171,14 +171,14 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
-    XCTAssertTrue(file.isDataAvailable);
+    XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     file = [PFFile fileWithName:nil data:[NSData data] contentType:@"content-type"];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
-    XCTAssertTrue(file.isDataAvailable);
+    XCTAssertTrue(file.dataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     file = [PFFile fileWithName:nil data:[NSData data] contentType:@"content-type" error:&error];
@@ -186,7 +186,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
     XCTAssertTrue(file.dirty);
-    XCTAssertTrue(file.isDataAvailable);
+    XCTAssertTrue(file.dataAvailable);
 }
 
 - (void)testConstructorWithTooLargeData {

--- a/Tests/Unit/FileUnitTests.m
+++ b/Tests/Unit/FileUnitTests.m
@@ -140,28 +140,28 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     PFFile *file = [PFFile fileWithData:[NSData data]];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
-    XCTAssertTrue(file.isDirty);
+    XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.isDataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     file = [PFFile fileWithData:[NSData data] contentType:@"content-type"];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
-    XCTAssertTrue(file.isDirty);
+    XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.isDataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     file = [PFFile fileWithName:@"name" data:[NSData data]];
     XCTAssertEqualObjects(file.name, @"name");
     XCTAssertNil(file.url);
-    XCTAssertTrue(file.isDirty);
+    XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.isDataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     file = [PFFile fileWithName:nil contentsAtPath:[self sampleFilePath]];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
-    XCTAssertTrue(file.isDirty);
+    XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.isDataAvailable);
 
     [self clearStagingAndTemporaryFiles];
@@ -170,14 +170,14 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     XCTAssertNil(error);
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
-    XCTAssertTrue(file.isDirty);
+    XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.isDataAvailable);
 
     [self clearStagingAndTemporaryFiles];
     file = [PFFile fileWithName:nil data:[NSData data] contentType:@"content-type"];
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
-    XCTAssertTrue(file.isDirty);
+    XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.isDataAvailable);
 
     [self clearStagingAndTemporaryFiles];
@@ -185,7 +185,7 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     XCTAssertNil(error);
     XCTAssertEqualObjects(file.name, @"file");
     XCTAssertNil(file.url);
-    XCTAssertTrue(file.isDirty);
+    XCTAssertTrue(file.dirty);
     XCTAssertTrue(file.isDataAvailable);
 }
 


### PR DESCRIPTION
- Convert methods to properties with custom getters for backwards compatibility
- Update all usages of methods to properties