### PR TITLE
builds dynamic framworks

### DIFF
--- a/Configurations/Bolts-iOS-Dynamic.xcconfig
+++ b/Configurations/Bolts-iOS-Dynamic.xcconfig
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+
+SUPPORTED_PLATFORMS                    = iphonesimulator iphoneos
+VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
+VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
+
+ENABLE_BITCODE               = NO
+ENABLE_BITCODE[sdk=iphoneos*]   = YES
+ENABLE_BITCODE[sdk=iphonesimulator*]      = YES
+
+// Dynamic linking uses different default copy paths
+LD_RUNPATH_SEARCH_PATHS         = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+
+DYLIB_INSTALL_NAME_BASE				  = @rpath
+
+MACH_O_TYPE                     = mh_dylib
+CLANG_MODULES_AUTOLINK          = YES
+IPHONEOS_DEPLOYMENT_TARGET      = 8.0
+ONLY_ACTIVE_ARCH                = NO

--- a/Configurations/Framework-iOS-Dynamic.xcconfig
+++ b/Configurations/Framework-iOS-Dynamic.xcconfig
@@ -7,7 +7,8 @@
 // of patent rights can be found in the PATENTS file in the same directory.
 //
 
-#include "Configurations/Framework-iOS-Dynamic.xcconfig"
+// Common configuration for iOS-Dynamic frameworks
+
 
 SUPPORTED_PLATFORMS                    = iphonesimulator iphoneos
 VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s

--- a/Configurations/Parse-iOS-Dynamic.xcconfig
+++ b/Configurations/Parse-iOS-Dynamic.xcconfig
@@ -6,44 +6,18 @@
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
 //
-
+#include "Shared/Platform/iOS.xcconfig"
 #include "Shared/Product/Framework.xcconfig"
+#include "Configurations/Parse-iOS.xcconfig"
+#include "Configurations/Framework-iOS-Dynamic.xcconfig"
 
-PRODUCT_NAME                    = Parse
-IPHONEOS_DEPLOYMENT_TARGET      = 8.0
+
+// Force SDKROOT to the passed var
+SDKROOT = $(SDKROOT)
 // This silence a warning
-
 SDKROOT[sdk=macos*] = iphoneos
-SDKROOT[sdk=iphoneos*]          = iphoneos
-SDKROOT[sdk=iphonesimulator*]   = iphonesimulator
-
-MACH_O_TYPE                     = mh_dylib
-
-ENABLE_BITCODE               = NO
-ENABLE_BITCODE[sdk=iphoneos*]               = YES
-ENABLE_BITCODE[sdk=iphonesimulator*]        = YES
-DEFINES_MODULE = YES
-
-SUPPORTED_PLATFORMS                    = iphonesimulator iphoneos
-
-VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
-
-ARCHS[sdk=iphoneos*] = arm64 armv7 armv7s
-ARCHS[sdk=iphonesimulator*]      = i386 x86_64
 
 // Breaks the build if intherited $(BUILD_PRODUCTS_DIR)
 FRAMEWORK_SEARCH_PATHS = $PARSE_DIR/build
 
-// Dynamic linking uses different default copy paths
-LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*]         = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
-LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]  = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
-
-DYLIB_INSTALL_NAME_BASE         = @rpath
-
 OTHER_LDFLAGS                   = $(inherited) '-dynamiclib' '-lsqlite3'
-CLANG_MODULES_AUTOLINK          = YES
-
-ONLY_ACTIVE_ARCH                = NO
-
-INFOPLIST_FILE = $(PROJECT_DIR)/$(PRODUCT_NAME)/Resources/Parse-iOS.Info.plist

