### PR TITLE
Create in-memory eventually queue for analytics events on tvOS.

### DIFF
--- a/Parse.podspec
+++ b/Parse.podspec
@@ -11,20 +11,22 @@ Pod::Spec.new do |s|
   s.platform = :ios, :osx
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
-  
+
   s.requires_arc = true
 
   s.source_files = 'Parse/*.{h,m}',
                    'Parse/Internal/**/*.{h,m}'
   s.public_header_files = 'Parse/*.h'
-  
+
+  s.ios.exclude_files = 'Parse/Internal/PFMemoryEventuallyQueue.{h,m}'
   s.osx.exclude_files = 'Parse/PFNetworkActivityIndicatorManager.{h,m}',
                         'Parse/PFProduct.{h,m}',
                         'Parse/PFPurchase.{h,m}',
                         'Parse/Internal/PFAlertView.{h,m}',
                         'Parse/Internal/Product/**/*.{h,m}',
-                        'Parse/Internal/Purchase/**/*.{h,m}'
-  
+                        'Parse/Internal/Purchase/**/*.{h,m}',
+                        'Parse/Internal/PFMemoryEventuallyQueue.{h,m}'
+
   s.resources = 'Parse/Resources/en.lproj'
 
   s.ios.frameworks        = 'AudioToolbox',
@@ -44,7 +46,7 @@ Pod::Spec.new do |s|
                      'QuartzCore',
                      'Security',
                      'SystemConfiguration'
-                            
+
   s.libraries        = 'z', 'sqlite3'
 
   s.dependency 'Bolts/Tasks', '>= 1.4.0'

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -654,6 +654,8 @@
 		815960A21ABCA3B30069EBCC /* PFFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8159609F1ABCA3B30069EBCC /* PFFileManager.h */; };
 		815960A31ABCA3B30069EBCC /* PFFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 815960A01ABCA3B30069EBCC /* PFFileManager.m */; };
 		815960A41ABCA3B30069EBCC /* PFFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 815960A01ABCA3B30069EBCC /* PFFileManager.m */; };
+		815CC4411BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 815CC43F1BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.h */; };
+		815CC4421BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 815CC4401BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.m */; };
 		815E764D1BDF168A00E1DF8E /* PFPersistenceController.h in Headers */ = {isa = PBXBuildFile; fileRef = 815E764B1BDF168A00E1DF8E /* PFPersistenceController.h */; };
 		815E764E1BDF168A00E1DF8E /* PFPersistenceController.h in Headers */ = {isa = PBXBuildFile; fileRef = 815E764B1BDF168A00E1DF8E /* PFPersistenceController.h */; };
 		815E764F1BDF168A00E1DF8E /* PFPersistenceController.h in Headers */ = {isa = PBXBuildFile; fileRef = 815E764B1BDF168A00E1DF8E /* PFPersistenceController.h */; };
@@ -1939,6 +1941,8 @@
 		815618FF1A1F79AC0076504A /* PFDateFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFDateFormatter.m; sourceTree = "<group>"; };
 		8159609F1ABCA3B30069EBCC /* PFFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFFileManager.h; sourceTree = "<group>"; };
 		815960A01ABCA3B30069EBCC /* PFFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFFileManager.m; sourceTree = "<group>"; };
+		815CC43F1BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMemoryEventuallyQueue.h; sourceTree = "<group>"; };
+		815CC4401BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFMemoryEventuallyQueue.m; sourceTree = "<group>"; };
 		815E764B1BDF168A00E1DF8E /* PFPersistenceController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFPersistenceController.h; sourceTree = "<group>"; };
 		815E764C1BDF168A00E1DF8E /* PFPersistenceController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFPersistenceController.m; sourceTree = "<group>"; };
 		815EE8EE19F976D50076FE5D /* PFRESTCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFRESTCommand.h; sourceTree = "<group>"; };
@@ -2504,6 +2508,8 @@
 			children = (
 				81EDD4BC1B59A6D8002F69C0 /* CommandRunner */,
 				8119C9961A76E28F0085B516 /* PFNetworkCommand.h */,
+				815CC43F1BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.h */,
+				815CC4401BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.m */,
 				7C1FDDCA14E1B1BD00A77007 /* PFCommandCache.h */,
 				7C1FDDCB14E1B1BD00A77007 /* PFCommandCache.m */,
 				913B9F2C1A311FF40040247C /* PFCommandCache_Private.h */,
@@ -4176,6 +4182,7 @@
 				815F23E91BD04D150054659F /* PFMutableRelationState.h in Headers */,
 				815F23EA1BD04D150054659F /* PFSession_Private.h in Headers */,
 				815F23EB1BD04D150054659F /* PFObjectEstimatedData.h in Headers */,
