### PR TITLE
Specialize generic type on 'channels' key of PFInstallation.

### DIFF
--- a/Parse/PFInstallation.h
+++ b/Parse/PFInstallation.h
@@ -84,7 +84,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 /*!
  @abstract The channels for the `PFInstallation`.
  */
-@property (nullable, nonatomic, copy) NSArray *channels;
+@property (nullable, nonatomic, copy) NSArray PF_GENERIC(NSString *)*channels;
 
 /*!
  @abstract Sets the device token string property from an `NSData`-encoded token.

--- a/Parse/PFInstallation.m
+++ b/Parse/PFInstallation.m
@@ -210,7 +210,7 @@ static NSSet *protectedKeys;
      onlyIfDifferent:YES];
 }
 
-- (void)setChannels:(NSArray *)channels {
+- (void)setChannels:(NSArray PF_GENERIC(NSString *)*)channels {
     [self _setObject:channels forKey:PFInstallationKeyChannels onlyIfDifferent:YES];
 }
 


### PR DESCRIPTION
This could only ever be a `NSString *`, specify that.