--- a/Configurations/Parse-iOS-Dynamic.xcconfig
+++ b/Configurations/Parse-iOS-Dynamic.xcconfig
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2015-present, Parse, LLC.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+
+#include "Shared/Product/Framework.xcconfig"
+
+PRODUCT_NAME                    = Parse
+IPHONEOS_DEPLOYMENT_TARGET      = 8.0
+// This silence a warning
+
+SDKROOT[sdk=macos*] = iphoneos
+SDKROOT[sdk=iphoneos*]          = iphoneos
+SDKROOT[sdk=iphonesimulator*]   = iphonesimulator
+
+MACH_O_TYPE                     = mh_dylib
+
+ENABLE_BITCODE               = NO
+ENABLE_BITCODE[sdk=iphoneos*]               = YES
+ENABLE_BITCODE[sdk=iphonesimulator*]        = YES
+DEFINES_MODULE = YES
+
+SUPPORTED_PLATFORMS                    = iphonesimulator iphoneos
+
+VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
+VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
+
+ARCHS[sdk=iphoneos*] = arm64 armv7 armv7s
+ARCHS[sdk=iphonesimulator*]      = i386 x86_64
+
+// Breaks the build if intherited $(BUILD_PRODUCTS_DIR)
+FRAMEWORK_SEARCH_PATHS = $PARSE_DIR/build
+
+// Dynamic linking uses different default copy paths
+LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*]         = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]  = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+
+DYLIB_INSTALL_NAME_BASE         = @rpath
+
+OTHER_LDFLAGS                   = $(inherited) '-dynamiclib' '-lsqlite3'
+CLANG_MODULES_AUTOLINK          = YES
+
+ONLY_ACTIVE_ARCH                = NO
+
+INFOPLIST_FILE = $(PROJECT_DIR)/$(PRODUCT_NAME)/Resources/Parse-iOS.Info.plist

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -1574,6 +1574,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4A8E7F261C0627D300E8AF28 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 09D33641139C54930098E916 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4A8E7F1E1C0627AF00E8AF28;
+			remoteInfo = "Bolts-iOS-Dynamic";
+		};
 		811167461B8402DA003CB026 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 09D33641139C54930098E916 /* Project object */;
@@ -1719,6 +1726,8 @@
 		499E425615B6409000A2C28E /* PFProduct.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFProduct.m; sourceTree = "<group>"; };
 		49FDE2EC158C138F00126F64 /* PFPurchase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFPurchase.h; sourceTree = "<group>"; };
 		49FDE2ED158C138F00126F64 /* PFPurchase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFPurchase.m; sourceTree = "<group>"; };
+		4A26C3B61C053AEE00E5F505 /* Parse-iOS-Dynamic.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Parse-iOS-Dynamic.xcconfig"; sourceTree = "<group>"; };
+		4A8E7F291C06458F00E8AF28 /* Bolts-iOS-Dynamic.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Bolts-iOS-Dynamic.xcconfig"; sourceTree = "<group>"; };
 		63723F6D1565A085007A1A73 /* PFRole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFRole.h; sourceTree = "<group>"; };
 		63723F6E1565A085007A1A73 /* PFRole.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFRole.m; sourceTree = "<group>"; };
 		638CBBB415191435004F54E4 /* PFAnonymousUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFAnonymousUtils.h; sourceTree = "<group>"; };
@@ -3724,12 +3733,14 @@
 			isa = PBXGroup;
 			children = (
 				F55ABB531B4F39DA00A0ECD5 /* Parse-iOS.xcconfig */,
+				4A26C3B61C053AEE00E5F505 /* Parse-iOS-Dynamic.xcconfig */,
 				F55ABB541B4F39DA00A0ECD5 /* Parse-OSX.xcconfig */,
 				815F24171BD04D310054659F /* Parse-tvOS.xcconfig */,
 				810154FE1BB382F800D7C7BD /* Parse-watchOS.xcconfig */,
 				F55ABB591B4F39DA00A0ECD5 /* ParseUnitTests-iOS.xcconfig */,
 				F55ABB5A1B4F39DA00A0ECD5 /* ParseUnitTests-OSX.xcconfig */,
 				812F31FB1BCF40DC00FCBCD4 /* Bolts-iOS.xcconfig */,
