### PR TITLE
Add missing generic type to PFPush.getSubscribedChannels().

### DIFF
--- a/Parse/Internal/Push/ChannelsController/PFPushChannelsController.h
+++ b/Parse/Internal/Push/ChannelsController/PFPushChannelsController.h
@@ -36,7 +36,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushChannelsController : NSO
 /// @name Get
 ///--------------------------------------
 
-- (BFTask *)getSubscribedChannelsAsync;
+- (BFTask PF_GENERIC(NSSet<NSString *> *)*)getSubscribedChannelsAsync;
 
 ///--------------------------------------
 /// @name Subscribe

--- a/Parse/Internal/Push/ChannelsController/PFPushChannelsController.m
+++ b/Parse/Internal/Push/ChannelsController/PFPushChannelsController.m
@@ -49,7 +49,7 @@
 #pragma mark - Get
 ///--------------------------------------
 
-- (BFTask *)getSubscribedChannelsAsync {
+- (BFTask PF_GENERIC(NSSet<NSString *> *)*)getSubscribedChannelsAsync {
     return [[self _getCurrentObjectAsync] continueWithSuccessBlock:^id(BFTask *task) {
         PFInstallation *installation = task.result;
 

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -413,7 +413,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
  @returns Returns an `NSSet` containing all the channel names this device is subscribed to.
  */
-+ (nullable NSSet *)getSubscribedChannels:(NSError **)error;
++ (nullable NSSet PF_GENERIC(NSString *)*)getSubscribedChannels:(NSError **)error;
 
 /*!
  @abstract *Asynchronously* get all the channels that this device is subscribed to.
@@ -437,8 +437,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  It should have the following signature: `(void)callbackWithResult:(NSSet *)result error:(NSError *)error`.
  `error` will be `nil` on success and set if there was an error.
  */
-+ (void)getSubscribedChannelsInBackgroundWithTarget:(id)target
-                                           selector:(SEL)selector;
++ (void)getSubscribedChannelsInBackgroundWithTarget:(id)target selector:(SEL)selector;
 
 /*!
  @abstract *Synchrnously* subscribes the device to a channel of push notifications.

--- a/Parse/PFPush.m
+++ b/Parse/PFPush.m
@@ -316,11 +316,11 @@ static Class _pushInternalUtilClass = nil;
 
 #pragma mark Get
 
-+ (NSSet *)getSubscribedChannels:(NSError **)error {
++ (NSSet PF_GENERIC(NSString *)*)getSubscribedChannels:(NSError **)error {
     return [[self getSubscribedChannelsInBackground] waitForResult:error];
 }
 
-+ (BFTask *)getSubscribedChannelsInBackground {
++ (BFTask PF_GENERIC(NSSet<NSString *> *)*)getSubscribedChannelsInBackground {
     return [[self channelsController] getSubscribedChannelsAsync];
 }
 


### PR DESCRIPTION
Add missing generic type to the public method and the entire pipe.