### PR TITLE
Improve isAuthenticated property name on PFUser.

### DIFF
--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -65,7 +65,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @discussion An authenticated `PFUser` is one that is obtained via a <signUp> or <logIn> method.
  An authenticated object is required in order to save (with altered values) or delete it.
  */
-@property (nonatomic, assign, readonly, getter=isAuthenticated) BOOL isAuthenticated;
+@property (nonatomic, assign, readonly, getter=isAuthenticated) BOOL authenticated;
 
 ///--------------------------------------
 /// @name Creating a New User

--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -96,7 +96,7 @@ static BOOL revocableSessionEnabled_;
 
 - (BFTask PF_GENERIC(PFVoid) *)_validateDeleteAsync {
     return [[super _validateDeleteAsync] continueWithSuccessBlock:^id(BFTask PF_GENERIC(PFVoid) *task) {
-        if (!self.isAuthenticated) {
+        if (!self.authenticated) {
             NSError *error = [PFErrorUtilities errorWithCode:kPFErrorUserCannotBeAlteredWithoutSession
                                                      message:@"User cannot be deleted unless they have been authenticated."];
             return [BFTask taskWithError:error];


### PR DESCRIPTION
(－‸ლ) Converted method to a property, but forgot to kill the `is` prefix.
Not a breaking change, since we didn't release this yet (the last change is from Nov 11).