+				815CC4411BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.h in Headers */,
 				815F23EC1BD04D150054659F /* PFObjectFilePersistenceController.h in Headers */,
 				815F23ED1BD04D150054659F /* PFInstallationConstants.h in Headers */,
 				815F23EE1BD04D150054659F /* PFUserPrivate.h in Headers */,
@@ -5142,6 +5149,7 @@
 			files = (
 				815F22B41BD04D150054659F /* PFWeakValue.m in Sources */,
 				815F22B51BD04D150054659F /* PFUserState.m in Sources */,
+				815CC4421BF533EF00FBF8D3 /* PFMemoryEventuallyQueue.m in Sources */,
 				815F22B61BD04D150054659F /* PFCommandURLRequestConstructor.m in Sources */,
 				815F22B71BD04D150054659F /* PFCoreManager.m in Sources */,
 				815F22B81BD04D150054659F /* PFURLSessionUploadTaskDelegate.m in Sources */,

--- a/Parse/Internal/PFMemoryEventuallyQueue.h
+++ b/Parse/Internal/PFMemoryEventuallyQueue.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "PFEventuallyQueue.h"
+
+PF_IOS_UNAVAILABLE_WARNING
+PF_OSX_UNAVAILABLE_WARNING
+PF_WATCH_UNAVAILABLE_WARNING
+
+PF_IOS_UNAVAILABLE PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFMemoryEventuallyQueue : PFEventuallyQueue
+
++ (instancetype)newDefaultMemoryEventuallyQueueWithCommandRunner:(id<PFCommandRunning>)commandRunner;
+
+@end

--- a/Parse/Internal/PFMemoryEventuallyQueue.m
+++ b/Parse/Internal/PFMemoryEventuallyQueue.m
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "PFMemoryEventuallyQueue.h"
+#import "PFEventuallyQueue_Private.h"
+
+#import <Bolts/BFTask.h>
+#import <Bolts/BFExecutor.h>
+
+@interface PFMemoryEventuallyQueue () <PFEventuallyQueueSubclass> {
+    dispatch_queue_t _dataAccessQueue;
+    BFExecutor *_dataAccessExecutor;
+
+    NSMutableArray PF_GENERIC(NSString *)*_pendingCommandIdentifiers;
+    NSMutableDictionary PF_GENERIC(NSString *, id<PFNetworkCommand>)*_commandsDictionary;
+}
+
+@end
+
+@implementation PFMemoryEventuallyQueue
+
+///--------------------------------------
+#pragma mark - Init
+///--------------------------------------
+
++ (instancetype)newDefaultMemoryEventuallyQueueWithCommandRunner:(id<PFCommandRunning>)commandRunner {
+    PFMemoryEventuallyQueue *queue = [[self alloc] initWithCommandRunner:commandRunner
+                                                        maxAttemptsCount:PFEventuallyQueueDefaultMaxAttemptsCount
+                                                           retryInterval:PFEventuallyQueueDefaultTimeoutRetryInterval];
+    [queue start];
+    return queue;
+}
+
+- (instancetype)initWithCommandRunner:(id<PFCommandRunning>)commandRunner
+                     maxAttemptsCount:(NSUInteger)attemptsCount
+                        retryInterval:(NSTimeInterval)retryInterval {
+    self = [super initWithCommandRunner:commandRunner maxAttemptsCount:attemptsCount retryInterval:retryInterval];
+    if (!self) return nil;
+
+    _dataAccessQueue = dispatch_queue_create("com.parse.eventuallyQueue.memory", DISPATCH_QUEUE_SERIAL);
+    _dataAccessExecutor = [BFExecutor executorWithDispatchQueue:_dataAccessQueue];
+
+    _pendingCommandIdentifiers = [NSMutableArray array];
+    _commandsDictionary = [NSMutableDictionary dictionary];
+
+    return self;
+}
+
+///--------------------------------------
+#pragma mark - Controlling Queue
+///--------------------------------------
+
+- (void)removeAllCommands {
+    [super removeAllCommands];
+
+    dispatch_sync(_dataAccessQueue, ^{
+        [_pendingCommandIdentifiers removeAllObjects];
+        [_commandsDictionary removeAllObjects];
+    });
+}
+
+///--------------------------------------
+#pragma mark - PFEventuallyQueueSubclass
+///--------------------------------------
+
+- (NSString *)_newIdentifierForCommand:(id<PFNetworkCommand>)command {
+    return [NSUUID UUID].UUIDString;
+}
+
+- (NSArray PF_GENERIC(NSString *)*)_pendingCommandIdentifiers {
+    __block NSArray *array = nil;
+    dispatch_sync(_dataAccessQueue, ^{
+        array = [_pendingCommandIdentifiers copy];
+    });
+    return array;
+}
+
+- (id<PFNetworkCommand>)_commandWithIdentifier:(NSString *)identifier error:(NSError **)error {
+    __block id<PFNetworkCommand> command = nil;
+    dispatch_sync(_dataAccessQueue, ^{
+        command = _commandsDictionary[identifier];
+    });
+    return command;
+}
+
+- (BFTask *)_enqueueCommandInBackground:(id<PFNetworkCommand>)command object:(PFObject *)object identifier:(NSString *)identifier {
+    return [BFTask taskFromExecutor:_dataAccessExecutor withBlock:^id{
+        [_pendingCommandIdentifiers addObject:identifier];
+        _commandsDictionary[identifier] = command;
+        return nil;
+    }];
+}
+
+- (BFTask *)_didFinishRunningCommand:(id<PFNetworkCommand>)command withIdentifier:(NSString *)identifier resultTask:(BFTask *)resultTask {
+    return [BFTask taskFromExecutor:_dataAccessExecutor withBlock:^id{
+        [_pendingCommandIdentifiers removeObject:identifier];
+        [_commandsDictionary removeObjectForKey:identifier];
+        return [super _didFinishRunningCommand:command withIdentifier:identifier resultTask:resultTask];
+    }];
+}
+
+- (BFTask *)_waitForOperationSet:(PFOperationSet *)operationSet eventuallyPin:(PFEventuallyPin *)eventuallyPin {
+    return [BFTask taskWithResult:nil];
+}
+
+@end

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -38,6 +38,10 @@
 #import "PFProduct.h"
 #endif
 
+#if TARGET_OS_TV
+#import "PFMemoryEventuallyQueue.h"
+#endif
+
 static NSString *const _ParseApplicationIdFileName = @"applicationId";
 
 @interface ParseManager () <PFCoreManagerDataSource>
@@ -165,6 +169,11 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
 - (PFEventuallyQueue *)eventuallyQueue {
     __block PFEventuallyQueue *queue = nil;
     dispatch_sync(_eventuallyQueueAccessQueue, ^{
+#if TARGET_OS_TV
+        if (!_eventuallyQueue) {
+            _eventuallyQueue = [PFMemoryEventuallyQueue newDefaultMemoryEventuallyQueueWithCommandRunner:self.commandRunner];
+        }
+#else
         if (!_eventuallyQueue ||
             (self.offlineStoreLoaded && [_eventuallyQueue isKindOfClass:[PFCommandCache class]]) ||
             (!self.offlineStoreLoaded && [_eventuallyQueue isKindOfClass:[PFPinningEventuallyQueue class]])) {
@@ -184,6 +193,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
                 [commandCache removeAllCommands];
             }
         }
+#endif
         queue = _eventuallyQueue;
     });
     return queue;

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -498,6 +498,38 @@ extern NSString *const __nonnull PFNetworkNotificationURLResponseBodyUserInfoKey
 /// @name Avaiability Macros
 ///--------------------------------------
 
+#ifndef PF_IOS_UNAVAILABLE
+#  ifdef __IOS_UNAVILABLE
+#    define PF_IOS_UNAVAILABLE __IOS_UNAVAILABLE
+#  else
+#    define PF_IOS_UNAVAILABLE
+#  endif
+#endif
+
+#ifndef PF_IOS_UNAVAILABLE_WARNING
+#  if TARGET_OS_IOS
+#    define PF_IOS_UNAVAILABLE_WARNING _Pragma("GCC warning \"This file is unavailable on iOS.\"")
+#  else
+#    define PF_IOS_UNAVAILABLE_WARNING
+#  endif
+#endif
+
+#ifndef PF_OSX_UNAVAILABLE
+#  if PF_TARGET_OS_OSX
+#    define PF_OSX_UNAVAILABLE __OSX_UNAVAILABLE
+#  else
+#    define PF_OSX_UNAVAILABLE
+#  endif
+#endif
+
+#ifndef PF_OSX_UNAVAILABLE_WARNING
+#  if PF_TARGET_OS_OSX
+#    define PF_OSX_UNAVAILABLE_WARNING _Pragma("GCC warning \"This file is unavailable on OS X.\"")
+#  else
+#    define PF_OSX_UNAVAILABLE_WARNING
+#  endif
+#endif
+
 #ifndef PF_WATCH_UNAVAILABLE
 #  ifdef __WATCHOS_UNAVAILABLE
 #    define PF_WATCH_UNAVAILABLE __WATCHOS_UNAVAILABLE


### PR DESCRIPTION
- Created a new class that implements PFEventuallyQueue
- Use in-memory store only for all the commands
- Use the class if compiling for tvOS

Contributes to #250.