+				4A8E7F291C06458F00E8AF28 /* Bolts-iOS-Dynamic.xcconfig */,
 				812F31FC1BCF40DC00FCBCD4 /* Bolts-OSX.xcconfig */,
 				815F24191BD04DB70054659F /* Bolts-tvOS.xcconfig */,
 				812F31FD1BCF40DC00FCBCD4 /* Bolts-watchOS.xcconfig */,
@@ -4622,6 +4633,35 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXLegacyTarget section */
+		4A26C3BB1C053C2C00E5F505 /* Parse-iOS-Dynamic */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-xcconfig Configurations/Parse-iOS-Dynamic.xcconfig -workspace Parse.xcworkspace -scheme Parse-iOS -configuration $(CONFIGURATION) -sdk $SDKROOT CONFIGURATION_BUILD_DIR=$(CONFIGURATION_BUILD_DIR) $(ACTION)";
+			buildConfigurationList = 4A26C3BC1C053C2D00E5F505 /* Build configuration list for PBXLegacyTarget "Parse-iOS-Dynamic" */;
+			buildPhases = (
+			);
+			buildToolPath = xcodebuild;
+			buildWorkingDirectory = "$(SRCROOT)";
+			dependencies = (
+				4A8E7F271C0627D300E8AF28 /* PBXTargetDependency */,
+			);
+			name = "Parse-iOS-Dynamic";
+			passBuildSettingsInEnvironment = 1;
+			productName = Parse;
+		};
+		4A8E7F1E1C0627AF00E8AF28 /* Bolts-iOS-Dynamic */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "Scripts/build_bolts_dynamic.sh $(ACTION)";
+			buildConfigurationList = 4A8E7F251C0627AF00E8AF28 /* Build configuration list for PBXLegacyTarget "Bolts-iOS-Dynamic" */;
+			buildPhases = (
+			);
+			buildToolPath = sh;
+			buildWorkingDirectory = "$(SRCROOT)";
+			dependencies = (
+			);
+			name = "Bolts-iOS-Dynamic";
+			passBuildSettingsInEnvironment = 1;
+			productName = "Bolts-iOS-Dynamic";
+		};
 		812F31F71BCF40AA00FCBCD4 /* Bolts-watchOS */ = {
 			isa = PBXLegacyTarget;
 			buildArgumentsString = "$(SRCROOT)/Vendor/Bolts-ObjC/ \\\n\"Vendor/Bolts-ObjC/scripts/build_framework.sh -n -c Release --with-watchos --with-tvos\"";
@@ -4810,6 +4850,12 @@
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Parse Inc.";
 				TargetAttributes = {
+					4A26C3BB1C053C2C00E5F505 = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
+					4A8E7F1E1C0627AF00E8AF28 = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
 					81493A931A0D3492008D5504 = {
 						CreatedOnToolsVersion = 6.1;
 					};
@@ -4838,6 +4884,7 @@
 			projectRoot = "";
 			targets = (
 				81C3821B19CCA89E0066284A /* Parse-iOS */,
+				4A26C3BB1C053C2C00E5F505 /* Parse-iOS-Dynamic */,
 				816F441B1A8E8933009CDB32 /* ParseUnitTests-iOS */,
 				97010FAB1630B18F00AB761E /* Parse-OSX */,
 				81C09F501AF97A490043B49C /* ParseUnitTests-OSX */,
@@ -4847,6 +4894,7 @@
 				81493A931A0D3492008D5504 /* Bolts-OSX */,
 				815F241A1BD04DBB0054659F /* Bolts-tvOS */,
 				812F31F71BCF40AA00FCBCD4 /* Bolts-watchOS */,
+				4A8E7F1E1C0627AF00E8AF28 /* Bolts-iOS-Dynamic */,
 			);
 		};
 /* End PBXProject section */
@@ -5831,6 +5879,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4A8E7F271C0627D300E8AF28 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4A8E7F1E1C0627AF00E8AF28 /* Bolts-iOS-Dynamic */;
+			targetProxy = 4A8E7F261C0627D300E8AF28 /* PBXContainerItemProxy */;
+		};
 		811167471B8402DA003CB026 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 97010FAB1630B18F00AB761E /* Parse-OSX */;
@@ -6046,6 +6099,24 @@
 			buildConfigurations = (
 				09D3366B139C54940098E916 /* Debug */,
 				09D3366C139C54940098E916 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4A26C3BC1C053C2D00E5F505 /* Build configuration list for PBXLegacyTarget "Parse-iOS-Dynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A8E7F371C0652D500E8AF28 /* Debug */,
+				4A8E7F381C0652D500E8AF28 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4A8E7F251C0627AF00E8AF28 /* Build configuration list for PBXLegacyTarget "Bolts-iOS-Dynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A8E7F2A1C06458F00E8AF28 /* Debug */,
+				4A8E7F2B1C06458F00E8AF28 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -1728,6 +1728,7 @@
 		49FDE2ED158C138F00126F64 /* PFPurchase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFPurchase.m; sourceTree = "<group>"; };
 		4A26C3B61C053AEE00E5F505 /* Parse-iOS-Dynamic.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Parse-iOS-Dynamic.xcconfig"; sourceTree = "<group>"; };
 		4A8E7F291C06458F00E8AF28 /* Bolts-iOS-Dynamic.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Bolts-iOS-Dynamic.xcconfig"; sourceTree = "<group>"; };
+		4A9C0E851C0B7DDE009DC60E /* Framework-iOS-Dynamic.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Framework-iOS-Dynamic.xcconfig"; sourceTree = "<group>"; };
 		63723F6D1565A085007A1A73 /* PFRole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFRole.h; sourceTree = "<group>"; };
 		63723F6E1565A085007A1A73 /* PFRole.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFRole.m; sourceTree = "<group>"; };
 		638CBBB415191435004F54E4 /* PFAnonymousUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFAnonymousUtils.h; sourceTree = "<group>"; };
@@ -3732,6 +3733,7 @@
 		F55ABB501B4F39DA00A0ECD5 /* Configurations */ = {
 			isa = PBXGroup;
 			children = (
+				4A9C0E851C0B7DDE009DC60E /* Framework-iOS-Dynamic.xcconfig */,
 				F55ABB531B4F39DA00A0ECD5 /* Parse-iOS.xcconfig */,
 				4A26C3B61C053AEE00E5F505 /* Parse-iOS-Dynamic.xcconfig */,
 				F55ABB541B4F39DA00A0ECD5 /* Parse-OSX.xcconfig */,

--- a/Parse.xcodeproj/xcshareddata/xcschemes/Parse-iOS-Dynamic.xcscheme
+++ b/Parse.xcodeproj/xcshareddata/xcschemes/Parse-iOS-Dynamic.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A26C3BB1C053C2C00E5F505"
+               BuildableName = "Parse-iOS-Dynamic"
+               BlueprintName = "Parse-iOS-Dynamic"
+               ReferencedContainer = "container:Parse.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A26C3BB1C053C2C00E5F505"
+            BuildableName = "Parse-iOS-Dynamic"
+            BlueprintName = "Parse-iOS-Dynamic"
+            ReferencedContainer = "container:Parse.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A26C3BB1C053C2C00E5F505"
+            BuildableName = "Parse-iOS-Dynamic"
+            BlueprintName = "Parse-iOS-Dynamic"
+            ReferencedContainer = "container:Parse.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Rakefile
+++ b/Rakefile
@@ -78,6 +78,24 @@ namespace :build do
     end
   end
 
+  desc 'Build iOS Dynamic framework.'
+  task :ios_dynamic do
+    task = XCTask::BuildFrameworkTask.new do |t|
+      t.directory = script_folder
+      t.build_directory = build_folder
+      t.framework_type = XCTask::FrameworkType::IOS
+      t.framework_name = 'Parse.framework'
+      t.workspace = 'Parse.xcworkspace'
+      t.scheme = 'Parse-iOS-Dynamic'
+      t.configuration = 'Release'
+    end
+    result = task.execute
+    unless result
+      puts 'Failed to build iOS Framework.'
+      exit(1)
+    end
+  end
+
   desc 'Build watchOS framework.'
   task :watchos do
     task = XCTask::BuildFrameworkTask.new do |t|
@@ -138,6 +156,7 @@ end
 
 namespace :package do
   package_ios_name = 'Parse-iOS.zip'
+  package_ios_dynamic_name = 'Parse-iOS-Dynamic.zip'
   package_osx_name = 'Parse-OSX.zip'
   package_starter_ios_name = 'ParseStarterProject-iOS.zip'
   package_starter_osx_name = 'ParseStarterProject-OSX.zip'
@@ -159,6 +178,13 @@ namespace :package do
     make_package(release_folder,
                  [ios_framework_path, bolts_path],
                  package_ios_name)
+
+    Rake::Task['build:ios_dynamic'].invoke
+    bolts_path = File.join(build_folder, 'Bolts.framework')
+    ios_framework_path = File.join(build_folder, 'Parse.framework')
+    make_package(release_folder,
+                 [ios_framework_path, bolts_path],
+                 package_ios_dynamic_name)
 
     ## Build OS X Framework
     Rake::Task['build:osx'].invoke

--- a/Rakefile
+++ b/Rakefile
@@ -166,33 +166,52 @@ namespace :package do
     `rm -rf #{bolts_build_folder} && mkdir -p #{bolts_build_folder}`
   end
 
+  namespace :framework do
+
+    task :ios, [:version] => :prepare do |_, args|
+      version = args[:version] || Constants.current_version
+      Constants.update_version(version)
+      Rake::Task['build:ios'].invoke
+      bolts_path = File.join(bolts_build_folder, 'ios', 'Bolts.framework')
+      ios_framework_path = File.join(build_folder, 'Parse.framework')
+      make_package(release_folder,
+                   [ios_framework_path, bolts_path],
+                   package_ios_name)
+    end
+
+    task :ios_dynamic, [:version] => :prepare do |_, args|
+      version = args[:version] || Constants.current_version
+      Constants.update_version(version)
+      Rake::Task['build:ios_dynamic'].invoke
+      bolts_path = File.join(build_folder, 'Bolts.framework')
+      ios_framework_path = File.join(build_folder, 'Parse.framework')
+      make_package(release_folder,
+                   [ios_framework_path, bolts_path],
+                   package_ios_dynamic_name)
+    end
+
+    task :osx, [:version] => :prepare do |_, args|
+      version = args[:version] || Constants.current_version
+      Constants.update_version(version)
+      Rake::Task['build:osx'].invoke
+      bolts_path = File.join(bolts_build_folder, 'osx', 'Bolts.framework')
+      osx_framework_path = File.join(build_folder, 'Parse.framework')
+      make_package(release_folder,
+                   [osx_framework_path, bolts_path],
+                   package_osx_name)
+    end
+  end
+
   desc 'Build and package all frameworks for the release'
   task :frameworks, [:version] => :prepare do |_, args|
-    version = args[:version] || Constants.current_version
-    Constants.update_version(version)
-
     ## Build iOS Framework
-    Rake::Task['build:ios'].invoke
-    bolts_path = File.join(bolts_build_folder, 'ios', 'Bolts.framework')
-    ios_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                 [ios_framework_path, bolts_path],
-                 package_ios_name)
+    Rake::Task['package:framework:ios'].invoke
 
-    Rake::Task['build:ios_dynamic'].invoke
-    bolts_path = File.join(build_folder, 'Bolts.framework')
-    ios_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                 [ios_framework_path, bolts_path],
-                 package_ios_dynamic_name)
+    ## Build iOS Dynamic Framework
+    Rake::Task['package:framework:ios_dynamic'].invoke
 
     ## Build OS X Framework
-    Rake::Task['build:osx'].invoke
-    bolts_path = File.join(bolts_build_folder, 'osx', 'Bolts.framework')
-    osx_framework_path = File.join(build_folder, 'Parse.framework')
-    make_package(release_folder,
-                 [osx_framework_path, bolts_path],
-                 package_osx_name)
+    Rake::Task['package:framework:osx'].invoke
   end
 
   desc 'Build and package all starter projects for the release'

--- a/Scripts/build_bolts_dynamic.sh
+++ b/Scripts/build_bolts_dynamic.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+#
+# Copyright 2010-present Facebook.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script builds Bolts.framework as a dynamic lib
+
+# This script is a workaround in order to build bolts specifically dynamically for Parse-iOS-Dynamic
+
+# Process the build action, default to build
+ACTION=$1
+if [[ -z $ACTION ]]; then
+	ACTION=build
+fi
+
+# Setup the environment
+BOLTS_ROOT=./Vendor/Bolts-ObjC
+BOLTS_SCRIPT=$BOLTS_ROOT/scripts
+
+. ${BOLTS_SCRIPT:-$(dirname $0)}/common.sh
+
+BUILDCONFIGURATION=Release
+BOLTS_BUILD=$PARSE_DIR/build
+BOLTS_IOS_BINARY=$PARSE_DIR/build/${BUILDCONFIGURATION}-universal/Bolts.framework/Bolts
+
+XCCONFIG_FILE=$PARSE_DIR/Configurations/Bolts-iOS-Dynamic.xcconfig
+
+echo $XCODEBUILD
+
+
+function xcode_build_target() {
+  echo "Compiling for platform: ${1}."
+  "$XCODEBUILD" \
+  -project $BOLTS_ROOT/Bolts.xcodeproj\
+  -scheme "${3}" \
+  -sdk $1 \
+  -configuration "${2}" \
+  -xcconfig $XCCONFIG_FILE \
+  SYMROOT="$PARSE_DIR/build/" \
+  CURRENT_PROJECT_VERSION="$BOLTS_VERSION_FULL" \
+  $ACTION \
+  || die "Xcode build failed for platform: ${1}."
+}
+
+FRAMEWORK_NAME=Bolts
+
+xcode_build_target "iphonesimulator" "${BUILDCONFIGURATION}" "Bolts-iOS"
+xcode_build_target "iphoneos" "${BUILDCONFIGURATION}" "Bolts-iOS"
+
+if [ "$ACTION" == "clean" ]; then
+	#statements
+	echo "EXIT!"
+	exit 0
+fi
+
+mkdir -p "$(dirname "$BOLTS_IOS_BINARY")"
+
+cp -av \
+"$BOLTS_BUILD/${BUILDCONFIGURATION}-iphoneos/Bolts.framework" \
+"$BOLTS_BUILD/${BUILDCONFIGURATION}-universal"
+rm "$BOLTS_BUILD/${BUILDCONFIGURATION}-universal/Bolts.framework/Bolts"
+
+# Combine iOS/Simulator binaries into a single universal binary.
+"$LIPO" \
+-create \
+"$BOLTS_BUILD/${BUILDCONFIGURATION}-iphonesimulator/Bolts.framework/Bolts" \
+"$BOLTS_BUILD/${BUILDCONFIGURATION}-iphoneos/Bolts.framework/Bolts" \
+-output "$BOLTS_IOS_BINARY" \
+|| die "lipo failed - could not create universal static library"
+
+cp -av $PARSE_DIR/build/${BUILDCONFIGURATION}-universal/Bolts.framework \
+  "$BOLTS_BUILD"
+
+rm -rf $PARSE_DIR/build/${BUILDCONFIGURATION}-universal
+rm -rf $PARSE_DIR/build/${BUILDCONFIGURATION}-iphonesimulator


### PR DESCRIPTION
I have a 'workaround' here to build dynamic frameworks just based on xconfigs, as I needed dynamic frameworks for a swift framework.

This producing the frameworks in build/ios through a shell script (not integrated with the rake bundle).

How do you think you could support that? In the future I will only require dylibs in the project I'm working on.