### PR TITLE
Update all of the public documentation to new style.

### DIFF
--- a/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
+++ b/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
@@ -30,14 +30,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Default ACL
 ///--------------------------------------
 
-/*!
+/**
  Get the default ACL managed by this controller.
 
  @return A task that returns the ACL encapsulated by this controller.
  */
 - (BFTask *)getDefaultACLAsync;
 
-/*!
+/**
  Set the new default default ACL to be encapsulated in this controller.
 
  @param acl                  The new ACL. Will be copied.

--- a/Parse/Internal/ACL/PFACLPrivate.h
+++ b/Parse/Internal/ACL/PFACLPrivate.h
@@ -27,7 +27,7 @@
  */
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary;
 
-/*!
+/**
  Creates an ACL from its encoded format.
  */
 + (instancetype)ACLWithDictionary:(NSDictionary *)dictionary;

--- a/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
+++ b/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
@@ -33,7 +33,7 @@
 ///--------------------------------------
 
 /**
- @abstract Tracks this application being launched. If this happened as the result of the
+ Tracks this application being launched. If this happened as the result of the
  user opening a push notification, this method sends along information to
  correlate this open with that push.
 
@@ -46,7 +46,7 @@
                                                      sessionToken:(NSString *)sessionToken;
 
 /**
- @abstract Tracks the occurrence of a custom event with additional dimensions.
+ Tracks the occurrence of a custom event with additional dimensions.
 
  @param name         Event name.
  @param dimensions   `NSDictionary` of information by which to segment this event.

--- a/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
+++ b/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
@@ -32,7 +32,7 @@
 /// @name Track Event
 ///--------------------------------------
 
-/*!
+/**
  @abstract Tracks this application being launched. If this happened as the result of the
  user opening a push notification, this method sends along information to
  correlate this open with that push.
@@ -45,7 +45,7 @@
 - (BFTask *)trackAppOpenedEventAsyncWithRemoteNotificationPayload:(NSDictionary *)payload
                                                      sessionToken:(NSString *)sessionToken;
 
-/*!
+/**
  @abstract Tracks the occurrence of a custom event with additional dimensions.
 
  @param name         Event name.

--- a/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
+++ b/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
@@ -40,7 +40,7 @@
  @param payload      The Remote Notification payload.
  @param sessionToken Current user session token.
 
- @returns `BFTask` with result set to `@YES`.
+ @return `BFTask` with result set to `@YES`.
  */
 - (BFTask *)trackAppOpenedEventAsyncWithRemoteNotificationPayload:(NSDictionary *)payload
                                                      sessionToken:(NSString *)sessionToken;
@@ -52,7 +52,7 @@
  @param dimensions   `NSDictionary` of information by which to segment this event.
  @param sessionToken Current user session token.
 
- @returns `BFTask` with result set to `@YES`.
+ @return `BFTask` with result set to `@YES`.
  */
 - (BFTask *)trackEventAsyncWithName:(NSString *)name
                          dimensions:(NSDictionary *)dimensions

--- a/Parse/Internal/Analytics/PFAnalytics_Private.h
+++ b/Parse/Internal/Analytics/PFAnalytics_Private.h
@@ -9,7 +9,7 @@
 
 #import <Parse/PFAnalytics.h>
 
-/*!
+/**
  Predefined events - AppOpened, CrashReport
  Coming soon - Log, ...
  */

--- a/Parse/Internal/Analytics/Utilities/PFAnalyticsUtilities.h
+++ b/Parse/Internal/Analytics/Utilities/PFAnalyticsUtilities.h
@@ -11,7 +11,7 @@
 
 @interface PFAnalyticsUtilities : NSObject
 
-/*!
+/**
  Serializes and hexdigests an alert payload into a "push_hash" identifier
  for use in Analytics.
  Limitedly flexible - the payload is the value under the "alert" key in the

--- a/Parse/Internal/Analytics/Utilities/PFAnalyticsUtilities.h
+++ b/Parse/Internal/Analytics/Utilities/PFAnalyticsUtilities.h
@@ -21,7 +21,7 @@
 
  @param payload `alert` value from a push notification.
 
- @returns md5 identifier.
+ @return md5 identifier.
  */
 + (NSString *)md5DigestFromPushPayload:(id)payload;
 

--- a/Parse/Internal/BFTask+Private.h
+++ b/Parse/Internal/BFTask+Private.h
@@ -42,7 +42,7 @@
  the block will never be called. If the task had an exception, the exception
  will be throw on the main thread instead of running the block. Otherwise,
  the block will be given the result and error of this task.
- @returns A new task that will be finished once the block has run.
+ @return A new task that will be finished once the block has run.
  */
 - (BFTask *)thenCallBackOnMainThreadAsync:(void(^)(id result, NSError *error))block;
 

--- a/Parse/Internal/BFTask+Private.h
+++ b/Parse/Internal/BFTask+Private.h
@@ -36,7 +36,7 @@
 - (instancetype)continueWithMainThreadBooleanResultBlock:(PFBooleanResultBlock)resultBlock
                                       executeIfCancelled:(BOOL)executeIfCancelled;
 
-/*!
+/**
  Adds a continuation to the task that will run the given block on the main
  thread sometime after this task has finished. If the task was cancelled,
  the block will never be called. If the task had an exception, the exception
@@ -46,19 +46,19 @@
  */
 - (BFTask *)thenCallBackOnMainThreadAsync:(void(^)(id result, NSError *error))block;
 
-/*!
+/**
  Identical to thenCallBackOnMainThreadAsync:, except that the result of a successful
  task will be converted to a BOOL using the boolValue method, and that will
  be passed to the block instead of the original result.
  */
 - (BFTask *)thenCallBackOnMainThreadWithBoolValueAsync:(void(^)(BOOL result, NSError *error))block;
 
-/*!
+/**
  Same as `waitForResult:error withMainThreadWarning:YES`
  */
 - (id)waitForResult:(NSError **)error;
 
-/*!
+/**
  Waits until this operation is completed, then returns its value.
  This method is inefficient and consumes a thread resource while its running.
 

--- a/Parse/Internal/CloudCode/PFCloudCodeController.h
+++ b/Parse/Internal/CloudCode/PFCloudCodeController.h
@@ -31,7 +31,7 @@
 /// @name Cloud Functions
 ///--------------------------------------
 
-/*!
+/**
  Calls a Cloud Code function and returns a result of it's execution.
 
  @param functionName Function name to call.

--- a/Parse/Internal/CloudCode/PFCloudCodeController.h
+++ b/Parse/Internal/CloudCode/PFCloudCodeController.h
@@ -38,7 +38,7 @@
  @param parameters   Parameters to pass. (can't be nil).
  @param sessionToken Session token to use.
 
- @returns `BFTask` with a result set to a result of Cloud Function.
+ @return `BFTask` with a result set to a result of Cloud Function.
  */
 - (BFTask *)callCloudCodeFunctionAsync:(NSString *)functionName
                         withParameters:(NSDictionary *)parameters

--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Data Commands
 ///--------------------------------------
 
-/*!
+/**
  Run command.
 
  @param command   Command to run.
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask *)runCommandAsync:(PFRESTCommand *)command
                 withOptions:(PFCommandRunningOptions)options;
 
-/*!
+/**
  Run command.
 
  @param command           Command to run.

--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param command   Command to run.
  @param options   Options to use to run command.
 
- @returns `BFTask` with result set to `PFCommandResult`.
+ @return `BFTask` with result set to `PFCommandResult`.
  */
 - (BFTask *)runCommandAsync:(PFRESTCommand *)command
                 withOptions:(PFCommandRunningOptions)options;
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param options           Options to use to run command.
  @param cancellationToken Operation to use as a cancellation token.
 
- @returns `BFTask` with result set to `PFCommandResult`.
+ @return `BFTask` with result set to `PFCommandResult`.
  */
 - (BFTask *)runCommandAsync:(PFRESTCommand *)command
                 withOptions:(PFCommandRunningOptions)options

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate_Private.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate_Private.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) dispatch_queue_t dataQueue;
 
-/*!
+/**
  @abstract Defaults to to-memory output stream if not overwritten.
  */
 @property (nonatomic, strong, readonly) NSOutputStream *dataOutputStream;

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate_Private.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate_Private.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) dispatch_queue_t dataQueue;
 
 /**
- @abstract Defaults to to-memory output stream if not overwritten.
+ Defaults to to-memory output stream if not overwritten.
  */
 @property (nonatomic, strong, readonly) NSOutputStream *dataOutputStream;
 @property (nonatomic, assign, readonly) uint64_t downloadedBytes;

--- a/Parse/Internal/Commands/PFRESTCommand.m
+++ b/Parse/Internal/Commands/PFRESTCommand.m
@@ -136,7 +136,7 @@ static const int PFRESTCommandCacheKeyVersion = 1;
 
 #pragma mark Local Identifiers
 
-/*!
+/**
  If this was the second save on a new object while offline, then its objectId
  wasn't yet set when the command was created, so it would have been considered a
  "create". But if the first save succeeded, then there is an objectId now, and it

--- a/Parse/Internal/Config/Controller/PFConfigController.h
+++ b/Parse/Internal/Config/Controller/PFConfigController.h
@@ -34,7 +34,7 @@
 /// @name Fetch
 ///--------------------------------------
 
-/*!
+/**
  Fetches current config from network async.
 
  @param sessionToken Current user session token.

--- a/Parse/Internal/Config/Controller/PFConfigController.h
+++ b/Parse/Internal/Config/Controller/PFConfigController.h
@@ -39,7 +39,7 @@
 
  @param sessionToken Current user session token.
 
- @returns `BFTask` with result set to `PFConfig`.
+ @return `BFTask` with result set to `PFConfig`.
  */
 - (BFTask *)fetchConfigAsyncWithSessionToken:(NSString *)sessionToken;
 

--- a/Parse/Internal/FieldOperation/PFFieldOperation.h
+++ b/Parse/Internal/FieldOperation/PFFieldOperation.h
@@ -18,7 +18,7 @@
 #pragma mark - PFFieldOperation
 ///--------------------------------------
 
-/*!
+/**
  A PFFieldOperation represents a modification to a value in a PFObject.
  For example, setting, deleting, or incrementing a value are all different
  kinds of PFFieldOperations. PFFieldOperations themselves can be considered
@@ -26,7 +26,7 @@
  */
 @interface PFFieldOperation : NSObject
 
-/*!
+/**
  Converts the PFFieldOperation to a data structure (typically an NSDictionary)
  that can be converted to JSON and sent to Parse as part of a save operation.
 
@@ -35,7 +35,7 @@
  */
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder;
 
-/*!
+/**
  Returns a field operation that is composed of a previous operation followed by
  this operation. This will not mutate either operation. However, it may return
  self if the current operation is not affected by previous changes. For example:
@@ -49,7 +49,7 @@
  */
 - (PFFieldOperation *)mergeWithPrevious:(PFFieldOperation *)previous;
 
-/*!
+/**
  Returns a new estimated value based on a previous value and this operation. This
  value is not intended to be sent to Parse, but it used locally on the client to
  inspect the most likely current value for a field.
@@ -70,7 +70,7 @@
 #pragma mark - Independent Operations
 ///--------------------------------------
 
-/*!
+/**
  An operation where a field is set to a given value regardless of
  its previous value.
  */
@@ -84,7 +84,7 @@
 
 @end
 
-/*!
+/**
  An operation where a field is deleted from the object.
  */
 @interface PFDeleteOperation : PFFieldOperation
@@ -97,7 +97,7 @@
 #pragma mark - Numeric Operations
 ///--------------------------------------
 
-/*!
+/**
  An operation that increases a numeric field's value by a given amount.
  */
 @interface PFIncrementOperation : PFFieldOperation
@@ -114,7 +114,7 @@
 #pragma mark - Array Operations
 ///--------------------------------------
 
-/*!
+/**
  An operation that adds a new element to an array field.
  */
 @interface PFAddOperation : PFFieldOperation
@@ -125,7 +125,7 @@
 
 @end
 
-/*!
+/**
  An operation that adds a new element to an array field,
  only if it wasn't already present.
  */
@@ -137,7 +137,7 @@
 
 @end
 
-/*!
+/**
  An operation that removes every instance of an element from
  an array field.
  */
@@ -153,7 +153,7 @@
 #pragma mark - Relation Operations
 ///--------------------------------------
 
-/*!
+/**
  An operation where a PFRelation's value is modified.
  */
 @interface PFRelationOperation : PFFieldOperation

--- a/Parse/Internal/FieldOperation/PFFieldOperation.h
+++ b/Parse/Internal/FieldOperation/PFFieldOperation.h
@@ -31,7 +31,7 @@
  that can be converted to JSON and sent to Parse as part of a save operation.
 
  @param objectEncoder encoder that will be used to encode the object.
- @returns An object to be jsonified.
+ @return An object to be jsonified.
  */
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder;
 
@@ -45,7 +45,7 @@
  [{delete} mergeWithPrevious:{add "foo"}] -> {delete}
 
  @param previous The most recent operation on the field, or nil if none.
- @returns A new PFFieldOperation or self.
+ @return A new PFFieldOperation or self.
  */
 - (PFFieldOperation *)mergeWithPrevious:(PFFieldOperation *)previous;
 
@@ -60,7 +60,7 @@
  @param oldValue The previous value for the field.
  @param key The key that this value is for.
 
- @returns The new value for the field.
+ @return The new value for the field.
  */
 - (id)applyToValue:(id)oldValue forKey:(NSString *)key;
 

--- a/Parse/Internal/FieldOperation/PFFieldOperationDecoder.h
+++ b/Parse/Internal/FieldOperation/PFFieldOperationDecoder.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Decoding
 ///--------------------------------------
 
-/*!
+/**
  Converts a parsed JSON object into a PFFieldOperation.
 
  @param encoded An NSDictionary containing an __op field.

--- a/Parse/Internal/FieldOperation/PFFieldOperationDecoder.h
+++ b/Parse/Internal/FieldOperation/PFFieldOperationDecoder.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  Converts a parsed JSON object into a PFFieldOperation.
 
  @param encoded An NSDictionary containing an __op field.
- @returns An NSObject that conforms to PFFieldOperation.
+ @return An NSObject that conforms to PFFieldOperation.
  */
 - (PFFieldOperation *)decode:(NSDictionary *)encoded withDecoder:(PFDecoder *)decoder;
 

--- a/Parse/Internal/File/Controller/PFFileController.h
+++ b/Parse/Internal/File/Controller/PFFileController.h
@@ -41,7 +41,7 @@
 /// @name Download
 ///--------------------------------------
 
-/*!
+/**
  Downloads a file asynchronously with a given state.
 
  @param fileState         File state to download the file for.
@@ -54,7 +54,7 @@
                      cancellationToken:(BFCancellationToken *)cancellationToken
                          progressBlock:(PFProgressBlock)progressBlock;
 
-/*!
+/**
  Downloads a file asynchronously with a given state and yields a stream to the live download of that file.
 
  @param fileState File state to download the file for.
@@ -71,7 +71,7 @@
 /// @name Upload
 ///--------------------------------------
 
-/*!
+/**
  Uploads a file asynchronously from file path for a given file state.
 
  @param fileState         File state to upload the file for.

--- a/Parse/Internal/File/Controller/PFFileController.h
+++ b/Parse/Internal/File/Controller/PFFileController.h
@@ -48,7 +48,7 @@
  @param cancellationToken Cancellation token.
  @param progressBlock     Progress block to call (optional).
 
- @returns `BFTask` with a result set to `nil`.
+ @return `BFTask` with a result set to `nil`.
  */
 - (BFTask *)downloadFileAsyncWithState:(PFFileState *)fileState
                      cancellationToken:(BFCancellationToken *)cancellationToken
@@ -80,7 +80,7 @@
  @param cancellationToken Cancellation token.
  @param progressBlock     Progress block to call (optional).
 
- @returns `BFTask` with a result set to `PFFileState` of uploaded file.
+ @return `BFTask` with a result set to `PFFileState` of uploaded file.
  */
 - (BFTask *)uploadFileAsyncWithState:(PFFileState *)fileState
                       sourceFilePath:(NSString *)sourceFilePath

--- a/Parse/Internal/File/Controller/PFFileStagingController.h
+++ b/Parse/Internal/File/Controller/PFFileStagingController.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Staging
 ///--------------------------------------
 
-/*!
+/**
  Moves a file from the specified path to the staging directory based off of the name and unique ID passed in.
 
  @param filePath The source path to stage
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask *)stageFileAsyncAtPath:(NSString *)filePath name:(NSString *)name uniqueId:(uint64_t)uniqueId;
 
-/*!
+/**
  Creates a file from the specified data and places it into the staging directory based off of the name and unique 
  ID passed in.
 
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask *)stageFileAsyncWithData:(NSData *)fileData name:(NSString *)name uniqueId:(uint64_t)uniqueId;
 
-/*!
+/**
  Get the staged directory path for a file with the specified name and unique ID.
 
  @param name     The name of the staged file

--- a/Parse/Internal/File/FileDataStream/PFFileDataStream.h
+++ b/Parse/Internal/File/FileDataStream/PFFileDataStream.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  PFFileDataStream is an NSStream proxy which won't read the last byte of a file until the downlaod has finished.
 
  When downloading a file stream via `-[PFFile getDataDownloadStreamInBackground]`, we need to be able to read and write 

--- a/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.h
+++ b/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.h
@@ -30,7 +30,7 @@
 /// @name Accessors
 ///--------------------------------------
 
-/*!
+/**
  Returns a cached installationId or creates a new one, saves it to disk and returns it.
  */
 - (BFTask PF_GENERIC(NSString *)*)getInstallationIdentifierAsync;
@@ -39,7 +39,7 @@
 /// @name Clear
 ///--------------------------------------
 
-/*!
+/**
  Clears installation identifier on disk and in-memory.
  */
 - (BFTask *)clearInstallationIdentifierAsync;

--- a/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore_Private.h
+++ b/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore_Private.h
@@ -11,7 +11,7 @@
 
 @interface PFInstallationIdentifierStore (Private)
 
-/*!
+/**
  Clears in-memory cached installation identifier, if any.
  */
 - (BFTask *)_clearCachedInstallationIdentifierAsync;

--- a/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.h
+++ b/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.h
@@ -37,12 +37,12 @@ typedef NS_OPTIONS(uint8_t, PFOfflineQueryOption) {
 - (instancetype)initWithOfflineStore:(PFOfflineStore *)offlineStore;
 
 /**
- @returns YES iff the object is visible based on its read ACL and the given user objectId.
+ @return YES iff the object is visible based on its read ACL and the given user objectId.
  */
 + (BOOL)userHasReadAccess:(PFUser *)user ofObject:(PFObject *)object;
 
 /**
- @returns YES iff the object is visible based on its read ACL and the given user objectId.
+ @return YES iff the object is visible based on its read ACL and the given user objectId.
  */
 + (BOOL)userHasWriteAccess:(PFUser *)user ofObject:(PFObject *)object;
 
@@ -56,7 +56,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineQueryOption) {
 /**
  Sort given array with given `PFQuery` constraint.
 
- @returns sorted result.
+ @return sorted result.
  */
 - (NSArray *)resultsByApplyingOptions:(PFOfflineQueryOption)options
                          ofQueryState:(PFQueryState *)queryState

--- a/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.h
+++ b/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.h
@@ -30,30 +30,30 @@ typedef NS_OPTIONS(uint8_t, PFOfflineQueryOption) {
 
 @interface PFOfflineQueryLogic : NSObject
 
-/*!
+/**
  Initialize an `PFOfflineQueryLogic` instance with `PFOfflineStore` instance.
  `PFOfflineStore` is needed for subQuery, inQuery and fetch.
  */
 - (instancetype)initWithOfflineStore:(PFOfflineStore *)offlineStore;
 
-/*!
+/**
  @returns YES iff the object is visible based on its read ACL and the given user objectId.
  */
 + (BOOL)userHasReadAccess:(PFUser *)user ofObject:(PFObject *)object;
 
-/*!
+/**
  @returns YES iff the object is visible based on its read ACL and the given user objectId.
  */
 + (BOOL)userHasWriteAccess:(PFUser *)user ofObject:(PFObject *)object;
 
-/*!
+/**
  Returns a PFConstraintMatcherBlock that returns true iff the object matches the given
  query's constraints. This takes in a PFSQLiteDatabase connection because SQLite is finicky
  about nesting connections, so we want to reuse them whenever possible.
  */
 - (PFConstraintMatcherBlock)createMatcherForQueryState:(PFQueryState *)queryState user:(PFUser *)user;
 
-/*!
+/**
  Sort given array with given `PFQuery` constraint.
 
  @returns sorted result.
@@ -62,14 +62,14 @@ typedef NS_OPTIONS(uint8_t, PFOfflineQueryOption) {
                          ofQueryState:(PFQueryState *)queryState
                             toResults:(NSArray *)results;
 
-/*!
+/**
  Make sure all of the objects included by the given query get fetched.
  */
 - (BFTask *)fetchIncludesAsyncForResults:(NSArray *)results
                             ofQueryState:(PFQueryState *)queryState
                               inDatabase:(PFSQLiteDatabase *)database;
 
-/*!
+/**
  Make sure all of the objects included by the given query get fetched.
  */
 - (BFTask *)fetchIncludesForObjectAsync:(PFObject *)object

--- a/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
+++ b/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
@@ -28,7 +28,7 @@
 typedef BOOL (^PFComparatorDeciderBlock)(id value, id constraint);
 typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
 
-/*!
+/**
  A query to be used in $inQuery, $notInQuery, $select and $dontSelect
  */
 @interface PFSubQueryMatcher : NSObject
@@ -161,7 +161,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
 #pragma mark - Matcher With Decider
 ///--------------------------------------
 
-/*!
+/**
  Returns YES if decider returns YES for any value in the given array.
  */
 + (BOOL)matchesArray:(NSArray *)array
@@ -175,7 +175,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
     return NO;
 }
 
-/*!
+/**
  Returns YES if decider returns YES for any value in the given array.
  */
 + (BOOL)matchesValue:(id)value
@@ -192,7 +192,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
 #pragma mark - Matcher
 ///--------------------------------------
 
-/*!
+/**
  Implements simple equality constraints. This emulates Mongo's behavior where "equals" can mean array containment.
  */
 + (BOOL)matchesValue:(id)value
@@ -215,7 +215,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
     }];
 }
 
-/*!
+/**
  Matches $ne constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -223,7 +223,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
     return ![self matchesValue:value equalTo:constraint];
 }
 
-/*!
+/**
  Matches $lt constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -237,7 +237,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
     }];
 }
 
-/*!
+/**
  Matches $lte constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -251,7 +251,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
     }];
 }
 
-/*!
+/**
  Matches $gt constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -265,7 +265,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
     }];
 }
 
-/*!
+/**
  Matches $gte constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -279,7 +279,7 @@ greaterThanOrEqualTo:(id)constraint {
     }];
 }
 
-/*!
+/**
  Matches $in constraints.
  $in returns YES if the intersection of value and constraint is not an empty set.
  */
@@ -299,7 +299,7 @@ greaterThanOrEqualTo:(id)constraint {
     return NO;
 }
 
-/*!
+/**
  Matches $nin constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -307,7 +307,7 @@ greaterThanOrEqualTo:(id)constraint {
     return ![self matchesValue:value containedIn:constraint];
 }
 
-/*!
+/**
  Matches $all constraints.
  */
 + (BOOL)matchesValue:(id)value containsAllObjectsInArray:(id)constraints {
@@ -322,7 +322,7 @@ greaterThanOrEqualTo:(id)constraint {
     return YES;
 }
 
-/*!
+/**
  Matches $regex constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -361,7 +361,7 @@ greaterThanOrEqualTo:(id)constraint {
     return matches.count > 0;
 }
 
-/*!
+/**
  Matches $exists constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -373,7 +373,7 @@ greaterThanOrEqualTo:(id)constraint {
     return value == nil || value == [NSNull null];
 }
 
-/*!
+/**
  Matches $nearSphere constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -390,7 +390,7 @@ greaterThanOrEqualTo:(id)constraint {
     return [point1 distanceInRadiansTo:point2] <= [maxDistance doubleValue];
 }
 
-/*!
+/**
  Matches $within constraints.
  */
 + (BOOL)matchesValue:(id)value
@@ -415,7 +415,7 @@ greaterThanOrEqualTo:(id)constraint {
             target.longitude <= northEast.longitude);
 }
 
-/*!
+/**
  Returns YES iff the given value matches the given operator and constraint.
  Raise NSInvalidArgumentException if the operator is not one this function can handle
  */
@@ -463,7 +463,7 @@ greaterThanOrEqualTo:(id)constraint {
     return YES;
 }
 
-/*!
+/**
  Creates a matcher that handles $inQuery constraints.
  */
 - (PFConstraintMatcherBlock)createMatcherForKey:(NSString *)key
@@ -478,7 +478,7 @@ greaterThanOrEqualTo:(id)constraint {
     } user:user];
 }
 
-/*!
+/**
  Creates a matcher that handles $notInQuery constraints.
  */
 - (PFConstraintMatcherBlock)createMatcherForKey:(NSString *)key
@@ -492,7 +492,7 @@ greaterThanOrEqualTo:(id)constraint {
     };
 }
 
-/*!
+/**
  Creates a matcher that handles $select constraints.
  */
 - (PFConstraintMatcherBlock)createMatcherForKey:(NSString *)key
@@ -515,7 +515,7 @@ greaterThanOrEqualTo:(id)constraint {
     } user:user];
 }
 
-/*!
+/**
  Creates a matcher that handles $dontSelect constraints.
  */
 - (PFConstraintMatcherBlock)createMatcherForKey:(NSString *)key
@@ -529,7 +529,7 @@ greaterThanOrEqualTo:(id)constraint {
     };
 }
 
-/*!
+/**
  Creates a matcher for a particular constraint operator.
  */
 - (PFConstraintMatcherBlock)createMatcherWithOperator:(NSString *)operator
@@ -557,7 +557,7 @@ greaterThanOrEqualTo:(id)constraint {
     }
 }
 
-/*!
+/**
  Handles $or queries.
  */
 - (PFConstraintMatcherBlock)createOrMatcherForQueries:(NSArray *)queries user:(PFUser *)user {
@@ -582,7 +582,7 @@ greaterThanOrEqualTo:(id)constraint {
     };
 }
 
-/*!
+/**
  Returns a PFConstraintMatcherBlock that return true iff the object matches queryConstraints. This
  takes in a SQLiteDatabase connection because SQLite is finicky about nesting connections, so we
  want to reuse them whenever possible.

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
@@ -46,7 +46,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 
 - (BFTask *)fetchObjectLocallyAsync:(PFObject *)object;
 
-/*!
+/**
  Gets the data for the given object from the offline database. Returns a task that will be
  completed if data for the object was available. If the object is not in the cache, the task
  will be faulted, with a CACHE_MISS error.
@@ -64,7 +64,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 - (BFTask *)saveObjectLocallyAsync:(PFObject *)object includeChildren:(BOOL)includeChildren;
 - (BFTask *)saveObjectLocallyAsync:(PFObject *)object withChildren:(NSArray *)children;
 
-/*!
+/**
  Stores an object (and optionally, every object it points to recursively) in the local database.
  If any of the objects have not been fetched from Parse, they will not be stored. However, if
  they have changed data, the data will be retained. To get the objects back later, you can use a
@@ -85,7 +85,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /// @name Find
 ///--------------------------------------
 
-/*!
+/**
  Runs a PFQueryState against the store's contents.
 
  @returns The objects that match the query's constraint.
@@ -94,7 +94,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
                               user:(PFUser *)user
                                pin:(PFPin *)pin;
 
-/*!
+/**
  Runs a PFQueryState against the store's contents.
 
  @returns The count of objects that match the query's constraint.
@@ -103,7 +103,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
                                user:(PFUser *)user
                                 pin:(PFPin *)pin;
 
-/*!
+/**
  Runs a PFQueryState against the store's contents.
 
  @returns The objects that match the query's constraint.
@@ -113,7 +113,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
                                pin:(PFPin *)pin
                            isCount:(BOOL)isCount;
 
-/*!
+/**
  Runs a PFQueryState against the store's contents. May cause any instances of the object to get fetched from
  offline database. (TODO (hallucinogen): should we consider objects in memory but not in Offline Store?)
 
@@ -135,7 +135,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /// @name Update Internal State
 ///--------------------------------------
 
-/*!
+/**
  Takes an object that has been fetched from the database before and updates it with whatever
  data is in memory. This will only be used when data comes back from the server after a fetch
  or a save.
@@ -146,7 +146,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /// @name Delete
 ///--------------------------------------
 
-/*!
+/**
  Deletes the given object from Offline Store's pins
  */
 - (BFTask *)deleteDataForObjectAsync:(PFObject *)object;
@@ -161,14 +161,14 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /// @name Internal Helper Methods
 ///--------------------------------------
 
-/*!
+/**
  Gets the UUID for the given object, if it has one. Otherwise, creates a new UUID for the object
  and adds a new row to the database for the object with no data.
  */
 - (BFTask *)getOrCreateUUIDAsyncForObject:(PFObject *)object
                                  database:(PFSQLiteDatabase *)database;
 
-/*!
+/**
  This should only be called from `PFObject.objectWithoutDataWithClassName`.
 
  @returns an object from OfflineStore cache. If nil is returned the object is not found in the cache.
@@ -176,7 +176,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 - (PFObject *)getOrCreateObjectWithoutDataWithClassName:(NSString *)className
                                                objectId:(NSString *)objectId;
 
-/*!
+/**
  When an object is finished saving, it gets an objectId. Then it should call this method to
  clean up the bookeeping around ids.
  */
@@ -188,12 +188,12 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /// @name Unit Test Helper Methods
 ///--------------------------------------
 
-/*!
+/**
  Used in unit testing only. Clears all in-memory caches so that data must be retrieved from disk.
  */
 - (void)simulateReboot;
 
-/*!
+/**
  Used in unit testing only. Clears the database on disk.
  */
 - (void)clearDatabase;

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
@@ -88,7 +88,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /**
  Runs a PFQueryState against the store's contents.
 
- @returns The objects that match the query's constraint.
+ @return The objects that match the query's constraint.
  */
 - (BFTask *)findAsyncForQueryState:(PFQueryState *)queryState
                               user:(PFUser *)user
@@ -97,7 +97,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /**
  Runs a PFQueryState against the store's contents.
 
- @returns The count of objects that match the query's constraint.
+ @return The count of objects that match the query's constraint.
  */
 - (BFTask *)countAsyncForQueryState:(PFQueryState *)queryState
                                user:(PFUser *)user
@@ -106,7 +106,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /**
  Runs a PFQueryState against the store's contents.
 
- @returns The objects that match the query's constraint.
+ @return The objects that match the query's constraint.
  */
 - (BFTask *)findAsyncForQueryState:(PFQueryState *)queryState
                               user:(PFUser *)user
@@ -123,7 +123,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
  @param isCount     YES if we're doing count.
  @param database    The PFSQLiteDatabase
 
- @returns The objects that match the query's constraint.
+ @return The objects that match the query's constraint.
  */
 - (BFTask *)findAsyncForQueryState:(PFQueryState *)queryState
                               user:(PFUser *)user
@@ -171,7 +171,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions)
 /**
  This should only be called from `PFObject.objectWithoutDataWithClassName`.
 
- @returns an object from OfflineStore cache. If nil is returned the object is not found in the cache.
+ @return an object from OfflineStore cache. If nil is returned the object is not found in the cache.
  */
 - (PFObject *)getOrCreateObjectWithoutDataWithClassName:(NSString *)className
                                                objectId:(NSString *)objectId;

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -881,7 +881,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
 
  @param uuid        The UUID of the object to retrieve.
  @param database    The database instance to retrieve from.
- @returns The object with that UUID.
+ @return The object with that UUID.
  */
 - (BFTask *)_getPointerAsyncWithUUID:(NSString *)uuid database:(PFSQLiteDatabase *)database {
     @synchronized (self.lock) {

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -51,28 +51,28 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
 
 @property (nonatomic, strong, readonly) NSObject *lock;
 
-/*!
+/**
  In-memory map of (className, objectId) to ParseObject. This is used so that we can
  always return the same instance for a given object. Objects in this map may or may
  not be in the database.
  */
 @property (nonatomic, strong, readonly) NSMapTable *classNameAndObjectIdToObjectMap;
 
-/*!
+/**
  In-memory set of ParseObjects that have been fetched from local database already.
  If the object is in the map, a fetch of it has been started. If the value is a
  finished task, then the fetch was completed.
  */
 @property (nonatomic, strong, readonly) NSMapTable *fetchedObjects;
 
-/*!
+/**
  In-memory map of ParseObject to UUID. This is used so that we can always return
  the same instance for a given object. Objects in this map may or may not be in the
  database.
  */
 @property (nonatomic, strong, readonly) NSMapTable *objectToUUIDMap;
 
-/*!
+/**
  In-memory map of UUID to ParseObject. This is used so we can always return
  the same instance for a given object. The only objects in this map are ones that
  are in database.
@@ -873,7 +873,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
 
 #pragma mark Pointers
 
-/*!
+/**
  Gets an unfetched pointer to an object in the database, based on its uuid. The object may or may
  not be in memory, but it must be in database. If it is already in memory, the instance will be
  returned. Since this is only for creating pointers to objects that are referenced by other objects

--- a/Parse/Internal/LocalDataStore/Pin/PFPin.h
+++ b/Parse/Internal/LocalDataStore/Pin/PFPin.h
@@ -15,7 +15,7 @@
 extern NSString *const PFPinKeyName;
 extern NSString *const PFPinKeyObjects;
 
-/*!
+/**
  PFPin represent internal pin implementation of PFObject's `pin`.
  */
 @interface PFPin : PFObject<PFSubclassing>

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
@@ -19,22 +19,22 @@
 
 typedef id __nullable(^PFSQLiteDatabaseQueryBlock)(PFSQLiteDatabaseResult *__nonnull result);
 
-/*!
+/**
  Argument count given in executeSQLAsync or executeQueryAsync is invalid.
  */
 extern int const PFSQLiteDatabaseInvalidArgumenCountErrorCode;
 
-/*!
+/**
  Method `executeSQL` cannot execute SELECT. Use `executeQuery` instead.
  */
 extern int const PFSQLiteDatabaseInvalidSQL;
 
-/*!
+/**
  Database is opened already.
  */
 extern int const PFSQLiteDatabaseDatabaseAlreadyOpened;
 
-/*!
+/**
  Database is closed already.
  */
 extern int const PFSQLiteDatabaseDatabaseAlreadyClosed;
@@ -59,17 +59,17 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Connection
 ///--------------------------------------
 
-/*!
+/**
  @returns A `BFTask` that resolves to `YES` if the database is open.
  */
 - (BFTask *)isOpenAsync;
 
-/*!
+/**
  Opens database. Database is one time use. Open > Close > Open is forbidden.
  */
 - (BFTask *)openAsync;
 
-/*!
+/**
  Closes the database connection.
  */
 - (BFTask *)closeAsync;
@@ -78,17 +78,17 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Transaction
 ///--------------------------------------
 
-/*!
+/**
  Begins a database transaction in EXCLUSIVE mode.
  */
 - (BFTask *)beginTransactionAsync;
 
-/*!
+/**
  Commits running transaction.
  */
 - (BFTask *)commitAsync;
 
-/*!
+/**
  Rollbacks running transaction.
  */
 - (BFTask *)rollbackAsync;
@@ -97,17 +97,17 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Query Methods
 ///--------------------------------------
 
-/*!
+/**
  Runs a single SQL statement which return result (SELECT).
  */
 - (BFTask *)executeQueryAsync:(NSString *)query withArgumentsInArray:(nullable NSArray *)args block:(PFSQLiteDatabaseQueryBlock)block;
 
-/*!
+/**
  Runs a single SQL statement, while caching the resulting statement for future use.
  */
 - (BFTask *)executeCachedQueryAsync:(NSString *)sql withArgumentsInArray:(nullable NSArray *)args;
 
-/*!
+/**
  Runs a single SQL statement which doesn't return result (UPDATE/INSERT/DELETE).
  */
 - (BFTask *)executeSQLAsync:(NSString *)sql withArgumentsInArray:(nullable NSArray *)args;

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @returns A `BFTask` that resolves to `YES` if the database is open.
+ @return A `BFTask` that resolves to `YES` if the database is open.
  */
 - (BFTask *)isOpenAsync;
 

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.m
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.m
@@ -44,12 +44,12 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
     NSMutableDictionary *_cachedStatements;
 }
 
-/*!
+/**
  Database instance
  */
 @property (nonatomic, assign) sqlite3 *database;
 
-/*!
+/**
  Database path
  */
 @property (nonatomic, copy) NSString *databasePath;
@@ -265,7 +265,7 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
     }];
 }
 
-/*!
+/**
  bindObject will bind any object supported by PFSQLiteDatabase to query statement.
  Note: sqlite3 query index binding is one-based, while querying result is zero-based.
  */
@@ -317,7 +317,7 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
 #pragma mark - Errors
 ///--------------------------------------
 
-/*!
+/**
  Generates SQLite error. The details of the error code can be seen in: www.sqlite.org/c3ref/errcode.html
  */
 - (NSError *)_errorWithErrorCode:(int)errorCode {
@@ -331,7 +331,7 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
                               domain:PFSQLiteDatabaseErrorSQLiteDomain];
 }
 
-/*!
+/**
  Generates SQLite/PFSQLiteDatabase error.
  */
 - (NSError *)_errorWithErrorCode:(int)errorCode

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Asynchronously opens a database connection to the database with the name specified.
+ Asynchronously opens a database connection to the database with the name specified.
  @note Only one database can be actively open at a time.
 
  @param name The name of the database to open.

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Opening
 ///--------------------------------------
 
-/*!
+/**
  @abstract Asynchronously opens a database connection to the database with the name specified.
  @note Only one database can be actively open at a time.
 

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.h
@@ -17,19 +17,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithStatement:(PFSQLiteStatement *)statement queue:(dispatch_queue_t)queue;
 
-/*!
+/**
  Move current result to next row. Returns true if next result exists. False if current result
  is the end of result set.
  */
 - (BOOL)next;
 
-/*!
+/**
  Move the current result to next row, and returns the raw SQLite return code for the cursor.
  Useful for detecting end of cursor vs. error.
  */
 - (int)step;
 
-/*!
+/**
  Closes the database result.
  */
 - (BOOL)close;

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteStatement.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteStatement.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  PFSQLiteStatement is sqlite3_stmt wrapper class.
  */
 typedef struct sqlite3_stmt sqlite3_stmt;

--- a/Parse/Internal/MultiProcessLock/PFMultiProcessFileLockController.h
+++ b/Parse/Internal/MultiProcessLock/PFMultiProcessFileLockController.h
@@ -15,7 +15,7 @@
 //TODO: (nlutsenko) Re-consider using singleton here.
 + (instancetype)sharedController;
 
-/*!
+/**
  Increments the content access counter by 1.
  If the count was 0 - this will try to acquire the file lock first.
 
@@ -23,7 +23,7 @@
  */
 - (void)beginLockedContentAccessForFileAtPath:(NSString *)filePath;
 
-/*!
+/**
  Decrements the content access counter by 1.
  If the count reaches 0 - the lock is going to be released.
 

--- a/Parse/Internal/Object/Coder/File/PFObjectFileCoder.h
+++ b/Parse/Internal/Object/Coder/File/PFObjectFileCoder.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  Handles encoding/decoding of `PFObject`s into a /2 JSON format.
  /2 format is only used for persisting `currentUser`, `currentInstallation` to disk when LDS is not enabled.
  */

--- a/Parse/Internal/Object/Controller/PFObjectControlling.h
+++ b/Parse/Internal/Object/Controller/PFObjectControlling.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Fetch
 ///--------------------------------------
 
-/*!
+/**
  Fetches an object asynchronously.
 
  @param object       Object to fetch.
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Delete
 ///--------------------------------------
 
-/*!
+/**
  Deletes an object asynchronously.
 
  @param object       Object to fetch.

--- a/Parse/Internal/Object/Controller/PFObjectControlling.h
+++ b/Parse/Internal/Object/Controller/PFObjectControlling.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param object       Object to fetch.
  @param sessionToken Session token to use.
 
- @returns `BFTask` with result set to `PFObject`.
+ @return `BFTask` with result set to `PFObject`.
  */
 - (BFTask *)fetchObjectAsync:(PFObject *)object withSessionToken:(nullable NSString *)sessionToken;
 
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param object       Object to fetch.
  @param sessionToken Session token to use.
 
- @returns `BFTask` with result set to `nil`.
+ @return `BFTask` with result set to `nil`.
  */
 - (BFTask *)deleteObjectAsync:(PFObject *)object withSessionToken:(nullable NSString *)sessionToken;
 

--- a/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
+++ b/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
@@ -38,7 +38,7 @@
 
  @param key File name to use.
 
- @returns `BFTask` with `PFObject` or `nil` result.
+ @return `BFTask` with `PFObject` or `nil` result.
  */
 - (BFTask PF_GENERIC(PFObject *)*)loadPersistentObjectAsyncForKey:(NSString *)key;
 
@@ -48,7 +48,7 @@
  @param object Object to save.
  @param key    File name to use.
 
- @returns `BFTask` with `nil` result.
+ @return `BFTask` with `nil` result.
  */
 - (BFTask *)persistObjectAsync:(PFObject *)object forKey:(NSString *)key;
 

--- a/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
+++ b/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
@@ -33,7 +33,7 @@
 /// @name Objects
 ///--------------------------------------
 
-/*!
+/**
  Loads and creates a PFObject from file.
 
  @param key File name to use.
@@ -42,7 +42,7 @@
  */
 - (BFTask PF_GENERIC(PFObject *)*)loadPersistentObjectAsyncForKey:(NSString *)key;
 
-/*!
+/**
  Saves a given object to a file with name.
 
  @param object Object to save.
@@ -52,7 +52,7 @@
  */
 - (BFTask *)persistObjectAsync:(PFObject *)object forKey:(NSString *)key;
 
-/*!
+/**
  Removes a given object.
 
  @param key Key to use.

--- a/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
+++ b/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
@@ -11,7 +11,7 @@
 
 #import "PFDataProvider.h"
 
-/*!
+/**
  A disk-based map of local ids to global Parse objectIds. Every entry in this
  map has a retain count, and the entry will be removed from the map if the
  retain count reaches 0. Every time a localId is written out to disk, its retain

--- a/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
+++ b/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
@@ -23,7 +23,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
 #pragma mark - PFObjectLocalIdStoreMapEntry
 ///--------------------------------------
 
-/*!
+/**
  * Internal class representing all the information we know about a local id.
  */
 @interface PFObjectLocalIdStoreMapEntry : NSObject
@@ -86,7 +86,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     PFNotDesignatedInitializer();
 }
 
-/*!
+/**
  * Creates a new LocalIdManager with default options.
  */
 - (instancetype)initWithDataSource:(id<PFFileManagerProvider>)dataSource {
@@ -118,7 +118,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
 #pragma mark - Accessors
 ///--------------------------------------
 
-/*!
+/**
  * Returns Yes if localId has the right basic format for a local id.
  */
 + (BOOL)isLocalId:(NSString *)localId {
@@ -136,7 +136,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     return YES;
 }
 
-/*!
+/**
  * Grabs one entry in the local id map off the disk.
  */
 - (PFObjectLocalIdStoreMapEntry *)getMapEntry:(NSString *)localId {
@@ -166,7 +166,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     return entry;
 }
 
-/*!
+/**
  * Writes one entry to the local id map on disk.
  */
 - (void)putMapEntry:(PFObjectLocalIdStoreMapEntry *)entry forLocalId:(NSString *)localId {
@@ -176,7 +176,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     [entry writeToFile:file];
 }
 
-/*!
+/**
  * Removes an entry from the local id map on disk.
  */
 - (void)removeMapEntry:(NSString *)localId {
@@ -186,7 +186,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     [[NSFileManager defaultManager] removeItemAtPath:file error:nil];
 }
 
-/*!
+/**
  * Creates a new local id in the map.
  */
 - (NSString *)createLocalId {
@@ -204,7 +204,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     }
 }
 
-/*!
+/**
  * Increments the retain count of a local id on disk.
  */
 - (void)retainLocalIdOnDisk:(NSString *)localId {
@@ -215,7 +215,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     }
 }
 
-/*!
+/**
  * Decrements the retain count of a local id on disk.
  * If the retain count hits zero, the id is forgotten forever.
  */
@@ -230,7 +230,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     }
 }
 
-/*!
+/**
  * Sets the objectId associated with a given local id.
  */
 - (void)setObjectId:(NSString *)objectId forLocalId:(NSString *)localId {
@@ -244,7 +244,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     }
 }
 
-/*!
+/**
  * Returns the objectId associated with a given local id.
  * Returns nil if no objectId is yet known for the lcoal id.
  */
@@ -260,7 +260,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     }
 }
 
-/*!
+/**
  * Removes all local ids from the disk and memory caches.
  */
 - (BOOL)clear {
@@ -279,7 +279,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     }
 }
 
-/*!
+/**
  * Removes all local ids from the memory cache.
  */
 - (void)clearInMemoryCache {

--- a/Parse/Internal/Object/OperationSet/PFOperationSet.h
+++ b/Parse/Internal/Object/OperationSet/PFOperationSet.h
@@ -13,38 +13,38 @@
 @class PFEncoder;
 @class PFFieldOperation;
 
-/*!
+/**
  A set of field-level operations that can be performed on an object, corresponding to one
  command. For example, all the data for a single call to save() will be packaged here. It is
  assumed that the PFObject that owns the operations handles thread-safety.
  */
 @interface PFOperationSet : NSObject <NSCopying, NSFastEnumeration>
 
-/*!
+/**
  Returns true if this set corresponds to a call to saveEventually.
  */
 @property (nonatomic, assign, getter=isSaveEventually) BOOL saveEventually;
 
-/*!
+/**
  A unique id for this operation set.
  */
 @property (nonatomic, copy, readonly) NSString *uuid;
 
 @property (nonatomic, copy) NSDate *updatedAt;
 
-/*!
+/**
  Merges the changes from the given operation set into this one. Most typically, this is what
  happens when a save fails and changes need to be rolled into the next save.
  */
 - (void)mergeOperationSet:(PFOperationSet *)other;
 
-/*!
+/**
  Converts this operation set into its REST format for serializing to the pinning store
  */
 - (NSDictionary *)RESTDictionaryUsingObjectEncoder:(PFEncoder *)objectEncoder
                                  operationSetUUIDs:(NSArray **)operationSetUUIDs;
 
-/*!
+/**
  The inverse of RESTDictionaryUsingObjectEncoder.
  Creates a new OperationSet from the given NSDictionary
  */

--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -54,7 +54,7 @@
 /// @name Before Save
 ///--------------------------------------
 
-/*!
+/**
  Called before an object is going to be saved. Called in a context of object lock.
  Subclasses can override this method to do any custom updates before an object gets saved.
  */
@@ -69,7 +69,7 @@
 // Extension for property methods.
 @interface PFObject ()
 
-/*!
+/**
  @returns Current object state.
  */
 @property (nonatomic, copy) PFObjectState *_state;
@@ -102,7 +102,7 @@
 - (BFTask PF_GENERIC(PFVoid) *)_validateFetchAsync NS_REQUIRES_SUPER;
 - (BFTask PF_GENERIC(PFVoid) *)_validateDeleteAsync NS_REQUIRES_SUPER;
 
-/*!
+/**
  Validate the save eventually operation with the current state.
  The result of this task is ignored. The error/cancellation/exception will prevent `saveEventually`.
 
@@ -131,12 +131,12 @@
 
 @interface PFObject (Private)
 
-/*!
+/**
  Returns the object that should be used to synchronize all internal data access.
  */
 - (NSObject *)lock;
 
-/*!
+/**
  Blocks until all outstanding operations have completed.
  */
 - (void)waitUntilFinished;
@@ -147,7 +147,7 @@
 #pragma mark - Static methods for Subclassing
 ///--------------------------------------
 
-/*!
+/**
  Unregisters a class registered using registerSubclass:
  If we ever expose thsi method publicly, we must change the underlying implementation
  to have stack behavior. Currently unregistering a custom class for a built-in will
@@ -181,7 +181,7 @@
 #pragma mark - Validations
 ///--------------------------------------
 - (void)_checkSaveParametersWithCurrentUser:(PFUser *)currentUser;
-/*!
+/**
  Checks if Parse class name could be used to initialize a given instance of PFObject or it's subclass.
  */
 + (void)_assertValidInstanceClassName:(NSString *)className;
@@ -281,7 +281,7 @@
 #pragma mark - Subclass Helpers
 ///--------------------------------------
 
-/*!
+/**
  This method is called by -[PFObject init]; changes made to the object during this
  method will not mark the object as dirty. PFObject uses this method to to apply the
  default ACL; subclasses which override this method shold be sure to call the super
@@ -289,7 +289,7 @@
  */
 - (void)setDefaultValues;
 
-/*!
+/**
  This method allows subclasses to determine whether a default ACL should be applied
  to new instances.
  */

--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -70,7 +70,7 @@
 @interface PFObject ()
 
 /**
- @returns Current object state.
+ @return Current object state.
  */
 @property (nonatomic, copy) PFObjectState *_state;
 @property (nonatomic, copy) NSMutableSet *_availableKeys;
@@ -106,7 +106,7 @@
  Validate the save eventually operation with the current state.
  The result of this task is ignored. The error/cancellation/exception will prevent `saveEventually`.
 
- @returns Task that encapsulates the validation.
+ @return Task that encapsulates the validation.
  */
 - (BFTask PF_GENERIC(PFVoid) *)_validateSaveEventuallyAsync NS_REQUIRES_SUPER;
 

--- a/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
+++ b/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Pin
 ///--------------------------------------
 
-/*!
+/**
  Gets pin with name equals to given name.
 
  @param name Pin Name.
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask *)fetchPinAsyncWithName:(NSString *)name;
 
-/*!
+/**
  Pins given objects to the pin. Creates new pin if the pin with such name is not found.
 
  @param objects         Array of `PFObject`s to pin.
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Unpin
 ///--------------------------------------
 
-/*!
+/**
  Unpins given array of objects from the pin.
 
  @param objects Objects to unpin.
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask *)unpinObjectsAsync:(nullable NSArray *)objects withPinName:(NSString *)name;
 
-/*!
+/**
  Unpins all objects from the pin.
 
  @param name Pin name.

--- a/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
+++ b/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param name Pin Name.
 
- @returns `BFTask` with `PFPin` result if pinning succeeds.
+ @return `BFTask` with `PFPin` result if pinning succeeds.
  */
 - (BFTask *)fetchPinAsyncWithName:(NSString *)name;
 
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param name            Pin Name.
  @param includeChildren Whether children of `objects` should be pinned as well.
 
- @returns `BFTask` with `@YES` result.
+ @return `BFTask` with `@YES` result.
  */
 - (BFTask *)pinObjectsAsync:(nullable NSArray *)objects
                 withPinName:(NSString *)name
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param objects Objects to unpin.
  @param name    Pin name.
 
- @returns `BFTask` with `@YES` result.
+ @return `BFTask` with `@YES` result.
  */
 - (BFTask *)unpinObjectsAsync:(nullable NSArray *)objects withPinName:(NSString *)name;
 
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param name Pin name.
 
- @returns `BFTask` with `YES` result.
+ @return `BFTask` with `YES` result.
  */
 - (BFTask *)unpinAllObjectsAsyncWithPinName:(NSString *)name;
 

--- a/Parse/Internal/Object/State/PFObjectState.h
+++ b/Parse/Internal/Object/State/PFObjectState.h
@@ -57,7 +57,7 @@ typedef void(^PFObjectStateMutationBlock)(PFMutableObjectState *state);
 
  @param objectEncoder Encoder to use to encode custom objects.
 
- @returns `NSDictionary` instance representing object state.
+ @return `NSDictionary` instance representing object state.
  */
 - (NSDictionary *)dictionaryRepresentationWithObjectEncoder:(PFEncoder *)objectEncoder NS_REQUIRES_SUPER;
 

--- a/Parse/Internal/Object/State/PFObjectState.h
+++ b/Parse/Internal/Object/State/PFObjectState.h
@@ -50,7 +50,7 @@ typedef void(^PFObjectStateMutationBlock)(PFMutableObjectState *state);
 /// @name Coding
 ///--------------------------------------
 
-/*!
+/**
  Encodes all fields in `serverData`, `objectId`, `createdAt` and `updatedAt` into objects suitable for JSON/Persistence.
 
  @note `parseClassName` isn't automatically added to the dictionary.

--- a/Parse/Internal/PFApplication.h
+++ b/Parse/Internal/PFApplication.h
@@ -20,7 +20,7 @@
 @compatibility_alias UIApplication NSApplication;
 #endif
 
-/*!
+/**
  `PFApplication` class provides a centralized way to get the information about the current application,
  or the environment it's running in. Please note, that all device specific things - should go to <PFDevice>.
  */

--- a/Parse/Internal/PFAssert.h
+++ b/Parse/Internal/PFAssert.h
@@ -12,7 +12,7 @@
 #ifndef Parse_PFAssert_h
 #define Parse_PFAssert_h
 
-/*!
+/**
  Raises an `NSInvalidArgumentException` if the `condition` does not pass.
  Use `description` to supply the way to fix the exception.
  */
@@ -24,7 +24,7 @@
         } \
     } while(0)
 
-/*!
+/**
  Raises an `NSRangeException` if the `condition` does not pass.
  Use `description` to supply the way to fix the exception.
  */
@@ -36,7 +36,7 @@
     } \
 } while(0)
 
-/*!
+/**
  Raises an `NSInternalInconsistencyException` if the `condition` does not pass.
  Use `description` to supply the way to fix the exception.
  */
@@ -48,7 +48,7 @@
         } \
     } while(0)
 
-/*!
+/**
  Always raises `NSInternalInconsistencyException` with details
  about the method used and class that received the message
  */
@@ -61,7 +61,7 @@ do { \
     return nil; \
 } while (0)
 
-/*!
+/**
  Raises `NSInternalInconsistencyException` if current thread is not main thread.
  */
 #define PFAssertMainThread() \
@@ -69,7 +69,7 @@ do { \
     PFConsistencyAssert([NSThread isMainThread], @"This method must be called on the main thread."); \
 } while (0)
 
-/*!
+/**
  Raises `NSInternalInconsistencyException` if current thread is not the required one.
  */
 #define PFAssertIsOnThread(thread) \
@@ -78,7 +78,7 @@ do { \
                         @"This method must be called only on thread: %@.", thread); \
 } while (0)
 
-/*!
+/**
  Raises `NSInternalInconsistencyException` if the current queue
  is not the same as the queue provided.
  Make sure you mark the queue first via `PFMarkDispatchQueue`

--- a/Parse/Internal/PFBaseState.h
+++ b/Parse/Internal/PFBaseState.h
@@ -31,7 +31,7 @@ typedef NS_ENUM(uint8_t, PFPropertyInfoAssociationType) {
 
 @protocol PFBaseStateSubclass <NSObject>
 
-/*!
+/**
  This is the list of properties that should be used automatically for the methods implemented by PFBaseState.
 
  It should be a dictionary in the format of @{ @"<#property name#>": [PFPropertyAttributes attributes] }
@@ -43,7 +43,7 @@ typedef NS_ENUM(uint8_t, PFPropertyInfoAssociationType) {
 
 @end
 
-/*!
+/**
  Shared base class for all state objects.
  Implements -init, -description, -debugDescription, -hash, -isEqual:, -compareTo:, etc. for you.
  */
@@ -54,7 +54,7 @@ typedef NS_ENUM(uint8_t, PFPropertyInfoAssociationType) {
 
 - (NSComparisonResult)compare:(PFBaseState *)other;
 
-/*!
+/**
  Returns a dictionary representation of this object.
 
  Essentially, it takes the values for the keys of this object, and stuffs them in the dictionary.

--- a/Parse/Internal/PFCommandCache.h
+++ b/Parse/Internal/PFCommandCache.h
@@ -16,7 +16,7 @@
 @class PFCommandCacheTestHelper;
 @class PFObject;
 
-/*!
+/**
  ParseCommandCache manages an on-disk cache of commands to be executed, and a thread with a standard run loop
  that executes the commands.  There should only ever be one instance of this class, because multiple instances
  would be running separate threads trying to read and execute the same commands.
@@ -30,7 +30,7 @@
 /// @name Init
 ///--------------------------------------
 
-/*!
+/**
  Creates the command cache object for all ParseObjects with default configuration.
  This command cache is used to locally store save commands created by the [PFObject saveEventually].
  When a PFCommandCache is instantiated, it will begin running its run loop,

--- a/Parse/Internal/PFDateFormatter.h
+++ b/Parse/Internal/PFDateFormatter.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name String from Date
 ///--------------------------------------
 
-/*!
+/**
  Converts `NSDate` into `NSString` representation using the following format: yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
 
  @param date `NSDate` to convert.
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Date from String
 ///--------------------------------------
 
-/*!
+/**
  Converts `NSString` representation of a date into `NSDate` object.
 
  @discussion Following date formats are supported:

--- a/Parse/Internal/PFDateFormatter.h
+++ b/Parse/Internal/PFDateFormatter.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Converts `NSString` representation of a date into `NSDate` object.
 
- @discussion Following date formats are supported:
+ Following date formats are supported:
  YYYY-MM-DD
  YYYY-MM-DD HH:MM'Z'
  YYYY-MM-DD HH:MM:SS'Z'

--- a/Parse/Internal/PFDateFormatter.h
+++ b/Parse/Internal/PFDateFormatter.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param date `NSDate` to convert.
 
- @returns Formatted `NSString` representation.
+ @return Formatted `NSString` representation.
  */
 - (NSString *)preciseStringFromDate:(NSDate *)date;
 
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param string `NSString` representation to convert.
 
- @returns `NSDate` incapsulating the date.
+ @return `NSDate` incapsulating the date.
  */
 - (NSDate *)dateFromString:(NSString *)string;
 

--- a/Parse/Internal/PFDecoder.h
+++ b/Parse/Internal/PFDecoder.h
@@ -13,12 +13,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PFDecoder : NSObject
 
-/*!
+/**
  Globally available shared instance of PFDecoder.
  */
 + (PFDecoder *)objectDecoder;
 
-/*!
+/**
  Takes a complex object that was deserialized and converts encoded
  dictionaries into the proper Parse types. This is the inverse of
  encodeObject:allowUnsaved:allowObjects:seenObjects:.
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/*!
+/**
  Extends the normal JSON to PFObject decoding to also deal with placeholders for new objects
  that have been saved offline.
  */
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-/*!
+/**
  A subclass of PFDecoder which can keep PFObject that has been fetched instead of creating a new instance.
  */
 @interface PFKnownParseObjectDecoder : PFDecoder

--- a/Parse/Internal/PFDecoder.m
+++ b/Parse/Internal/PFDecoder.m
@@ -135,7 +135,7 @@
 
 @interface PFOfflineDecoder ()
 
-/*!
+/**
  A map of UUID to Task that will be finished once the given PFObject is loaded.
  The Tasks should all be finished before decode is called.
  */

--- a/Parse/Internal/PFEncoder.h
+++ b/Parse/Internal/PFEncoder.h
@@ -31,21 +31,21 @@
 
 @end
 
-/*!
+/**
  Encoding strategy that rejects PFObject.
  */
 @interface PFNoObjectEncoder : PFEncoder
 
 @end
 
-/*!
+/**
  Encoding strategy that encodes PFObject to PFPointer with objectId or with localId.
  */
 @interface PFPointerOrLocalIdObjectEncoder : PFEncoder
 
 @end
 
-/*!
+/**
  Encoding strategy that encodes PFObject to PFPointer with objectId and rejects
  unsaved PFObject.
  */
@@ -53,7 +53,7 @@
 
 @end
 
-/*!
+/**
  Encoding strategy that can encode objects that are available offline. After using this encoder,
  you must call encodeFinished and wait for its result to be finished before the results of the
  encoding will be valid.

--- a/Parse/Internal/PFErrorUtilities.h
+++ b/Parse/Internal/PFErrorUtilities.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PFErrorUtilities : NSObject
 
-/*!
+/**
  Construct an error object from a code and a message.
 
  @description Note that this logs all errors given to it.
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSError *)errorWithCode:(NSInteger)code message:(NSString *)message;
 + (NSError *)errorWithCode:(NSInteger)code message:(NSString *)message shouldLog:(BOOL)shouldLog;
 
-/*!
+/**
  Construct an error object from a result dictionary the API returned.
 
  @description Note that this logs all errors given to it.

--- a/Parse/Internal/PFEventuallyPin.h
+++ b/Parse/Internal/PFEventuallyPin.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSUInteger, PFEventuallyPinType) {
     PFEventuallyPinTypeCommand
 };
 
-/*!
+/**
  PFEventuallyPin represents PFCommand that's save locally so that it can be executed eventually.
 
  Properties of PFEventuallyPin:
@@ -58,12 +58,12 @@ typedef NS_ENUM(NSUInteger, PFEventuallyPinType) {
 #pragma mark - Eventually Pin
 ///--------------------------------------
 
-/*!
+/**
  Wrap given PFObject and PFCommand in a PFEventuallyPin with auto-generated UUID.
  */
 + (BFTask *)pinEventually:(PFObject *)object forCommand:(id<PFNetworkCommand>)command;
 
-/*!
+/**
  Wrap given PFObject and PFCommand in a PFEventuallyPin with given UUID.
  */
 + (BFTask *)pinEventually:(PFObject *)object forCommand:(id<PFNetworkCommand>)command withUUID:(NSString *)uuid;

--- a/Parse/Internal/PFEventuallyQueue.h
+++ b/Parse/Internal/PFEventuallyQueue.h
@@ -32,7 +32,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 
 @property (nonatomic, assign, readonly) NSUInteger commandCount;
 
-/*!
+/**
  Controls whether the queue should monitor network reachability and pause itself when there is no connection.
  Default: `YES`.
  */

--- a/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Internal/PFEventuallyQueue.m
@@ -398,7 +398,7 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
 #pragma mark - Accessors
 ///--------------------------------------
 
-/*! Manually sets the network connection status. */
+/** Manually sets the network connection status. */
 - (void)setConnected:(BOOL)connected {
     BFTaskCompletionSource *barrier = [BFTaskCompletionSource taskCompletionSource];
     dispatch_async(_processingQueue, ^{
@@ -426,7 +426,7 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
 #pragma mark - Test Helper Method
 ///--------------------------------------
 
-/*! Makes this command cache forget all the state it keeps during a single run of the app. */
+/** Makes this command cache forget all the state it keeps during a single run of the app. */
 - (void)_simulateReboot {
     // Make sure there is no command pending enqueuing
     [[[[_commandEnqueueTaskQueue enqueue:^BFTask *(BFTask *toAwait) {
@@ -441,12 +441,12 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
     }] waitUntilFinished];
 }
 
-/*! Test helper to return how many commands are being retained in memory by the cache. */
+/** Test helper to return how many commands are being retained in memory by the cache. */
 - (int)_commandsInMemory {
     return (int)[_taskCompletionSources count];
 }
 
-/*! Called by PFObject whenever an object has been updated after a saveEventually. */
+/** Called by PFObject whenever an object has been updated after a saveEventually. */
 - (void)_notifyTestHelperObjectUpdated {
     [self.testHelper notify:PFEventuallyQueueEventObjectUpdated];
 }

--- a/Parse/Internal/PFEventuallyQueue_Private.h
+++ b/Parse/Internal/PFEventuallyQueue_Private.h
@@ -34,7 +34,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 
     NSMutableDictionary *_taskCompletionSources;
 
-    /*!
+    /**
      Task queue that will enqueue command enqueueing task so that we enqueue the command
      one at a time.
      */
@@ -43,7 +43,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 
 @property (nonatomic, assign, readwrite, getter=isConnected) BOOL connected;
 
-/*!
+/**
  This method is used to do some work after the command is finished running and
  either succeeded or dropped from queue with error/exception.
 
@@ -87,12 +87,12 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 ///--------------------------------------
 
 
-/*!
+/**
  Generates a new identifier for a command so that it can be sorted later by this identifier.
  */
 - (NSString *)_newIdentifierForCommand:(id<PFNetworkCommand>)command;
 
-/*!
+/**
  This method is triggered on batch processing of the queue.
  It will capture the identifiers and use them to execute commands.
 
@@ -100,7 +100,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
  */
 - (NSArray *)_pendingCommandIdentifiers;
 
-/*!
+/**
  This method should return a command for a given identifier.
 
  @param identifier An identifier of a command, that was in array returned by <_pendingCommandIdentifiers>
@@ -114,7 +114,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 /// @name Running Commands
 ///--------------------------------------
 
-/*!
+/**
  This method serves as a way to do any kind of work to enqueue a command properly.
  If the task fails with an error/exception or is cancelled - execution won't start.
 

--- a/Parse/Internal/PFEventuallyQueue_Private.h
+++ b/Parse/Internal/PFEventuallyQueue_Private.h
@@ -50,7 +50,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
  @param command    Command that was run.
  @param identifier Unique identifier of the command
  @param resultTask Task that represents the result of running a command.
- @returns A continuation task in case the EventuallyQueue need to do something.
+ @return A continuation task in case the EventuallyQueue need to do something.
  Typically this will return back given resultTask.
  */
 - (BFTask *)_didFinishRunningCommand:(id<PFNetworkCommand>)command
@@ -96,7 +96,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
  This method is triggered on batch processing of the queue.
  It will capture the identifiers and use them to execute commands.
 
- @returns An array of identifiers of all commands that are pending sorted by the order they're enqueued.
+ @return An array of identifiers of all commands that are pending sorted by the order they're enqueued.
  */
 - (NSArray *)_pendingCommandIdentifiers;
 
@@ -106,7 +106,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
  @param identifier An identifier of a command, that was in array returned by <_pendingCommandIdentifiers>
  @param error      Pointer to `NSError *` that should be set if the method failed to construct/retrieve a command.
 
- @returns A command that needs to be run, or `nil` if there was an error.
+ @return A command that needs to be run, or `nil` if there was an error.
  */
 - (id<PFNetworkCommand>)_commandWithIdentifier:(NSString *)identifier error:(NSError **)error;
 
@@ -121,7 +121,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
  @param command              Command that needs to be enqueued
  @param object               The object on which the command is run against.
  @param identifier           Unique identifier used to represent a command.
- @returns Task that is resolved when the command is complete enqueueing.
+ @return Task that is resolved when the command is complete enqueueing.
  */
 - (BFTask *)_enqueueCommandInBackground:(id<PFNetworkCommand>)command
                                  object:(PFObject *)object

--- a/Parse/Internal/PFFileManager.h
+++ b/Parse/Internal/PFFileManager.h
@@ -55,7 +55,7 @@ typedef NS_OPTIONS(uint8_t, PFFileManagerOptions) {
 - (instancetype)initWithApplicationIdentifier:(NSString *)applicationIdentifier
                    applicationGroupIdentifier:(NSString *)applicationGroupIdentifier NS_DESIGNATED_INITIALIZER;
 
-/*!
+/**
  Returns <Application Home>/Library/Private Documents/Parse
  for non-user generated data that shouldn't be deleted by iOS, such as "offline data".
 
@@ -64,7 +64,7 @@ typedef NS_OPTIONS(uint8_t, PFFileManagerOptions) {
 - (NSString *)parseDefaultDataDirectoryPath;
 - (NSString *)parseLocalSandboxDataDirectoryPath;
 
-/*!
+/**
  The path including directories that we save data to for a given filename.
  If the file isn't found in the new "Private Documents" location, but is in the old "Documents" location,
  moves it and returns the new location.

--- a/Parse/Internal/PFGeoPointPrivate.h
+++ b/Parse/Internal/PFGeoPointPrivate.h
@@ -25,7 +25,7 @@ extern const double EARTH_RADIUS_KILOMETERS;
  */
 - (NSDictionary *)encodeIntoDictionary;
 
-/*!
+/**
  Creates an GeoPoint from its encoded format.
  */
 + (instancetype)geoPointWithDictionary:(NSDictionary *)dictionary;

--- a/Parse/Internal/PFInternalUtils.h
+++ b/Parse/Internal/PFInternalUtils.h
@@ -53,7 +53,7 @@
  **/
 + (id)traverseObject:(id)object usingBlock:(id (^)(id object))block;
 
-/*!
+/**
  This method will split an array into multiple arrays, each with up to maximum components count.
 
  @param array      Array to split.

--- a/Parse/Internal/PFJSONSerialization.h
+++ b/Parse/Internal/PFJSONSerialization.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PFJSONSerialization : NSObject
 
-/*!
+/**
  The object passed in must be one of:
  * NSString
  * NSNumber
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable NSData *)dataFromJSONObject:(id)object;
 
-/*!
+/**
  The object passed in must be one of:
  * NSString
  * NSNumber
@@ -37,19 +37,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable NSString *)stringFromJSONObject:(id)object;
 
-/*!
+/**
  Takes a JSON string and returns the NSDictionaries and NSArrays in it.
  You should still call decodeObject if you want Parse types.
  */
 + (nullable id)JSONObjectFromData:(NSData *)data;
 
-/*!
+/**
  Takes a JSON string and returns the NSDictionaries and NSArrays in it.
  You should still call decodeObject if you want Parse types.
  */
 + (nullable id)JSONObjectFromString:(NSString *)string;
 
-/*!
+/**
  @abstract Takes a file path to json file and returns the NSDictionaries and NSArrays in it.
 
  @description You should still call decodeObject if you want Parse types.

--- a/Parse/Internal/PFJSONSerialization.h
+++ b/Parse/Internal/PFJSONSerialization.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  * NSArray
  * NSNull
 
- @returns NSData of JSON representing the passed in object.
+ @return NSData of JSON representing the passed in object.
  */
 + (nullable NSData *)dataFromJSONObject:(id)object;
 
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  * NSArray
  * NSNull
 
- @returns NSString of JSON representing the passed in object.
+ @return NSString of JSON representing the passed in object.
  */
 + (nullable NSString *)stringFromJSONObject:(id)object;
 

--- a/Parse/Internal/PFJSONSerialization.h
+++ b/Parse/Internal/PFJSONSerialization.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable id)JSONObjectFromString:(NSString *)string;
 
 /**
- @abstract Takes a file path to json file and returns the NSDictionaries and NSArrays in it.
+ Takes a file path to json file and returns the NSDictionaries and NSArrays in it.
 
  @description You should still call decodeObject if you want Parse types.
 

--- a/Parse/Internal/PFKeychainStore.h
+++ b/Parse/Internal/PFKeychainStore.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const PFKeychainStoreDefaultService;
 
-/*!
+/**
  PFKeychainStore is NSUserDefaults-like wrapper on top of Keychain.
  It supports any object, with NSCoding support. Every object is serialized using NSKeyedArchiver.
 

--- a/Parse/Internal/PFLocationManager.h
+++ b/Parse/Internal/PFLocationManager.h
@@ -20,7 +20,7 @@
 
 typedef void(^PFLocationManagerLocationUpdateBlock)(CLLocation *location, NSError *error);
 
-/*!
+/**
  PFLocationManager is an internal class which wraps a CLLocationManager and
  returns an updated CLLocation via the provided block.
 

--- a/Parse/Internal/PFLogger.h
+++ b/Parse/Internal/PFLogger.h
@@ -24,7 +24,7 @@ typedef uint8_t PFLoggingTag;
 /**
 A shared instance of `PFLogger` that should be used for all logging.
 
-@returns An shared singleton instance of `PFLogger`.
+@return An shared singleton instance of `PFLogger`.
 */
 + (instancetype)sharedLogger; //TODO: (nlutsenko) Convert to use an instance everywhere instead of a shared singleton.
 

--- a/Parse/Internal/PFLogger.h
+++ b/Parse/Internal/PFLogger.h
@@ -21,7 +21,7 @@ typedef uint8_t PFLoggingTag;
 /// @name Shared Logger
 ///--------------------------------------
 
-/*!
+/**
 A shared instance of `PFLogger` that should be used for all logging.
 
 @returns An shared singleton instance of `PFLogger`.
@@ -32,7 +32,7 @@ A shared instance of `PFLogger` that should be used for all logging.
 /// @name Logging Messages
 ///--------------------------------------
 
-/*!
+/**
  Logs a message at a specific level for a tag.
  If current logging level doesn't include this level - this method does nothing.
 

--- a/Parse/Internal/PFMacros.h
+++ b/Parse/Internal/PFMacros.h
@@ -13,12 +13,12 @@
 #ifndef Parse_PFMacros_h
 #define Parse_PFMacros_h
 
-/*!
+/**
  This macro allows to create NSSet via subscript.
  */
 #define PF_SET(...)  [NSSet setWithObjects:__VA_ARGS__, nil]
 
-/*!
+/**
  This macro is a handy thing for converting libSystem objects to (void *) pointers.
  If you are targeting OSX 10.8+ and iOS 6.0+ - this is no longer required.
  */
@@ -30,7 +30,7 @@
     (void *)(object)
 #endif
 
-/*!
+/**
  Mark a queue in order to be able to check PFAssertIsOnMarkedQueue.
  */
 #define PFMarkDispatchQueue(queue) \
@@ -45,7 +45,7 @@ dispatch_queue_set_specific((queue), \
 /// The following macros are influenced and include portions of libextobjc.
 ///--------------------------------------
 
-/*!
+/**
  Creates a __weak version of the variable provided,
  which can later be safely used or converted into strong variable via @strongify.
  */
@@ -53,7 +53,7 @@ dispatch_queue_set_specific((queue), \
 try {} @catch (...) {} \
 __weak __typeof__(var) var ## _weak = var;
 
-/*!
+/**
  Creates a strong shadow reference of the variable provided.
  Variable must have previously been passed to @weakify.
  */
@@ -65,7 +65,7 @@ __strong __typeof__(var) var = var ## _weak;
 /// @name KVC
 ///--------------------------------------
 
-/*!
+/**
  This macro ensures that object.key exists at compile time.
  It can accept a chained key path.
  */
@@ -76,7 +76,7 @@ __strong __typeof__(var) var = var ## _weak;
 /// @name Runtime
 ///--------------------------------------
 
-/*!
+/**
  Using objc_msgSend directly is bad, very bad. Doing so without casting could result in stack-smashing on architectures
  (*cough* x86 *cough*) that use strange methods of returning values of different types.
 
@@ -87,7 +87,7 @@ __strong __typeof__(var) var = var ## _weak;
 #define objc_msgSend(...)  _Pragma("GCC error \"Use objc_msgSend_safe() instead!\"")
 #define objc_msgSend_safe(returnType, argTypes...) ((returnType (*)(id, SEL, ##argTypes))(objc_msgSend))
 
-/*!
+/**
  This exists because if we throw an exception from dispatch_sync, it doesn't 'bubble up' to the calling thread.
  This simply wraps dispatch_sync and properly throws the exception back to the calling thread, not the thread that
  the exception was originally raised on.
@@ -109,7 +109,7 @@ __strong __typeof__(var) var = var ## _weak;
         if (caught) @throw caught;            \
     } while (0)
 
-/*!
+/**
  To prevent retain cycles by OCMock, this macro allows us to capture a weak reference to return from a stubbed method.
  */
 #define andReturnWeak(variable) _andDo(                                              \
@@ -122,7 +122,7 @@ __strong __typeof__(var) var = var ## _weak;
     })                                                                               \
 )
 
-/*!
+/**
  This exists to use along with bolts generic tasks. Instead of returning a BFTask with no generic type, or a generic
  type of 'NSNull' when there is no usable result from a task, we use the type 'PFVoid', which will always have a value
  of  'nil'.

--- a/Parse/Internal/PFMulticastDelegate.h
+++ b/Parse/Internal/PFMulticastDelegate.h
@@ -9,12 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
-/*!
+/**
  Represents an event that can be subscribed to by multiple observers.
  */
 @interface PFMulticastDelegate : NSObject
 
-/*!
+/**
  Subscribes a block for callback.
 
  Important: if you ever plan to be able to unsubscribe the block, you must copy the block

--- a/Parse/Internal/PFNetworkCommand.h
+++ b/Parse/Internal/PFNetworkCommand.h
@@ -35,7 +35,7 @@
 /// @name Local Identifiers
 ///--------------------------------------
 
-/*!
+/**
  Replaces all local ids in this command with the correct objectId for that object.
  This should be called before sending the command over the network, so that there
  are no local ids sent to the Parse Cloud. If any local id refers to an object that

--- a/Parse/Internal/PFPinningEventuallyQueue.m
+++ b/Parse/Internal/PFPinningEventuallyQueue.m
@@ -25,30 +25,30 @@
 #import "PFTaskQueue.h"
 
 @interface PFPinningEventuallyQueue () <PFEventuallyQueueSubclass> {
-    /*!
+    /**
      Queue for reading/writing eventually operations from LDS. Makes all reads/writes atomic
      operations.
      */
     PFTaskQueue *_taskQueue;
 
-    /*!
+    /**
      List of `PFEventuallyPin.uuid` that are currently queued in `_processingQueue`. This contains
      uuid of PFEventuallyPin that's enqueued.
      */
     NSMutableArray *_eventuallyPinUUIDQueue;
 
-    /*!
+    /**
      Map of eventually operation UUID to matching PFEventuallyPin. This contains PFEventuallyPin
      that's enqueued.
      */
     NSMutableDictionary *_uuidToEventuallyPin;
 
-    /*!
+    /**
      Map OperationSetUUID to PFOperationSet
      */
     NSMutableDictionary *_operationSetUUIDToOperationSet;
 
-    /*!
+    /**
      Map OperationSetUUID to PFEventuallyPin
      */
     NSMutableDictionary *_operationSetUUIDToEventuallyPin;
@@ -261,7 +261,7 @@
     }];
 }
 
-/*!
+/**
  Synchronizes PFObject taskQueue (Many) and PFPinningEventuallyQueue taskQueue (None). Each queue will be held
  until both are ready, matched on operationSetUUID. Once both are ready, the eventually task will run.
  */

--- a/Parse/Internal/PFTaskQueue.h
+++ b/Parse/Internal/PFTaskQueue.h
@@ -18,7 +18,7 @@
 // The lock for this task queue.
 @property (nonatomic, strong, readonly) NSObject *mutex;
 
-/*!
+/**
  Enqueues a task created by the given block. Then block is given a task to
  await once state is snapshotted (e.g. after capturing session tokens at the
  time of the save call. Awaiting this task will wait for the created task's

--- a/Parse/Internal/ParseManager.h
+++ b/Parse/Internal/ParseManager.h
@@ -56,7 +56,7 @@ PFInstallationIdentifierStoreProvider>
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/*!
+/**
  Initializes an instance of ParseManager class.
 
  @param applicationId                   ApplicationId of Parse app.
@@ -67,7 +67,7 @@ PFInstallationIdentifierStoreProvider>
 - (instancetype)initWithApplicationId:(NSString *)applicationId
                             clientKey:(NSString *)clientKey NS_DESIGNATED_INITIALIZER;
 
-/*!
+/**
  Configures ParseManager with specified properties.
 
  @param applicationGroupIdentifier      Shared AppGroup container identifier.

--- a/Parse/Internal/ParseManager.h
+++ b/Parse/Internal/ParseManager.h
@@ -62,7 +62,7 @@ PFInstallationIdentifierStoreProvider>
  @param applicationId                   ApplicationId of Parse app.
  @param clientKey                       ClientKey of Parse app.
 
- @returns `ParseManager` instance.
+ @return `ParseManager` instance.
  */
 - (instancetype)initWithApplicationId:(NSString *)applicationId
                             clientKey:(NSString *)clientKey NS_DESIGNATED_INITIALIZER;

--- a/Parse/Internal/ParseModule.m
+++ b/Parse/Internal/ParseModule.m
@@ -96,7 +96,7 @@ typedef void (^ParseModuleEnumerationBlock)(id<ParseModule> module, BOOL *stop, 
     dispatch_sync(self.collectionQueue, block);
 }
 
-/*!
+/**
  Enumerates all existing modules in this collection.
 
  NOTE: This **will modify the contents of the collection** if any of the modules were deallocated since last loop.

--- a/Parse/Internal/Product/PFProduct+Private.h
+++ b/Parse/Internal/Product/PFProduct+Private.h
@@ -23,22 +23,22 @@ typedef enum {
 }
 
 /// The properties below are transient properties, not stored on Parse's server.
-/*!
+/**
  The price of the product, discovered via iTunes Connect.
  */
 @property (nonatomic, strong) NSDecimalNumber *price;
 
-/*!
+/**
  The price locale of the product.
  */
 @property (nonatomic, strong) NSLocale *priceLocale;
 
-/*!
+/**
  The progress of the download, if one is in progress. It's an integer between 0 and 100.
  */
 @property (nonatomic, assign) NSInteger progress;
 
-/*!
+/**
  The content path of the download.
  */
 @property (nonatomic, strong) NSString *contentPath;

--- a/Parse/Internal/Product/ProductsRequestHandler/PFProductsRequestHandler.h
+++ b/Parse/Internal/Product/ProductsRequestHandler/PFProductsRequestHandler.h
@@ -26,7 +26,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFProductsRequestResult : NSO
 
 @end
 
-/*!
+/**
  * This class is responsible for handling the first part of an IAP handshake.
  * It sends a request to iTunes Connect with a set of product identifiers, and iTunes returns
  * with a list of valid and invalid products. The class then proceeds to call the completion block passed in.

--- a/Parse/Internal/PropertyInfo/PFPropertyInfo.h
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *name;
 @property (nonatomic, readonly) PFPropertyInfoAssociationType associationType;
 
-/*!
+/**
  Returns the value of this property,
  properly wrapped from the target object.
  When possible, just invokes the property.

--- a/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.h
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.h
@@ -12,7 +12,7 @@
 #import <objc/runtime.h>
 
 /**
- @abstract Safely sets an object's instance variable to the variable in the specified address.
+ Safely sets an object's instance variable to the variable in the specified address.
  @discussion The Objective-C runtime's built-in methods for setting instance variables (`object_setIvar`) and
  (`object_setInstanceVariable`), are both terrible. They never read any more than a single pointer, so they
  fail for structs, as well as 64 bit numbers on 32 bit platforms. Because of this, we need a solution to allow us to
@@ -28,7 +28,7 @@
 extern void object_setIvarValue_safe(__unsafe_unretained id obj, Ivar ivar, void *fromMemory, uint8_t associationType);
 
 /**
- @abstract Safely gets an object's instance variable and puts it into the specified address.
+ Safely gets an object's instance variable and puts it into the specified address.
  @discussion  The Objective-C runtime's built-in methods for getting instance variables (`object_getIvar`) and
  (`object_getInstanceVariable`), are both terrible. They never read any more than a single pointer, so they
  fail for structs, as well as 64 bit numbers on 32 bit platforms. Because of this, we need a solution to allow us to

--- a/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.h
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.h
@@ -11,7 +11,7 @@
 
 #import <objc/runtime.h>
 
-/*!
+/**
  @abstract Safely sets an object's instance variable to the variable in the specified address.
  @discussion The Objective-C runtime's built-in methods for setting instance variables (`object_setIvar`) and
  (`object_setInstanceVariable`), are both terrible. They never read any more than a single pointer, so they
@@ -27,7 +27,7 @@
  */
 extern void object_setIvarValue_safe(__unsafe_unretained id obj, Ivar ivar, void *fromMemory, uint8_t associationType);
 
-/*!
+/**
  @abstract Safely gets an object's instance variable and puts it into the specified address.
  @discussion  The Objective-C runtime's built-in methods for getting instance variables (`object_getIvar`) and
  (`object_getInstanceVariable`), are both terrible. They never read any more than a single pointer, so they

--- a/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.h
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.h
@@ -13,7 +13,7 @@
 
 /**
  Safely sets an object's instance variable to the variable in the specified address.
- @discussion The Objective-C runtime's built-in methods for setting instance variables (`object_setIvar`) and
+ The Objective-C runtime's built-in methods for setting instance variables (`object_setIvar`) and
  (`object_setInstanceVariable`), are both terrible. They never read any more than a single pointer, so they
  fail for structs, as well as 64 bit numbers on 32 bit platforms. Because of this, we need a solution to allow us to
  safely set instance variable values whose sizes may be significantly more than a pointer.
@@ -29,7 +29,7 @@ extern void object_setIvarValue_safe(__unsafe_unretained id obj, Ivar ivar, void
 
 /**
  Safely gets an object's instance variable and puts it into the specified address.
- @discussion  The Objective-C runtime's built-in methods for getting instance variables (`object_getIvar`) and
+  The Objective-C runtime's built-in methods for getting instance variables (`object_getIvar`) and
  (`object_getInstanceVariable`), are both terrible. They never read any more than a single pointer, so they
  fail for structs, as well as 64 bit numbers on 32 bit platforms. Because of this, we need a solution to allow us to
  safely get instance variable values whose sizes may be significantly more than a pointer.

--- a/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.m
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.m
@@ -12,7 +12,7 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
-/*!
+/**
  This macro is really interesting. Because ARC will insert implicit retains, releases and other memory managment code
  that we don't want here, we have to basically trick ARC into treating the functions we want as functions with type
  `void *`. The way we do that is actually via the linker - instead of coming up with some crazy macro to forward all

--- a/Parse/Internal/Purchase/PaymentTransactionObserver/PFPaymentTransactionObserver.h
+++ b/Parse/Internal/Purchase/PaymentTransactionObserver/PFPaymentTransactionObserver.h
@@ -15,7 +15,7 @@
 PF_OSX_UNAVAILABLE_WARNING
 PF_WATCH_UNAVAILABLE_WARNING
 
-/*!
+/**
  * The PFPaymentTransactionObserver listens to the payment queue, processes a payment by running business logic,
  * and completes the transaction. It's a complex interaction and best explained as follows:
  * 1) an observer object is created and added to the payment queue, typically before IAP happens (but not necessarily),

--- a/Parse/Internal/Push/Controller/PFPushController.h
+++ b/Parse/Internal/Push/Controller/PFPushController.h
@@ -37,7 +37,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushController : NSObject
 /// @name Sending Push
 ///--------------------------------------
 
-/*!
+/**
  Requests push notification to be sent for a given state.
 
  @param state        State to use to send notifications.

--- a/Parse/Internal/Push/Controller/PFPushController.h
+++ b/Parse/Internal/Push/Controller/PFPushController.h
@@ -43,7 +43,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushController : NSObject
  @param state        State to use to send notifications.
  @param sessionToken Current user session token.
 
- @returns `BFTask` with result set to `NSNumber` with `BOOL` identifying whether the request succeeded.
+ @return `BFTask` with result set to `NSNumber` with `BOOL` identifying whether the request succeeded.
  */
 - (BFTask *)sendPushNotificationAsyncWithState:(PFPushState *)state sessionToken:(nullable NSString *)sessionToken;
 

--- a/Parse/Internal/Query/Controller/PFQueryController.h
+++ b/Parse/Internal/Query/Controller/PFQueryController.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Find
 ///--------------------------------------
 
-/*!
+/**
  Finds objects from network or LDS for any given query state.
  Supports cancellation and ACLed changes for a specific user.
 
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Count
 ///--------------------------------------
 
-/*!
+/**
  Counts objects from network or LDS for any given query state.
  Supports cancellation and ACLed changes for a specific user.
 
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol PFQueryControllerSubclass <NSObject>
 
-/*!
+/**
  Implementation should run a command on a network runner.
 
  @param command           Command to run.

--- a/Parse/Internal/Query/Controller/PFQueryController.h
+++ b/Parse/Internal/Query/Controller/PFQueryController.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cancellationToken Cancellation token or `nil`.
  @param user              `user` to use for ACLs or `nil`.
 
- @returns Task that resolves to `NSArray` of `PFObject`s.
+ @return Task that resolves to `NSArray` of `PFObject`s.
  */
 - (BFTask *)findObjectsAsyncForQueryState:(PFQueryState *)queryState
                     withCancellationToken:(nullable BFCancellationToken *)cancellationToken
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cancellationToken Cancellation token or `nil`.
  @param user              `user` to use for ACLs or `nil`.
 
- @returns Task that resolves to `NSNumber` with a count of results.
+ @return Task that resolves to `NSNumber` with a count of results.
  */
 - (BFTask *)countObjectsAsyncForQueryState:(PFQueryState *)queryState
                      withCancellationToken:(nullable BFCancellationToken *)cancellationToken
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param cancellationToken Cancellation token.
  @param queryState        Query state to run command for.
 
- @returns `BFTask` instance with result of `PFCommandResult`.
+ @return `BFTask` instance with result of `PFCommandResult`.
  */
 - (BFTask *)runNetworkCommandAsync:(PFRESTCommand *)command
              withCancellationToken:(nullable BFCancellationToken *)cancellationToken

--- a/Parse/Internal/Query/State/PFQueryState.h
+++ b/Parse/Internal/Query/State/PFQueryState.h
@@ -42,12 +42,12 @@
 /// @name Local Datastore Options
 ///--------------------------------------
 
-/*!
+/**
  If ignoreACLs is enabled, we don't check ACLs when querying from LDS. We also don't grab
  `PFUser currentUser` since it's unnecessary when ignoring ACLs.
  */
 @property (nonatomic, assign, readonly) BOOL shouldIgnoreACLs;
-/*!
+/**
  This is currently unused, but is here to allow future querying across objects that are in the
  process of being deleted eventually.
  */

--- a/Parse/Internal/Query/Utilities/PFQueryUtilities.h
+++ b/Parse/Internal/Query/Utilities/PFQueryUtilities.h
@@ -29,7 +29,7 @@
 
  @param string String to convert from.
 
- @returns Query regex string from a string.
+ @return Query regex string from a string.
  */
 + (NSString *)regexStringForString:(NSString *)string;
 

--- a/Parse/Internal/Query/Utilities/PFQueryUtilities.h
+++ b/Parse/Internal/Query/Utilities/PFQueryUtilities.h
@@ -15,7 +15,7 @@
 /// @name Predicate
 ///--------------------------------------
 
-/*!
+/**
  Takes an arbitrary predicate and normalizes it to a form that can easily be converted to a `PFQuery`.
  */
 + (NSPredicate *)predicateByNormalizingPredicate:(NSPredicate *)predicate;
@@ -24,7 +24,7 @@
 /// @name Regex
 ///--------------------------------------
 
-/*!
+/**
  Converts a string into a regex that matches it.
 
  @param string String to convert from.

--- a/Parse/Internal/Query/Utilities/PFQueryUtilities.m
+++ b/Parse/Internal/Query/Utilities/PFQueryUtilities.m
@@ -23,7 +23,7 @@
     return [self _hoistCommonPredicates:[self _normalizeToDNF:predicate]];
 }
 
-/*!
+/**
  Traverses over all of the subpredicates in the given predicate, calling the given blocks to
  transform any instances of NSPredicate.
  */
@@ -60,7 +60,7 @@
     return nil;
 }
 
-/*!
+/**
  Returns a predicate that is the negation of the input predicate, or throws on error.
  */
 + (NSPredicate *)_negatePredicate:(NSPredicate *)predicate {
@@ -159,7 +159,7 @@
                  }];
 }
 
-/*!
+/**
  Returns a version of the given predicate that contains no NSNotPredicateType compound predicates.
  This greatly simplifies the diversity of predicates we have to handle later in the pipeline.
  */
@@ -184,7 +184,7 @@
                  } comparisonBlock:nil];
 }
 
-/*!
+/**
  Returns a version of the given predicate that contains no NSBetweenPredicateOperatorType predicates.
  (A BETWEEN {C, D}) gets converted to (A >= C AND A <= D).
  */
@@ -233,7 +233,7 @@
                }];
 }
 
-/*!
+/**
  Returns a version of the given predicate that contains no Yoda conditions.
  A Yoda condition is one where there's a constant on the LHS, such as (3 <= X).
  The predicate returned by this method will instead have (X >= 3).
@@ -299,7 +299,7 @@
                }];
 }
 
-/*!
+/**
  Returns a version of the given predicate converted to disjunctive normal form (DNF).
  Unlike normalizeToDNF:error:, this method only accepts compound predicates, and assumes that
  removeNegation:error: has already been applied to the given predicate.
@@ -395,7 +395,7 @@
     return nil;
 }
 
-/*!
+/**
  Throws an exception if any comparison predicate inside this predicate has any modifiers, such as ANY, EVERY, etc.
  */
 + (void)assertNoPredicateModifiers:(NSPredicate *)predicate {
@@ -409,7 +409,7 @@
         }];
 }
 
-/*!
+/**
  Returns a version of the given predicate converted to disjunctive normal form (DNF),
  known colloqially as an "or of ands", the only form of query that PFQuery accepts.
  */
@@ -435,7 +435,7 @@
     return [self asOrOfAnds:(NSCompoundPredicate *)predicate];
 }
 
-/*!
+/**
  Takes a predicate like ((A AND B) OR (A AND C)) and rewrites it as the more efficient (A AND (B OR C)).
  Assumes the input predicate is already in DNF.
  // TODO: (nlutsenko): Move this logic into the server and remove it from here.
@@ -508,7 +508,7 @@
 #pragma mark - Regex
 ///--------------------------------------
 
-/*!
+/**
  This is used to create a regex string to match the input string. By using Q and E flags to match, we can do this
  without requiring super expensive rewrites, but me must be careful to escape existing \E flags in the input string.
  By replacing it with `\E\\E\Q`, the regex engine will end the old literal block, put in the user's `\E` string, and

--- a/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.h
+++ b/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.h
@@ -17,7 +17,7 @@ extern NSString *const PFAnonymousUserAuthenticationType;
 
 @interface PFAnonymousAuthenticationProvider : NSObject <PFUserAuthenticationDelegate>
 
-/*!
+/**
  Gets auth data with a fresh UUID.
  */
 @property (nonatomic, copy, readonly) NSDictionary *authData;

--- a/Parse/PFACL.h
+++ b/Parse/PFACL.h
@@ -27,14 +27,14 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Creates an ACL with no permissions granted.
+ Creates an ACL with no permissions granted.
 
  @returns Returns a new `PFACL`.
  */
 + (instancetype)ACL;
 
 /**
- @abstract Creates an ACL where only the provided user has access.
+ Creates an ACL where only the provided user has access.
 
  @param user The user to assign access.
  */
@@ -45,12 +45,12 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Controls whether the public is allowed to read this object.
+ Controls whether the public is allowed to read this object.
  */
 @property (nonatomic, assign, getter=getPublicReadAccess) BOOL publicReadAccess;
 
 /**
- @abstract Controls whether the public is allowed to write this object.
+ Controls whether the public is allowed to write this object.
  */
 @property (nonatomic, assign, getter=getPublicWriteAccess) BOOL publicWriteAccess;
 
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Set whether the given user id is allowed to read this object.
+ Set whether the given user id is allowed to read this object.
 
  @param allowed Whether the given user can write this object.
  @param userId The <[PFObject objectId]> of the user to assign access.
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setReadAccess:(BOOL)allowed forUserId:(NSString *)userId;
 
 /**
- @abstract Gets whether the given user id is *explicitly* allowed to read this object.
+ Gets whether the given user id is *explicitly* allowed to read this object.
  Even if this returns `NO`, the user may still be able to access it if <getPublicReadAccess> returns `YES`
  or if the user belongs to a role that has access.
 
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)getReadAccessForUserId:(NSString *)userId;
 
 /**
- @abstract Set whether the given user id is allowed to write this object.
+ Set whether the given user id is allowed to write this object.
 
  @param allowed Whether the given user can read this object.
  @param userId The `objectId` of the user to assign access.
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setWriteAccess:(BOOL)allowed forUserId:(NSString *)userId;
 
 /**
- @abstract Gets whether the given user id is *explicitly* allowed to write this object.
+ Gets whether the given user id is *explicitly* allowed to write this object.
  Even if this returns NO, the user may still be able to write it if <getPublicWriteAccess> returns `YES`
  or if the user belongs to a role that has access.
 
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)getWriteAccessForUserId:(NSString *)userId;
 
 /**
- @abstract Set whether the given user is allowed to read this object.
+ Set whether the given user is allowed to read this object.
 
  @param allowed Whether the given user can read this object.
  @param user The user to assign access.
@@ -105,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setReadAccess:(BOOL)allowed forUser:(PFUser *)user;
 
 /**
- @abstract Gets whether the given user is *explicitly* allowed to read this object.
+ Gets whether the given user is *explicitly* allowed to read this object.
  Even if this returns `NO`, the user may still be able to access it if <getPublicReadAccess> returns `YES`
  or if the user belongs to a role that has access.
 
@@ -116,7 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)getReadAccessForUser:(PFUser *)user;
 
 /**
- @abstract Set whether the given user is allowed to write this object.
+ Set whether the given user is allowed to write this object.
 
  @param allowed Whether the given user can write this object.
  @param user The user to assign access.
@@ -124,7 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setWriteAccess:(BOOL)allowed forUser:(PFUser *)user;
 
 /**
- @abstract Gets whether the given user is *explicitly* allowed to write this object.
+ Gets whether the given user is *explicitly* allowed to write this object.
  Even if this returns `NO`, the user may still be able to write it if <getPublicWriteAccess> returns `YES`
  or if the user belongs to a role that has access.
 
@@ -139,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Get whether users belonging to the role with the given name are allowed to read this object.
+ Get whether users belonging to the role with the given name are allowed to read this object.
  Even if this returns `NO`, the role may still be able to read it if a parent role has read access.
 
  @param name The name of the role.
@@ -149,7 +149,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)getReadAccessForRoleWithName:(NSString *)name;
 
 /**
- @abstract Set whether users belonging to the role with the given name are allowed to read this object.
+ Set whether users belonging to the role with the given name are allowed to read this object.
 
  @param allowed Whether the given role can read this object.
  @param name The name of the role.
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setReadAccess:(BOOL)allowed forRoleWithName:(NSString *)name;
 
 /**
- @abstract Get whether users belonging to the role with the given name are allowed to write this object.
+ Get whether users belonging to the role with the given name are allowed to write this object.
  Even if this returns `NO`, the role may still be able to write it if a parent role has write access.
 
  @param name The name of the role.
@@ -167,7 +167,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)getWriteAccessForRoleWithName:(NSString *)name;
 
 /**
- @abstract Set whether users belonging to the role with the given name are allowed to write this object.
+ Set whether users belonging to the role with the given name are allowed to write this object.
 
  @param allowed Whether the given role can write this object.
  @param name The name of the role.
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setWriteAccess:(BOOL)allowed forRoleWithName:(NSString *)name;
 
 /**
- @abstract Get whether users belonging to the given role are allowed to read this object.
+ Get whether users belonging to the given role are allowed to read this object.
  Even if this returns `NO`, the role may still be able to read it if a parent role has read access.
 
  @discussion The role must already be saved on the server and
@@ -188,7 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)getReadAccessForRole:(PFRole *)role;
 
 /**
- @abstract Set whether users belonging to the given role are allowed to read this object.
+ Set whether users belonging to the given role are allowed to read this object.
 
  @discussion The role must already be saved on the server and
  it's data must have been fetched in order to use this method.
@@ -199,7 +199,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setReadAccess:(BOOL)allowed forRole:(PFRole *)role;
 
 /**
- @abstract Get whether users belonging to the given role are allowed to write this object.
+ Get whether users belonging to the given role are allowed to write this object.
  Even if this returns `NO`, the role may still be able to write it if a parent role has write access.
 
  @discussion The role must already be saved on the server and
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)getWriteAccessForRole:(PFRole *)role;
 
 /**
- @abstract Set whether users belonging to the given role are allowed to write this object.
+ Set whether users belonging to the given role are allowed to write this object.
 
  @discussion The role must already be saved on the server and
  it's data must have been fetched in order to use this method.
@@ -227,7 +227,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Sets a default ACL that will be applied to all instances of <PFObject> when they are created.
+ Sets a default ACL that will be applied to all instances of <PFObject> when they are created.
 
  @param acl The ACL to use as a template for all instance of <PFObject> created after this method has been called.
  This value will be copied and used as a template for the creation of new ACLs, so changes to the

--- a/Parse/PFACL.h
+++ b/Parse/PFACL.h
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get whether users belonging to the given role are allowed to read this object.
  Even if this returns `NO`, the role may still be able to read it if a parent role has read access.
 
- @discussion The role must already be saved on the server and
+ The role must already be saved on the server and
  it's data must have been fetched in order to use this method.
 
  @param role The name of the role.
@@ -190,7 +190,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Set whether users belonging to the given role are allowed to read this object.
 
- @discussion The role must already be saved on the server and
+ The role must already be saved on the server and
  it's data must have been fetched in order to use this method.
 
  @param allowed Whether the given role can read this object.
@@ -202,7 +202,7 @@ NS_ASSUME_NONNULL_BEGIN
  Get whether users belonging to the given role are allowed to write this object.
  Even if this returns `NO`, the role may still be able to write it if a parent role has write access.
 
- @discussion The role must already be saved on the server and
+ The role must already be saved on the server and
  it's data must have been fetched in order to use this method.
 
  @param role The name of the role.
@@ -214,7 +214,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Set whether users belonging to the given role are allowed to write this object.
 
- @discussion The role must already be saved on the server and
+ The role must already be saved on the server and
  it's data must have been fetched in order to use this method.
 
  @param allowed Whether the given role can write this object.

--- a/Parse/PFACL.h
+++ b/Parse/PFACL.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The `PFACL` class is used to control which users can access or modify a particular object.
- Each <PFObject> can have its own `PFACL`. You can grant read and write permissions separately to specific users,
+ Each `PFObject` can have its own `PFACL`. You can grant read and write permissions separately to specific users,
  to groups of users that belong to roles, or you can grant permissions to "the public" so that,
  for example, any user could read a particular object but only a particular set of users could write to that object.
  */
@@ -62,16 +62,16 @@ NS_ASSUME_NONNULL_BEGIN
  Set whether the given user id is allowed to read this object.
 
  @param allowed Whether the given user can write this object.
- @param userId The <[PFObject objectId]> of the user to assign access.
+ @param userId The `PFObject.objectId` of the user to assign access.
  */
 - (void)setReadAccess:(BOOL)allowed forUserId:(NSString *)userId;
 
 /**
  Gets whether the given user id is *explicitly* allowed to read this object.
- Even if this returns `NO`, the user may still be able to access it if <getPublicReadAccess> returns `YES`
+ Even if this returns `NO`, the user may still be able to access it if `publicReadAccess` returns `YES`
  or if the user belongs to a role that has access.
 
- @param userId The <[PFObject objectId]> of the user for which to retrive access.
+ @param userId The `PFObject.objectId` of the user for which to retrive access.
 
  @return `YES` if the user with this `objectId` has *explicit* read access, otherwise `NO`.
  */
@@ -81,18 +81,18 @@ NS_ASSUME_NONNULL_BEGIN
  Set whether the given user id is allowed to write this object.
 
  @param allowed Whether the given user can read this object.
- @param userId The `objectId` of the user to assign access.
+ @param userId The `PFObject.objectId` of the user to assign access.
  */
 - (void)setWriteAccess:(BOOL)allowed forUserId:(NSString *)userId;
 
 /**
  Gets whether the given user id is *explicitly* allowed to write this object.
- Even if this returns NO, the user may still be able to write it if <getPublicWriteAccess> returns `YES`
+ Even if this returns NO, the user may still be able to write it if `publicWriteAccess` returns `YES`
  or if the user belongs to a role that has access.
 
- @param userId The <[PFObject objectId]> of the user for which to retrive access.
+ @param userId The `PFObject.objectId` of the user for which to retrive access.
 
- @return `YES` if the user with this `objectId` has *explicit* write access, otherwise `NO`.
+ @return `YES` if the user with this `PFObject.objectId` has *explicit* write access, otherwise `NO`.
  */
 - (BOOL)getWriteAccessForUserId:(NSString *)userId;
 
@@ -106,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Gets whether the given user is *explicitly* allowed to read this object.
- Even if this returns `NO`, the user may still be able to access it if <getPublicReadAccess> returns `YES`
+ Even if this returns `NO`, the user may still be able to access it if `publicReadAccess` returns `YES`
  or if the user belongs to a role that has access.
 
  @param user The user for which to retrive access.
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Gets whether the given user is *explicitly* allowed to write this object.
- Even if this returns `NO`, the user may still be able to write it if <getPublicWriteAccess> returns `YES`
+ Even if this returns `NO`, the user may still be able to write it if `publicWriteAccess` returns `YES`
  or if the user belongs to a role that has access.
 
  @param user The user for which to retrive access.
@@ -227,13 +227,13 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- Sets a default ACL that will be applied to all instances of <PFObject> when they are created.
+ Sets a default ACL that will be applied to all instances of `PFObject` when they are created.
 
- @param acl The ACL to use as a template for all instance of <PFObject> created after this method has been called.
+ @param acl The ACL to use as a template for all instance of `PFObject` created after this method has been called.
  This value will be copied and used as a template for the creation of new ACLs, so changes to the
- instance after this method has been called will not be reflected in new instance of <PFObject>.
- @param currentUserAccess - If `YES`, the `PFACL` that is applied to newly-created instance of <PFObject> will
- provide read and write access to the <[PFUser currentUser]> at the time of creation.
+ instance after this method has been called will not be reflected in new instance of `PFObject`.
+ @param currentUserAccess - If `YES`, the `PFACL` that is applied to newly-created instance of `PFObject` will
+ provide read and write access to the `PFUser.+currentUser` at the time of creation.
  - If `NO`, the provided `acl` will be used without modification.
  - If `acl` is `nil`, this value is ignored.
  */

--- a/Parse/PFACL.h
+++ b/Parse/PFACL.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates an ACL with no permissions granted.
 
- @returns Returns a new `PFACL`.
+ @return Returns a new `PFACL`.
  */
 + (instancetype)ACL;
 
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param userId The <[PFObject objectId]> of the user for which to retrive access.
 
- @returns `YES` if the user with this `objectId` has *explicit* read access, otherwise `NO`.
+ @return `YES` if the user with this `objectId` has *explicit* read access, otherwise `NO`.
  */
 - (BOOL)getReadAccessForUserId:(NSString *)userId;
 
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param userId The <[PFObject objectId]> of the user for which to retrive access.
 
- @returns `YES` if the user with this `objectId` has *explicit* write access, otherwise `NO`.
+ @return `YES` if the user with this `objectId` has *explicit* write access, otherwise `NO`.
  */
 - (BOOL)getWriteAccessForUserId:(NSString *)userId;
 
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param user The user for which to retrive access.
 
- @returns `YES` if the user has *explicit* read access, otherwise `NO`.
+ @return `YES` if the user has *explicit* read access, otherwise `NO`.
  */
 - (BOOL)getReadAccessForUser:(PFUser *)user;
 
@@ -130,7 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param user The user for which to retrive access.
 
- @returns `YES` if the user has *explicit* write access, otherwise `NO`.
+ @return `YES` if the user has *explicit* write access, otherwise `NO`.
  */
 - (BOOL)getWriteAccessForUser:(PFUser *)user;
 
@@ -144,7 +144,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param name The name of the role.
 
- @returns `YES` if the role has read access, otherwise `NO`.
+ @return `YES` if the role has read access, otherwise `NO`.
  */
 - (BOOL)getReadAccessForRoleWithName:(NSString *)name;
 
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param name The name of the role.
 
- @returns `YES` if the role has read access, otherwise `NO`.
+ @return `YES` if the role has read access, otherwise `NO`.
  */
 - (BOOL)getWriteAccessForRoleWithName:(NSString *)name;
 
@@ -183,7 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param role The name of the role.
 
- @returns `YES` if the role has read access, otherwise `NO`.
+ @return `YES` if the role has read access, otherwise `NO`.
  */
 - (BOOL)getReadAccessForRole:(PFRole *)role;
 
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param role The name of the role.
 
- @returns `YES` if the role has write access, otherwise `NO`.
+ @return `YES` if the role has write access, otherwise `NO`.
  */
 - (BOOL)getWriteAccessForRole:(PFRole *)role;
 

--- a/Parse/PFACL.h
+++ b/Parse/PFACL.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class PFRole;
 @class PFUser;
 
-/*!
+/**
  The `PFACL` class is used to control which users can access or modify a particular object.
  Each <PFObject> can have its own `PFACL`. You can grant read and write permissions separately to specific users,
  to groups of users that belong to roles, or you can grant permissions to "the public" so that,
@@ -26,14 +26,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Creating an ACL
 ///--------------------------------------
 
-/*!
+/**
  @abstract Creates an ACL with no permissions granted.
 
  @returns Returns a new `PFACL`.
  */
 + (instancetype)ACL;
 
-/*!
+/**
  @abstract Creates an ACL where only the provided user has access.
 
  @param user The user to assign access.
@@ -44,12 +44,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Controlling Public Access
 ///--------------------------------------
 
-/*!
+/**
  @abstract Controls whether the public is allowed to read this object.
  */
 @property (nonatomic, assign, getter=getPublicReadAccess) BOOL publicReadAccess;
 
-/*!
+/**
  @abstract Controls whether the public is allowed to write this object.
  */
 @property (nonatomic, assign, getter=getPublicWriteAccess) BOOL publicWriteAccess;
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Controlling Access Per-User
 ///--------------------------------------
 
-/*!
+/**
  @abstract Set whether the given user id is allowed to read this object.
 
  @param allowed Whether the given user can write this object.
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setReadAccess:(BOOL)allowed forUserId:(NSString *)userId;
 
-/*!
+/**
  @abstract Gets whether the given user id is *explicitly* allowed to read this object.
  Even if this returns `NO`, the user may still be able to access it if <getPublicReadAccess> returns `YES`
  or if the user belongs to a role that has access.
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)getReadAccessForUserId:(NSString *)userId;
 
-/*!
+/**
  @abstract Set whether the given user id is allowed to write this object.
 
  @param allowed Whether the given user can read this object.
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setWriteAccess:(BOOL)allowed forUserId:(NSString *)userId;
 
-/*!
+/**
  @abstract Gets whether the given user id is *explicitly* allowed to write this object.
  Even if this returns NO, the user may still be able to write it if <getPublicWriteAccess> returns `YES`
  or if the user belongs to a role that has access.
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)getWriteAccessForUserId:(NSString *)userId;
 
-/*!
+/**
  @abstract Set whether the given user is allowed to read this object.
 
  @param allowed Whether the given user can read this object.
@@ -104,7 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setReadAccess:(BOOL)allowed forUser:(PFUser *)user;
 
-/*!
+/**
  @abstract Gets whether the given user is *explicitly* allowed to read this object.
  Even if this returns `NO`, the user may still be able to access it if <getPublicReadAccess> returns `YES`
  or if the user belongs to a role that has access.
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)getReadAccessForUser:(PFUser *)user;
 
-/*!
+/**
  @abstract Set whether the given user is allowed to write this object.
 
  @param allowed Whether the given user can write this object.
@@ -123,7 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setWriteAccess:(BOOL)allowed forUser:(PFUser *)user;
 
-/*!
+/**
  @abstract Gets whether the given user is *explicitly* allowed to write this object.
  Even if this returns `NO`, the user may still be able to write it if <getPublicWriteAccess> returns `YES`
  or if the user belongs to a role that has access.
@@ -138,7 +138,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Controlling Access Per-Role
 ///--------------------------------------
 
-/*!
+/**
  @abstract Get whether users belonging to the role with the given name are allowed to read this object.
  Even if this returns `NO`, the role may still be able to read it if a parent role has read access.
 
@@ -148,7 +148,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)getReadAccessForRoleWithName:(NSString *)name;
 
-/*!
+/**
  @abstract Set whether users belonging to the role with the given name are allowed to read this object.
 
  @param allowed Whether the given role can read this object.
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setReadAccess:(BOOL)allowed forRoleWithName:(NSString *)name;
 
-/*!
+/**
  @abstract Get whether users belonging to the role with the given name are allowed to write this object.
  Even if this returns `NO`, the role may still be able to write it if a parent role has write access.
 
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)getWriteAccessForRoleWithName:(NSString *)name;
 
-/*!
+/**
  @abstract Set whether users belonging to the role with the given name are allowed to write this object.
 
  @param allowed Whether the given role can write this object.
@@ -174,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setWriteAccess:(BOOL)allowed forRoleWithName:(NSString *)name;
 
-/*!
+/**
  @abstract Get whether users belonging to the given role are allowed to read this object.
  Even if this returns `NO`, the role may still be able to read it if a parent role has read access.
 
@@ -187,7 +187,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)getReadAccessForRole:(PFRole *)role;
 
-/*!
+/**
  @abstract Set whether users belonging to the given role are allowed to read this object.
 
  @discussion The role must already be saved on the server and
@@ -198,7 +198,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setReadAccess:(BOOL)allowed forRole:(PFRole *)role;
 
-/*!
+/**
  @abstract Get whether users belonging to the given role are allowed to write this object.
  Even if this returns `NO`, the role may still be able to write it if a parent role has write access.
 
@@ -211,7 +211,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)getWriteAccessForRole:(PFRole *)role;
 
-/*!
+/**
  @abstract Set whether users belonging to the given role are allowed to write this object.
 
  @discussion The role must already be saved on the server and
@@ -226,7 +226,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Setting Access Defaults
 ///--------------------------------------
 
-/*!
+/**
  @abstract Sets a default ACL that will be applied to all instances of <PFObject> when they are created.
 
  @param acl The ACL to use as a template for all instance of <PFObject> created after this method has been called.

--- a/Parse/PFAnalytics.h
+++ b/Parse/PFAnalytics.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  user opening a push notification, this method sends along information to
  correlate this open with that push.
 
- @discussion Pass in `nil` to track a standard "application opened" event.
+ Pass in `nil` to track a standard "application opened" event.
 
  @param launchOptions The `NSDictionary` indicating the reason the application was
  launched, if any. This value can be found as a parameter to various
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  If this happened as the result of the user opening a push notification,
  this method sends along information to correlate this open with that push.
 
- @discussion Pass in `nil` to track a standard "application opened" event.
+ Pass in `nil` to track a standard "application opened" event.
 
  @param launchOptions The dictionary indicating the reason the application was
  launched, if any. This value can be found as a parameter to various
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Tracks the occurrence of a custom event.
 
- @discussion Parse will store a data point at the time of invocation with the given event name.
+ Parse will store a data point at the time of invocation with the given event name.
 
  @param name The name of the custom event to report to Parse as having happened.
 
@@ -117,7 +117,7 @@ NS_ASSUME_NONNULL_BEGIN
  Tracks the occurrence of a custom event with additional dimensions. Parse will
  store a data point at the time of invocation with the given event name.
 
- @discussion Dimensions will allow segmentation of the occurrences of this custom event.
+ Dimensions will allow segmentation of the occurrences of this custom event.
  Keys and values should be NSStrings, and will throw otherwise.
 
  To track a user signup along with additional metadata, consider the following:

--- a/Parse/PFAnalytics.h
+++ b/Parse/PFAnalytics.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  launched, if any. This value can be found as a parameter to various
  `UIApplicationDelegate` methods, and can be empty or `nil`.
 
- @returns Returns the task encapsulating the work being done.
+ @return Returns the task encapsulating the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)trackAppOpenedWithLaunchOptions:(nullable NSDictionary *)launchOptions;
 
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  or as a parameter to `application:didReceiveRemoteNotification:`.
  This can be empty or `nil`.
 
- @returns Returns the task encapsulating the work being done.
+ @return Returns the task encapsulating the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)trackAppOpenedWithRemoteNotificationPayload:(nullable NSDictionary *)userInfo;
 
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param name The name of the custom event to report to Parse as having happened.
 
- @returns Returns the task encapsulating the work being done.
+ @return Returns the task encapsulating the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)trackEvent:(NSString *)name;
 
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param name The name of the custom event to report to Parse as having happened.
  @param dimensions The `NSDictionary` of information by which to segment this event.
 
- @returns Returns the task encapsulating the work being done.
+ @return Returns the task encapsulating the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)trackEvent:(NSString *)name
                                   dimensions:(nullable NSDictionary PF_GENERIC(NSString *, NSString *)*)dimensions;

--- a/Parse/PFAnalytics.h
+++ b/Parse/PFAnalytics.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  `PFAnalytics` provides an interface to Parse's logging and analytics backend.
 
  Methods will return immediately and cache the request (+ timestamp) to be
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name App-Open / Push Analytics
 ///--------------------------------------
 
-/*!
+/**
  @abstract Tracks this application being launched. If this happened as the result of the
  user opening a push notification, this method sends along information to
  correlate this open with that push.
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BFTask PF_GENERIC(NSNumber *)*)trackAppOpenedWithLaunchOptions:(nullable NSDictionary *)launchOptions;
 
-/*!
+/**
  @abstract Tracks this application being launched.
  If this happened as the result of the user opening a push notification,
  this method sends along information to correlate this open with that push.
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)trackAppOpenedWithLaunchOptionsInBackground:(nullable NSDictionary *)launchOptions
                                               block:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract Tracks this application being launched. If this happened as the result of the
  user opening a push notification, this method sends along information to
  correlate this open with that push.
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BFTask PF_GENERIC(NSNumber *)*)trackAppOpenedWithRemoteNotificationPayload:(nullable NSDictionary *)userInfo;
 
-/*!
+/**
  @abstract Tracks this application being launched. If this happened as the result of the
  user opening a push notification, this method sends along information to
  correlate this open with that push.
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Custom Analytics
 ///--------------------------------------
 
-/*!
+/**
  @abstract Tracks the occurrence of a custom event.
 
  @discussion Parse will store a data point at the time of invocation with the given event name.
@@ -102,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BFTask PF_GENERIC(NSNumber *)*)trackEvent:(NSString *)name;
 
-/*!
+/**
  @abstract Tracks the occurrence of a custom event. Parse will store a data point at the
  time of invocation with the given event name. The event will be sent at some
  unspecified time in the future, even if Parse is currently inaccessible.
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)trackEventInBackground:(NSString *)name block:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract Tracks the occurrence of a custom event with additional dimensions. Parse will
  store a data point at the time of invocation with the given event name.
 
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BFTask PF_GENERIC(NSNumber *)*)trackEvent:(NSString *)name
                                   dimensions:(nullable NSDictionary PF_GENERIC(NSString *, NSString *)*)dimensions;
 
-/*!
+/**
  @abstract Tracks the occurrence of a custom event with additional dimensions. Parse will
  store a data point at the time of invocation with the given event name. The
  event will be sent at some unspecified time in the future, even if Parse is currently inaccessible.

--- a/Parse/PFAnalytics.h
+++ b/Parse/PFAnalytics.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Tracks this application being launched. If this happened as the result of the
+ Tracks this application being launched. If this happened as the result of the
  user opening a push notification, this method sends along information to
  correlate this open with that push.
 
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BFTask PF_GENERIC(NSNumber *)*)trackAppOpenedWithLaunchOptions:(nullable NSDictionary *)launchOptions;
 
 /**
- @abstract Tracks this application being launched.
+ Tracks this application being launched.
  If this happened as the result of the user opening a push notification,
  this method sends along information to correlate this open with that push.
 
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
                                               block:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract Tracks this application being launched. If this happened as the result of the
+ Tracks this application being launched. If this happened as the result of the
  user opening a push notification, this method sends along information to
  correlate this open with that push.
 
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BFTask PF_GENERIC(NSNumber *)*)trackAppOpenedWithRemoteNotificationPayload:(nullable NSDictionary *)userInfo;
 
 /**
- @abstract Tracks this application being launched. If this happened as the result of the
+ Tracks this application being launched. If this happened as the result of the
  user opening a push notification, this method sends along information to
  correlate this open with that push.
 
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Tracks the occurrence of a custom event.
+ Tracks the occurrence of a custom event.
 
  @discussion Parse will store a data point at the time of invocation with the given event name.
 
@@ -103,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BFTask PF_GENERIC(NSNumber *)*)trackEvent:(NSString *)name;
 
 /**
- @abstract Tracks the occurrence of a custom event. Parse will store a data point at the
+ Tracks the occurrence of a custom event. Parse will store a data point at the
  time of invocation with the given event name. The event will be sent at some
  unspecified time in the future, even if Parse is currently inaccessible.
 
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)trackEventInBackground:(NSString *)name block:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract Tracks the occurrence of a custom event with additional dimensions. Parse will
+ Tracks the occurrence of a custom event with additional dimensions. Parse will
  store a data point at the time of invocation with the given event name.
 
  @discussion Dimensions will allow segmentation of the occurrences of this custom event.
@@ -138,7 +138,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   dimensions:(nullable NSDictionary PF_GENERIC(NSString *, NSString *)*)dimensions;
 
 /**
- @abstract Tracks the occurrence of a custom event with additional dimensions. Parse will
+ Tracks the occurrence of a custom event with additional dimensions. Parse will
  store a data point at the time of invocation with the given event name. The
  event will be sent at some unspecified time in the future, even if Parse is currently inaccessible.
 

--- a/Parse/PFAnonymousUtils.h
+++ b/Parse/PFAnonymousUtils.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates an anonymous user asynchronously and sets as a result to `BFTask`.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(PFUser *)*)logInInBackground;
 
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param user <PFUser> object to check for anonymity. The user must be logged in on this device.
 
- @returns `YES` if the user is anonymous. `NO` if the user is not the current user or is not anonymous.
+ @return `YES` if the user is anonymous. `NO` if the user is not the current user or is not anonymous.
  */
 + (BOOL)isLinkedWithUser:(nullable PFUser *)user;
 

--- a/Parse/PFAnonymousUtils.h
+++ b/Parse/PFAnonymousUtils.h
@@ -41,14 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Creates an anonymous user asynchronously and sets as a result to `BFTask`.
+ Creates an anonymous user asynchronously and sets as a result to `BFTask`.
 
  @returns The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(PFUser *)*)logInInBackground;
 
 /**
- @abstract Creates an anonymous user.
+ Creates an anonymous user.
 
  @param block The block to execute when anonymous user creation is complete.
  It should have the following argument signature: `^(PFUser *user, NSError *error)`.
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)logInWithBlock:(nullable PFUserResultBlock)block;
 
 /*
- @abstract Creates an anonymous user.
+ Creates an anonymous user.
 
  @param target Target object for the selector.
  @param selector The selector that will be called when the asynchronous request is complete.
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Whether the <PFUser> object is logged in anonymously.
+ Whether the <PFUser> object is logged in anonymously.
 
  @param user <PFUser> object to check for anonymity. The user must be logged in on this device.
 

--- a/Parse/PFAnonymousUtils.h
+++ b/Parse/PFAnonymousUtils.h
@@ -69,9 +69,9 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- Whether the <PFUser> object is logged in anonymously.
+ Whether the `PFUser` object is logged in anonymously.
 
- @param user <PFUser> object to check for anonymity. The user must be logged in on this device.
+ @param user `PFUser` object to check for anonymity. The user must be logged in on this device.
 
  @return `YES` if the user is anonymous. `NO` if the user is not the current user or is not anonymous.
  */

--- a/Parse/PFAnonymousUtils.h
+++ b/Parse/PFAnonymousUtils.h
@@ -16,7 +16,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  Provides utility functions for working with Anonymously logged-in users.
  Anonymous users have some unique characteristics:
 
@@ -40,14 +40,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Creating an Anonymous User
 ///--------------------------------------
 
-/*!
+/**
  @abstract Creates an anonymous user asynchronously and sets as a result to `BFTask`.
 
  @returns The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(PFUser *)*)logInInBackground;
 
-/*!
+/**
  @abstract Creates an anonymous user.
 
  @param block The block to execute when anonymous user creation is complete.
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Determining Whether a User is Anonymous
 ///--------------------------------------
 
-/*!
+/**
  @abstract Whether the <PFUser> object is logged in anonymously.
 
  @param user <PFUser> object to check for anonymity. The user must be logged in on this device.

--- a/Parse/PFCloud.h
+++ b/Parse/PFCloud.h
@@ -15,12 +15,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  The `PFCloud` class provides methods for interacting with Parse Cloud Functions.
  */
 @interface PFCloud : NSObject
 
-/*!
+/**
  @abstract Calls the given cloud function *synchronously* with the parameters provided.
 
  @param function The function name to call.
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable id)callFunction:(NSString *)function withParameters:(nullable NSDictionary *)parameters PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Calls the given cloud function *synchronously* with the parameters provided and
  sets the error if there is one.
 
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
              withParameters:(nullable NSDictionary *)parameters
                       error:(NSError **)error;
 
-/*!
+/**
  @abstract Calls the given cloud function *asynchronously* with the parameters provided.
 
  @param function The function name to call.
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BFTask PF_GENERIC(id) *)callFunctionInBackground:(NSString *)function
                                      withParameters:(nullable NSDictionary *)parameters;
 
-/*!
+/**
  @abstract Calls the given cloud function *asynchronously* with the parameters provided
  and executes the given block when it is done.
 

--- a/Parse/PFCloud.h
+++ b/Parse/PFCloud.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param function The function name to call.
  @param parameters The parameters to send to the function.
 
- @returns The response from the cloud function.
+ @return The response from the cloud function.
  */
 + (nullable id)callFunction:(NSString *)function withParameters:(nullable NSDictionary *)parameters PF_SWIFT_UNAVAILABLE;
 
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param parameters The parameters to send to the function.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns The response from the cloud function.
+ @return The response from the cloud function.
  This result could be a `NSDictionary`, an `NSArray`, `NSNumber` or `NSString`.
  */
 + (nullable id)callFunction:(NSString *)function
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param function The function name to call.
  @param parameters The parameters to send to the function.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(id) *)callFunctionInBackground:(NSString *)function
                                      withParameters:(nullable NSDictionary *)parameters;

--- a/Parse/PFCloud.h
+++ b/Parse/PFCloud.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFCloud : NSObject
 
 /**
- @abstract Calls the given cloud function *synchronously* with the parameters provided.
+ Calls the given cloud function *synchronously* with the parameters provided.
 
  @param function The function name to call.
  @param parameters The parameters to send to the function.
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable id)callFunction:(NSString *)function withParameters:(nullable NSDictionary *)parameters PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Calls the given cloud function *synchronously* with the parameters provided and
+ Calls the given cloud function *synchronously* with the parameters provided and
  sets the error if there is one.
 
  @param function The function name to call.
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
                       error:(NSError **)error;
 
 /**
- @abstract Calls the given cloud function *asynchronously* with the parameters provided.
+ Calls the given cloud function *asynchronously* with the parameters provided.
 
  @param function The function name to call.
  @param parameters The parameters to send to the function.
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
                                      withParameters:(nullable NSDictionary *)parameters;
 
 /**
- @abstract Calls the given cloud function *asynchronously* with the parameters provided
+ Calls the given cloud function *asynchronously* with the parameters provided
  and executes the given block when it is done.
 
  @param function The function name to call.
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
                            block:(nullable PFIdResultBlock)block;
 
 /*
- @abstract Calls the given cloud function *asynchronously* with the parameters provided
+ Calls the given cloud function *asynchronously* with the parameters provided
  and then executes the given selector when it is done.
 
  @param function The function name to call.

--- a/Parse/PFConfig.h
+++ b/Parse/PFConfig.h
@@ -30,7 +30,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 ///--------------------------------------
 
 /**
- @abstract Returns the most recently fetched config.
+ Returns the most recently fetched config.
 
  @discussion If there was no config fetched - this method will return an empty instance of `PFConfig`.
 
@@ -43,14 +43,14 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 ///--------------------------------------
 
 /**
- @abstract Gets the `PFConfig` object *synchronously* from the server.
+ Gets the `PFConfig` object *synchronously* from the server.
 
  @returns Instance of `PFConfig` if the operation succeeded, otherwise `nil`.
  */
 + (nullable PFConfig *)getConfig PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Gets the `PFConfig` object *synchronously* from the server and sets an error if it occurs.
+ Gets the `PFConfig` object *synchronously* from the server and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -59,14 +59,14 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 + (nullable PFConfig *)getConfig:(NSError **)error;
 
 /**
- @abstract Gets the `PFConfig` *asynchronously* and sets it as a result of a task.
+ Gets the `PFConfig` *asynchronously* and sets it as a result of a task.
 
  @returns The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(PFConfig *)*)getConfigInBackground;
 
 /**
- @abstract Gets the `PFConfig` *asynchronously* and executes the given callback block.
+ Gets the `PFConfig` *asynchronously* and executes the given callback block.
 
  @param block The block to execute.
  It should have the following argument signature: `^(PFConfig *config, NSError *error)`.
@@ -78,7 +78,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 ///--------------------------------------
 
 /**
- @abstract Returns the object associated with a given key.
+ Returns the object associated with a given key.
 
  @param key The key for which to return the corresponding configuration value.
 
@@ -87,7 +87,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 - (nullable id)objectForKey:(NSString *)key;
 
 /**
- @abstract Returns the object associated with a given key.
+ Returns the object associated with a given key.
 
  @discussion This method enables usage of literal syntax on `PFConfig`.
  E.g. `NSString *value = config[@"key"];`

--- a/Parse/PFConfig.h
+++ b/Parse/PFConfig.h
@@ -32,7 +32,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 /**
  Returns the most recently fetched config.
 
- @discussion If there was no config fetched - this method will return an empty instance of `PFConfig`.
+ If there was no config fetched - this method will return an empty instance of `PFConfig`.
 
  @returns Current, last fetched instance of PFConfig.
  */
@@ -89,7 +89,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 /**
  Returns the object associated with a given key.
 
- @discussion This method enables usage of literal syntax on `PFConfig`.
+ This method enables usage of literal syntax on `PFConfig`.
  E.g. `NSString *value = config[@"key"];`
 
  @see objectForKey:

--- a/Parse/PFConfig.h
+++ b/Parse/PFConfig.h
@@ -34,7 +34,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 
  If there was no config fetched - this method will return an empty instance of `PFConfig`.
 
- @returns Current, last fetched instance of PFConfig.
+ @return Current, last fetched instance of PFConfig.
  */
 + (PFConfig *)currentConfig;
 
@@ -45,7 +45,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 /**
  Gets the `PFConfig` object *synchronously* from the server.
 
- @returns Instance of `PFConfig` if the operation succeeded, otherwise `nil`.
+ @return Instance of `PFConfig` if the operation succeeded, otherwise `nil`.
  */
 + (nullable PFConfig *)getConfig PF_SWIFT_UNAVAILABLE;
 
@@ -54,14 +54,14 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Instance of PFConfig if the operation succeeded, otherwise `nil`.
+ @return Instance of PFConfig if the operation succeeded, otherwise `nil`.
  */
 + (nullable PFConfig *)getConfig:(NSError **)error;
 
 /**
  Gets the `PFConfig` *asynchronously* and sets it as a result of a task.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(PFConfig *)*)getConfigInBackground;
 
@@ -82,7 +82,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 
  @param key The key for which to return the corresponding configuration value.
 
- @returns The value associated with `key`, or `nil` if there is no such value.
+ @return The value associated with `key`, or `nil` if there is no such value.
  */
 - (nullable id)objectForKey:(NSString *)key;
 
@@ -96,7 +96,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 
  @param keyedSubscript The keyed subscript for which to return the corresponding configuration value.
 
- @returns The value associated with `key`, or `nil` if there is no such value.
+ @return The value associated with `key`, or `nil` if there is no such value.
  */
 - (nullable id)objectForKeyedSubscript:(NSString *)keyedSubscript;
 

--- a/Parse/PFConfig.h
+++ b/Parse/PFConfig.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nullable error);
 
-/*!
+/**
  `PFConfig` is a representation of the remote configuration object.
  It enables you to add things like feature gating, a/b testing or simple "Message of the day".
  */
@@ -29,7 +29,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 /// @name Current Config
 ///--------------------------------------
 
-/*!
+/**
  @abstract Returns the most recently fetched config.
 
  @discussion If there was no config fetched - this method will return an empty instance of `PFConfig`.
@@ -42,14 +42,14 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 /// @name Retrieving Config
 ///--------------------------------------
 
-/*!
+/**
  @abstract Gets the `PFConfig` object *synchronously* from the server.
 
  @returns Instance of `PFConfig` if the operation succeeded, otherwise `nil`.
  */
 + (nullable PFConfig *)getConfig PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Gets the `PFConfig` object *synchronously* from the server and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -58,14 +58,14 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
  */
 + (nullable PFConfig *)getConfig:(NSError **)error;
 
-/*!
+/**
  @abstract Gets the `PFConfig` *asynchronously* and sets it as a result of a task.
 
  @returns The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(PFConfig *)*)getConfigInBackground;
 
-/*!
+/**
  @abstract Gets the `PFConfig` *asynchronously* and executes the given callback block.
 
  @param block The block to execute.
@@ -77,7 +77,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 /// @name Parameters
 ///--------------------------------------
 
-/*!
+/**
  @abstract Returns the object associated with a given key.
 
  @param key The key for which to return the corresponding configuration value.
@@ -86,7 +86,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
  */
 - (nullable id)objectForKey:(NSString *)key;
 
-/*!
+/**
  @abstract Returns the object associated with a given key.
 
  @discussion This method enables usage of literal syntax on `PFConfig`.

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -58,31 +58,31 @@ extern NSString *const __nonnull kPFParseServer;
  */
 typedef NS_ENUM(uint8_t, PFCachePolicy) {
     /**
-     @abstract The query does not load from the cache or save results to the cache.
+     The query does not load from the cache or save results to the cache.
      This is the default cache policy.
      */
     kPFCachePolicyIgnoreCache = 0,
     /**
-     @abstract The query only loads from the cache, ignoring the network.
+     The query only loads from the cache, ignoring the network.
      If there are no cached results, this causes a `NSError` with `kPFErrorCacheMiss` code.
      */
     kPFCachePolicyCacheOnly,
     /**
-     @abstract The query does not load from the cache, but it will save results to the cache.
+     The query does not load from the cache, but it will save results to the cache.
      */
     kPFCachePolicyNetworkOnly,
     /**
-     @abstract The query first tries to load from the cache, but if that fails, it loads results from the network.
+     The query first tries to load from the cache, but if that fails, it loads results from the network.
      If there are no cached results, this causes a `NSError` with `kPFErrorCacheMiss` code.
      */
     kPFCachePolicyCacheElseNetwork,
     /**
-     @abstract The query first tries to load from the network, but if that fails, it loads results from the cache.
+     The query first tries to load from the network, but if that fails, it loads results from the cache.
      If there are no cached results, this causes a `NSError` with `kPFErrorCacheMiss` code.
      */
     kPFCachePolicyNetworkElseCache,
     /**
-     @abstract The query first loads from the cache, then loads from the network.
+     The query first loads from the cache, then loads from the network.
      The callback will be called twice - first with the cached results, then with the network results.
      Since it returns two results at different times, this cache policy cannot be used with synchronous or task methods.
      */
@@ -144,96 +144,96 @@ extern NSString *const __nonnull PFParseErrorDomain;
  */
 typedef NS_ENUM(NSInteger, PFErrorCode) {
     /**
-     @abstract Internal server error. No information available.
+     Internal server error. No information available.
      */
     kPFErrorInternalServer = 1,
     /**
-     @abstract The connection to the Parse servers failed.
+     The connection to the Parse servers failed.
      */
     kPFErrorConnectionFailed = 100,
     /**
-     @abstract Object doesn't exist, or has an incorrect password.
+     Object doesn't exist, or has an incorrect password.
      */
     kPFErrorObjectNotFound = 101,
     /**
-     @abstract You tried to find values matching a datatype that doesn't
+     You tried to find values matching a datatype that doesn't
      support exact database matching, like an array or a dictionary.
      */
     kPFErrorInvalidQuery = 102,
     /**
-     @abstract Missing or invalid classname. Classnames are case-sensitive.
+     Missing or invalid classname. Classnames are case-sensitive.
      They must start with a letter, and `a-zA-Z0-9_` are the only valid characters.
      */
     kPFErrorInvalidClassName = 103,
     /**
-     @abstract Missing object id.
+     Missing object id.
      */
     kPFErrorMissingObjectId = 104,
     /**
-     @abstract Invalid key name. Keys are case-sensitive.
+     Invalid key name. Keys are case-sensitive.
      They must start with a letter, and `a-zA-Z0-9_` are the only valid characters.
      */
     kPFErrorInvalidKeyName = 105,
     /**
-     @abstract Malformed pointer. Pointers must be arrays of a classname and an object id.
+     Malformed pointer. Pointers must be arrays of a classname and an object id.
      */
     kPFErrorInvalidPointer = 106,
     /**
-     @abstract Malformed json object. A json dictionary is expected.
+     Malformed json object. A json dictionary is expected.
      */
     kPFErrorInvalidJSON = 107,
     /**
-     @abstract Tried to access a feature only available internally.
+     Tried to access a feature only available internally.
      */
     kPFErrorCommandUnavailable = 108,
     /**
-     @abstract Field set to incorrect type.
+     Field set to incorrect type.
      */
     kPFErrorIncorrectType = 111,
     /**
-     @abstract Invalid channel name. A channel name is either an empty string (the broadcast channel)
+     Invalid channel name. A channel name is either an empty string (the broadcast channel)
      or contains only `a-zA-Z0-9_` characters and starts with a letter.
      */
     kPFErrorInvalidChannelName = 112,
     /**
-     @abstract Invalid device token.
+     Invalid device token.
      */
     kPFErrorInvalidDeviceToken = 114,
     /**
-     @abstract Push is misconfigured. See details to find out how.
+     Push is misconfigured. See details to find out how.
      */
     kPFErrorPushMisconfigured = 115,
     /**
-     @abstract The object is too large.
+     The object is too large.
      */
     kPFErrorObjectTooLarge = 116,
     /**
-     @abstract That operation isn't allowed for clients.
+     That operation isn't allowed for clients.
      */
     kPFErrorOperationForbidden = 119,
     /**
-     @abstract The results were not found in the cache.
+     The results were not found in the cache.
      */
     kPFErrorCacheMiss = 120,
     /**
-     @abstract Keys in `NSDictionary` values may not include `$` or `.`.
+     Keys in `NSDictionary` values may not include `$` or `.`.
      */
     kPFErrorInvalidNestedKey = 121,
     /**
-     @abstract Invalid file name.
+     Invalid file name.
      A file name can contain only `a-zA-Z0-9_.` characters and should be between 1 and 36 characters.
      */
     kPFErrorInvalidFileName = 122,
     /**
-     @abstract Invalid ACL. An ACL with an invalid format was saved. This should not happen if you use <PFACL>.
+     Invalid ACL. An ACL with an invalid format was saved. This should not happen if you use <PFACL>.
      */
     kPFErrorInvalidACL = 123,
     /**
-     @abstract The request timed out on the server. Typically this indicates the request is too expensive.
+     The request timed out on the server. Typically this indicates the request is too expensive.
      */
     kPFErrorTimeout = 124,
     /**
-     @abstract The email address was invalid.
+     The email address was invalid.
      */
     kPFErrorInvalidEmailAddress = 125,
     /**
@@ -241,107 +241,107 @@ typedef NS_ENUM(NSInteger, PFErrorCode) {
      */
     kPFErrorDuplicateValue = 137,
     /**
-     @abstract Role's name is invalid.
+     Role's name is invalid.
      */
     kPFErrorInvalidRoleName = 139,
     /**
-     @abstract Exceeded an application quota. Upgrade to resolve.
+     Exceeded an application quota. Upgrade to resolve.
      */
     kPFErrorExceededQuota = 140,
     /**
-     @abstract Cloud Code script had an error.
+     Cloud Code script had an error.
      */
     kPFScriptError = 141,
     /**
-     @abstract Cloud Code validation failed.
+     Cloud Code validation failed.
      */
     kPFValidationError = 142,
     /**
-     @abstract Product purchase receipt is missing.
+     Product purchase receipt is missing.
      */
     kPFErrorReceiptMissing = 143,
     /**
-     @abstract Product purchase receipt is invalid.
+     Product purchase receipt is invalid.
      */
     kPFErrorInvalidPurchaseReceipt = 144,
     /**
-     @abstract Payment is disabled on this device.
+     Payment is disabled on this device.
      */
     kPFErrorPaymentDisabled = 145,
     /**
-     @abstract The product identifier is invalid.
+     The product identifier is invalid.
      */
     kPFErrorInvalidProductIdentifier = 146,
     /**
-     @abstract The product is not found in the App Store.
+     The product is not found in the App Store.
      */
     kPFErrorProductNotFoundInAppStore = 147,
     /**
-     @abstract The Apple server response is not valid.
+     The Apple server response is not valid.
      */
     kPFErrorInvalidServerResponse = 148,
     /**
-     @abstract Product fails to download due to file system error.
+     Product fails to download due to file system error.
      */
     kPFErrorProductDownloadFileSystemFailure = 149,
     /**
-     @abstract Fail to convert data to image.
+     Fail to convert data to image.
      */
     kPFErrorInvalidImageData = 150,
     /**
-     @abstract Unsaved file.
+     Unsaved file.
      */
     kPFErrorUnsavedFile = 151,
     /**
-     @abstract Fail to delete file.
+     Fail to delete file.
      */
     kPFErrorFileDeleteFailure = 153,
     /**
-     @abstract Application has exceeded its request limit.
+     Application has exceeded its request limit.
      */
     kPFErrorRequestLimitExceeded = 155,
     /**
-     @abstract Invalid event name.
+     Invalid event name.
      */
     kPFErrorInvalidEventName = 160,
     /**
-     @abstract Username is missing or empty.
+     Username is missing or empty.
      */
     kPFErrorUsernameMissing = 200,
     /**
-     @abstract Password is missing or empty.
+     Password is missing or empty.
      */
     kPFErrorUserPasswordMissing = 201,
     /**
-     @abstract Username has already been taken.
+     Username has already been taken.
      */
     kPFErrorUsernameTaken = 202,
     /**
-     @abstract Email has already been taken.
+     Email has already been taken.
      */
     kPFErrorUserEmailTaken = 203,
     /**
-     @abstract The email is missing, and must be specified.
+     The email is missing, and must be specified.
      */
     kPFErrorUserEmailMissing = 204,
     /**
-     @abstract A user with the specified email was not found.
+     A user with the specified email was not found.
      */
     kPFErrorUserWithEmailNotFound = 205,
     /**
-     @abstract The user cannot be altered by a client without the session.
+     The user cannot be altered by a client without the session.
      */
     kPFErrorUserCannotBeAlteredWithoutSession = 206,
     /**
-     @abstract Users can only be created through sign up.
+     Users can only be created through sign up.
      */
     kPFErrorUserCanOnlyBeCreatedThroughSignUp = 207,
     /**
-     @abstract An existing Facebook account already linked to another user.
+     An existing Facebook account already linked to another user.
      */
     kPFErrorFacebookAccountAlreadyLinked = 208,
     /**
-     @abstract An existing account already linked to another user.
+     An existing account already linked to another user.
      */
     kPFErrorAccountAlreadyLinked = 208,
     /**
@@ -350,19 +350,19 @@ typedef NS_ENUM(NSInteger, PFErrorCode) {
     kPFErrorInvalidSessionToken = 209,
     kPFErrorUserIdMismatch = 209,
     /**
-     @abstract Facebook id missing from request.
+     Facebook id missing from request.
      */
     kPFErrorFacebookIdMissing = 250,
     /**
-     @abstract Linked id missing from request.
+     Linked id missing from request.
      */
     kPFErrorLinkedIdMissing = 250,
     /**
-     @abstract Invalid Facebook session.
+     Invalid Facebook session.
      */
     kPFErrorFacebookInvalidSession = 251,
     /**
-     @abstract Invalid linked session.
+     Invalid linked session.
      */
     kPFErrorInvalidLinkedSession = 251,
 };
@@ -389,29 +389,29 @@ typedef void (^PFProgressBlock)(int percentDone);
 ///--------------------------------------
 
 /**
- @abstract The name of the notification that is going to be sent before any URL request is sent.
+ The name of the notification that is going to be sent before any URL request is sent.
  */
 extern NSString *const __nonnull PFNetworkWillSendURLRequestNotification;
 
 /**
- @abstract The name of the notification that is going to be sent after any URL response is received.
+ The name of the notification that is going to be sent after any URL response is received.
  */
 extern NSString *const __nonnull PFNetworkDidReceiveURLResponseNotification;
 
 /**
- @abstract The key of request(NSURLRequest) in the userInfo dictionary of a notification.
+ The key of request(NSURLRequest) in the userInfo dictionary of a notification.
  @note This key is populated in userInfo, only if `PFLogLevel` on `Parse` is set to `PFLogLevelDebug`.
  */
 extern NSString *const __nonnull PFNetworkNotificationURLRequestUserInfoKey;
 
 /**
- @abstract The key of response(NSHTTPURLResponse) in the userInfo dictionary of a notification.
+ The key of response(NSHTTPURLResponse) in the userInfo dictionary of a notification.
  @note This key is populated in userInfo, only if `PFLogLevel` on `Parse` is set to `PFLogLevelDebug`.
  */
 extern NSString *const __nonnull PFNetworkNotificationURLResponseUserInfoKey;
 
 /**
- @abstract The key of repsonse body (usually `NSString` with JSON) in the userInfo dictionary of a notification.
+ The key of repsonse body (usually `NSString` with JSON) in the userInfo dictionary of a notification.
  @note This key is populated in userInfo, only if `PFLogLevel` on `Parse` is set to `PFLogLevelDebug`.
  */
 extern NSString *const __nonnull PFNetworkNotificationURLResponseBodyUserInfoKey;

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -45,7 +45,7 @@ extern NSString *const __nonnull kPFParseServer;
 /// @name Cache Policies
 ///--------------------------------------
 
-/*!
+/**
  `PFCachePolicy` specifies different caching policies that could be used with <PFQuery>.
 
  This lets you show data when the user's device is offline,
@@ -57,31 +57,31 @@ extern NSString *const __nonnull kPFParseServer;
  @see PFQuery
  */
 typedef NS_ENUM(uint8_t, PFCachePolicy) {
-    /*!
+    /**
      @abstract The query does not load from the cache or save results to the cache.
      This is the default cache policy.
      */
     kPFCachePolicyIgnoreCache = 0,
-    /*!
+    /**
      @abstract The query only loads from the cache, ignoring the network.
      If there are no cached results, this causes a `NSError` with `kPFErrorCacheMiss` code.
      */
     kPFCachePolicyCacheOnly,
-    /*!
+    /**
      @abstract The query does not load from the cache, but it will save results to the cache.
      */
     kPFCachePolicyNetworkOnly,
-    /*!
+    /**
      @abstract The query first tries to load from the cache, but if that fails, it loads results from the network.
      If there are no cached results, this causes a `NSError` with `kPFErrorCacheMiss` code.
      */
     kPFCachePolicyCacheElseNetwork,
-    /*!
+    /**
      @abstract The query first tries to load from the network, but if that fails, it loads results from the cache.
      If there are no cached results, this causes a `NSError` with `kPFErrorCacheMiss` code.
      */
     kPFCachePolicyNetworkElseCache,
-    /*!
+    /**
      @abstract The query first loads from the cache, then loads from the network.
      The callback will be called twice - first with the cached results, then with the network results.
      Since it returns two results at different times, this cache policy cannot be used with synchronous or task methods.
@@ -93,35 +93,35 @@ typedef NS_ENUM(uint8_t, PFCachePolicy) {
 /// @name Logging Levels
 ///--------------------------------------
 
-/*!
+/**
  `PFLogLevel` enum specifies different levels of logging that could be used to limit or display more messages in logs.
 
  @see [Parse setLogLevel:]
  @see [Parse logLevel]
  */
 typedef NS_ENUM(uint8_t, PFLogLevel) {
-    /*!
+    /**
      Log level that disables all logging.
      */
     PFLogLevelNone = 0,
-    /*!
+    /**
      Log level that if set is going to output error messages to the log.
      */
     PFLogLevelError = 1,
-    /*!
+    /**
      Log level that if set is going to output the following messages to log:
      - Errors
      - Warnings
      */
     PFLogLevelWarning = 2,
-    /*!
+    /**
      Log level that if set is going to output the following messages to log:
      - Errors
      - Warnings
      - Informational messages
      */
     PFLogLevelInfo = 3,
-    /*!
+    /**
      Log level that if set is going to output the following messages to log:
      - Errors
      - Warnings
@@ -137,231 +137,231 @@ typedef NS_ENUM(uint8_t, PFLogLevel) {
 
 extern NSString *const __nonnull PFParseErrorDomain;
 
-/*!
+/**
  `PFErrorCode` enum contains all custom error codes that are used as `code` for `NSError` for callbacks on all classes.
 
  These codes are used when `domain` of `NSError` that you receive is set to `PFParseErrorDomain`.
  */
 typedef NS_ENUM(NSInteger, PFErrorCode) {
-    /*!
+    /**
      @abstract Internal server error. No information available.
      */
     kPFErrorInternalServer = 1,
-    /*!
+    /**
      @abstract The connection to the Parse servers failed.
      */
     kPFErrorConnectionFailed = 100,
-    /*!
+    /**
      @abstract Object doesn't exist, or has an incorrect password.
      */
     kPFErrorObjectNotFound = 101,
-    /*!
+    /**
      @abstract You tried to find values matching a datatype that doesn't
      support exact database matching, like an array or a dictionary.
      */
     kPFErrorInvalidQuery = 102,
-    /*!
+    /**
      @abstract Missing or invalid classname. Classnames are case-sensitive.
      They must start with a letter, and `a-zA-Z0-9_` are the only valid characters.
      */
     kPFErrorInvalidClassName = 103,
-    /*!
+    /**
      @abstract Missing object id.
      */
     kPFErrorMissingObjectId = 104,
-    /*!
+    /**
      @abstract Invalid key name. Keys are case-sensitive.
      They must start with a letter, and `a-zA-Z0-9_` are the only valid characters.
      */
     kPFErrorInvalidKeyName = 105,
-    /*!
+    /**
      @abstract Malformed pointer. Pointers must be arrays of a classname and an object id.
      */
     kPFErrorInvalidPointer = 106,
-    /*!
+    /**
      @abstract Malformed json object. A json dictionary is expected.
      */
     kPFErrorInvalidJSON = 107,
-    /*!
+    /**
      @abstract Tried to access a feature only available internally.
      */
     kPFErrorCommandUnavailable = 108,
-    /*!
+    /**
      @abstract Field set to incorrect type.
      */
     kPFErrorIncorrectType = 111,
-    /*!
+    /**
      @abstract Invalid channel name. A channel name is either an empty string (the broadcast channel)
      or contains only `a-zA-Z0-9_` characters and starts with a letter.
      */
     kPFErrorInvalidChannelName = 112,
-    /*!
+    /**
      @abstract Invalid device token.
      */
     kPFErrorInvalidDeviceToken = 114,
-    /*!
+    /**
      @abstract Push is misconfigured. See details to find out how.
      */
     kPFErrorPushMisconfigured = 115,
-    /*!
+    /**
      @abstract The object is too large.
      */
     kPFErrorObjectTooLarge = 116,
-    /*!
+    /**
      @abstract That operation isn't allowed for clients.
      */
     kPFErrorOperationForbidden = 119,
-    /*!
+    /**
      @abstract The results were not found in the cache.
      */
     kPFErrorCacheMiss = 120,
-    /*!
+    /**
      @abstract Keys in `NSDictionary` values may not include `$` or `.`.
      */
     kPFErrorInvalidNestedKey = 121,
-    /*!
+    /**
      @abstract Invalid file name.
      A file name can contain only `a-zA-Z0-9_.` characters and should be between 1 and 36 characters.
      */
     kPFErrorInvalidFileName = 122,
-    /*!
+    /**
      @abstract Invalid ACL. An ACL with an invalid format was saved. This should not happen if you use <PFACL>.
      */
     kPFErrorInvalidACL = 123,
-    /*!
+    /**
      @abstract The request timed out on the server. Typically this indicates the request is too expensive.
      */
     kPFErrorTimeout = 124,
-    /*!
+    /**
      @abstract The email address was invalid.
      */
     kPFErrorInvalidEmailAddress = 125,
-    /*!
+    /**
      A unique field was given a value that is already taken.
      */
     kPFErrorDuplicateValue = 137,
-    /*!
+    /**
      @abstract Role's name is invalid.
      */
     kPFErrorInvalidRoleName = 139,
-    /*!
+    /**
      @abstract Exceeded an application quota. Upgrade to resolve.
      */
     kPFErrorExceededQuota = 140,
-    /*!
+    /**
      @abstract Cloud Code script had an error.
      */
     kPFScriptError = 141,
-    /*!
+    /**
      @abstract Cloud Code validation failed.
      */
     kPFValidationError = 142,
-    /*!
+    /**
      @abstract Product purchase receipt is missing.
      */
     kPFErrorReceiptMissing = 143,
-    /*!
+    /**
      @abstract Product purchase receipt is invalid.
      */
     kPFErrorInvalidPurchaseReceipt = 144,
-    /*!
+    /**
      @abstract Payment is disabled on this device.
      */
     kPFErrorPaymentDisabled = 145,
-    /*!
+    /**
      @abstract The product identifier is invalid.
      */
     kPFErrorInvalidProductIdentifier = 146,
-    /*!
+    /**
      @abstract The product is not found in the App Store.
      */
     kPFErrorProductNotFoundInAppStore = 147,
-    /*!
+    /**
      @abstract The Apple server response is not valid.
      */
     kPFErrorInvalidServerResponse = 148,
-    /*!
+    /**
      @abstract Product fails to download due to file system error.
      */
     kPFErrorProductDownloadFileSystemFailure = 149,
-    /*!
+    /**
      @abstract Fail to convert data to image.
      */
     kPFErrorInvalidImageData = 150,
-    /*!
+    /**
      @abstract Unsaved file.
      */
     kPFErrorUnsavedFile = 151,
-    /*!
+    /**
      @abstract Fail to delete file.
      */
     kPFErrorFileDeleteFailure = 153,
-    /*!
+    /**
      @abstract Application has exceeded its request limit.
      */
     kPFErrorRequestLimitExceeded = 155,
-    /*!
+    /**
      @abstract Invalid event name.
      */
     kPFErrorInvalidEventName = 160,
-    /*!
+    /**
      @abstract Username is missing or empty.
      */
     kPFErrorUsernameMissing = 200,
-    /*!
+    /**
      @abstract Password is missing or empty.
      */
     kPFErrorUserPasswordMissing = 201,
-    /*!
+    /**
      @abstract Username has already been taken.
      */
     kPFErrorUsernameTaken = 202,
-    /*!
+    /**
      @abstract Email has already been taken.
      */
     kPFErrorUserEmailTaken = 203,
-    /*!
+    /**
      @abstract The email is missing, and must be specified.
      */
     kPFErrorUserEmailMissing = 204,
-    /*!
+    /**
      @abstract A user with the specified email was not found.
      */
     kPFErrorUserWithEmailNotFound = 205,
-    /*!
+    /**
      @abstract The user cannot be altered by a client without the session.
      */
     kPFErrorUserCannotBeAlteredWithoutSession = 206,
-    /*!
+    /**
      @abstract Users can only be created through sign up.
      */
     kPFErrorUserCanOnlyBeCreatedThroughSignUp = 207,
-    /*!
+    /**
      @abstract An existing Facebook account already linked to another user.
      */
     kPFErrorFacebookAccountAlreadyLinked = 208,
-    /*!
+    /**
      @abstract An existing account already linked to another user.
      */
     kPFErrorAccountAlreadyLinked = 208,
-    /*!
+    /**
      Error code indicating that the current session token is invalid.
      */
     kPFErrorInvalidSessionToken = 209,
     kPFErrorUserIdMismatch = 209,
-    /*!
+    /**
      @abstract Facebook id missing from request.
      */
     kPFErrorFacebookIdMissing = 250,
-    /*!
+    /**
      @abstract Linked id missing from request.
      */
     kPFErrorLinkedIdMissing = 250,
-    /*!
+    /**
      @abstract Invalid Facebook session.
      */
     kPFErrorFacebookInvalidSession = 251,
-    /*!
+    /**
      @abstract Invalid linked session.
      */
     kPFErrorInvalidLinkedSession = 251,
@@ -388,29 +388,29 @@ typedef void (^PFProgressBlock)(int percentDone);
 /// @name Network Notifications
 ///--------------------------------------
 
-/*!
+/**
  @abstract The name of the notification that is going to be sent before any URL request is sent.
  */
 extern NSString *const __nonnull PFNetworkWillSendURLRequestNotification;
 
-/*!
+/**
  @abstract The name of the notification that is going to be sent after any URL response is received.
  */
 extern NSString *const __nonnull PFNetworkDidReceiveURLResponseNotification;
 
-/*!
+/**
  @abstract The key of request(NSURLRequest) in the userInfo dictionary of a notification.
  @note This key is populated in userInfo, only if `PFLogLevel` on `Parse` is set to `PFLogLevelDebug`.
  */
 extern NSString *const __nonnull PFNetworkNotificationURLRequestUserInfoKey;
 
-/*!
+/**
  @abstract The key of response(NSHTTPURLResponse) in the userInfo dictionary of a notification.
  @note This key is populated in userInfo, only if `PFLogLevel` on `Parse` is set to `PFLogLevelDebug`.
  */
 extern NSString *const __nonnull PFNetworkNotificationURLResponseUserInfoKey;
 
-/*!
+/**
  @abstract The key of repsonse body (usually `NSString` with JSON) in the userInfo dictionary of a notification.
  @note This key is populated in userInfo, only if `PFLogLevel` on `Parse` is set to `PFLogLevelDebug`.
  */

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -46,7 +46,7 @@ extern NSString *const __nonnull kPFParseServer;
 ///--------------------------------------
 
 /**
- `PFCachePolicy` specifies different caching policies that could be used with <PFQuery>.
+ `PFCachePolicy` specifies different caching policies that could be used with `PFQuery`.
 
  This lets you show data when the user's device is offline,
  or when the app has just started and network requests have not yet had time to complete.
@@ -96,8 +96,8 @@ typedef NS_ENUM(uint8_t, PFCachePolicy) {
 /**
  `PFLogLevel` enum specifies different levels of logging that could be used to limit or display more messages in logs.
 
- @see [Parse setLogLevel:]
- @see [Parse logLevel]
+ @see `Parse.+setLogLevel:`
+ @see `Parse.+logLevel`
  */
 typedef NS_ENUM(uint8_t, PFLogLevel) {
     /**
@@ -225,7 +225,7 @@ typedef NS_ENUM(NSInteger, PFErrorCode) {
      */
     kPFErrorInvalidFileName = 122,
     /**
-     Invalid ACL. An ACL with an invalid format was saved. This should not happen if you use <PFACL>.
+     Invalid ACL. An ACL with an invalid format was saved. This should not happen if you use `PFACL`.
      */
     kPFErrorInvalidACL = 123,
     /**

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param data The contents of the new `PFFile`.
 
- @returns A new `PFFile`.
+ @return A new `PFFile`.
  */
 + (nullable instancetype)fileWithData:(NSData *)data;
 
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  spaces, underscores, or dashes.
  @param data The contents of the new `PFFile`.
 
- @returns A new `PFFile` object.
+ @return A new `PFFile` object.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name data:(NSData *)data;
 
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
  and consist of alphanumeric characters, periods, spaces, underscores, or dashes.
  @param path  The path to the file that will be uploaded to Parse.
 
- @returns A new `PFFile` instance.
+ @return A new `PFFile` instance.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name
                        contentsAtPath:(NSString *)path PF_SWIFT_UNAVAILABLE;
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
  If an error occurs, this pointer is set to an actual error object containing the error information.
  You may specify `nil` for this parameter if you do not want the error information.
 
- @returns A new `PFFile` instance or `nil` if the error occured.
+ @return A new `PFFile` instance or `nil` if the error occured.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name
                        contentsAtPath:(NSString *)path
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param data        The contents of the new `PFFile`.
  @param contentType Represents MIME type of the data.
 
- @returns A new `PFFile` instance.
+ @return A new `PFFile` instance.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name
                                  data:(NSData *)data
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
  If an error occurs, this pointer is set to an actual error object containing the error information.
  You may specify `nil` for this parameter if you do not want the error information.
 
- @returns A new `PFFile` instance or `nil` if the error occured.
+ @return A new `PFFile` instance or `nil` if the error occured.
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name
                                  data:(NSData *)data
@@ -120,7 +120,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param data The contents of the new `PFFile`.
  @param contentType Represents MIME type of the data.
 
- @returns A new `PFFile` object.
+ @return A new `PFFile` object.
  */
 + (instancetype)fileWithData:(NSData *)data contentType:(nullable NSString *)contentType;
 
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Saves the file *synchronously*.
 
- @returns Returns whether the save succeeded.
+ @return Returns whether the save succeeded.
  */
 - (BOOL)save PF_SWIFT_UNAVAILABLE;
 
@@ -163,14 +163,14 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the save succeeded.
+ @return Returns whether the save succeeded.
  */
 - (BOOL)save:(NSError **)error;
 
 /**
  Saves the file *asynchronously*.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveInBackground;
 
@@ -179,7 +179,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param progressBlock The block should have the following argument signature: `^(int percentDone)`
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
@@ -225,7 +225,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *Synchronously* gets the data from cache if available or fetches its contents from the network.
 
- @returns The `NSData` object containing file data. Returns `nil` if there was an error in fetching.
+ @return The `NSData` object containing file data. Returns `nil` if there was an error in fetching.
  */
 - (nullable NSData *)getData PF_SWIFT_UNAVAILABLE;
 
@@ -234,7 +234,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  This can help applications with many large files avoid memory warnings.
 
- @returns A stream containing the data. Returns `nil` if there was an error in fetching.
+ @return A stream containing the data. Returns `nil` if there was an error in fetching.
  */
 - (nullable NSInputStream *)getDataStream PF_SWIFT_UNAVAILABLE;
 
@@ -244,7 +244,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns The `NSData` object containing file data. Returns `nil` if there was an error in fetching.
+ @return The `NSData` object containing file data. Returns `nil` if there was an error in fetching.
  */
 - (nullable NSData *)getData:(NSError **)error;
 
@@ -253,7 +253,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns A stream containing the data. Returns nil if there was an error in
+ @return A stream containing the data. Returns nil if there was an error in
  fetching.
  */
 - (nullable NSInputStream *)getDataStream:(NSError **)error;
@@ -263,7 +263,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see getData
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSData *)*)getDataInBackground;
 
@@ -276,7 +276,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param progressBlock The block should have the following argument signature: ^(int percentDone)
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSData *)*)getDataInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
@@ -286,7 +286,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  This can help applications with many large files avoid memory warnings.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataStreamInBackground;
 
@@ -301,7 +301,7 @@ NS_ASSUME_NONNULL_BEGIN
  @note You MUST open this stream before reading from it.
  @note Do NOT call <waitUntilFinished> on this task from the main thread. It may result in a deadlock.
 
- @returns A task that produces a *live* stream that is being written to with the data from the server.
+ @return A task that produces a *live* stream that is being written to with the data from the server.
  */
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataDownloadStreamInBackground;
 
@@ -312,7 +312,7 @@ NS_ASSUME_NONNULL_BEGIN
  This can help applications with many large files avoid memory warnings.
  @param progressBlock The block should have the following argument signature: ^(int percentDone)
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataStreamInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
@@ -329,7 +329,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param progressBlock The block should have the following argument signature: `^(int percentDone)`
 
- @returns A task that produces a *live* stream that is being written to with the data from the server.
+ @return A task that produces a *live* stream that is being written to with the data from the server.
  */
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataDownloadStreamInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
@@ -391,7 +391,7 @@ NS_ASSUME_NONNULL_BEGIN
  @note If you overwrite the contents of the file at returned path it will persist those change
  until the file cache is cleared.
 
- @returns The task, with the result set to `NSString` representation of a file path.
+ @return The task, with the result set to `NSString` representation of a file path.
  */
 - (BFTask PF_GENERIC(NSString *)*)getFilePathInBackground;
 
@@ -404,7 +404,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param progressBlock The block should have the following argument signature: `^(int percentDone)`.
 
- @returns The task, with the result set to `NSString` representation of a file path.
+ @return The task, with the result set to `NSString` representation of a file path.
  */
 - (BFTask PF_GENERIC(NSString *)*)getFilePathInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -131,7 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The name of the file.
 
- @discussion Before the file is saved, this is the filename given by
+ Before the file is saved, this is the filename given by
  the user. After the file is saved, that name gets prefixed with a unique
  identifier.
  */
@@ -193,7 +193,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Saves the file *asynchronously* and executes the given block.
 
- @discussion This method will execute the progressBlock periodically with the percent progress.
+ This method will execute the progressBlock periodically with the percent progress.
  `progressBlock` will get called with `100` before `resultBlock` is called.
 
  @param block The block should have the following argument signature: `^(BOOL succeeded, NSError *error)`
@@ -232,7 +232,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
 
- @discussion This can help applications with many large files avoid memory warnings.
+ This can help applications with many large files avoid memory warnings.
 
  @returns A stream containing the data. Returns `nil` if there was an error in fetching.
  */
@@ -270,7 +270,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This method is like <getData> but it fetches asynchronously to avoid blocking the current thread.
 
- @discussion This can help applications with many large files avoid memory warnings.
+ This can help applications with many large files avoid memory warnings.
 
  @see getData
 
@@ -284,7 +284,7 @@ NS_ASSUME_NONNULL_BEGIN
  This method is like <getDataInBackground> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
- @discussion This can help applications with many large files avoid memory warnings.
+ This can help applications with many large files avoid memory warnings.
 
  @returns The task, that encapsulates the work being done.
  */
@@ -293,7 +293,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This method is like <getDataStreamInBackground>, but yields a live-updating stream.
 
- @discussion Instead of <getDataStream>, which yields a stream that can be read from only after the request has
+ Instead of <getDataStream>, which yields a stream that can be read from only after the request has
  completed, this method gives you a stream directly written to by the HTTP session. As this stream is not pre-buffered,
  it is strongly advised to use the `NSStreamDelegate` methods, in combination with a run loop, to consume the data in
  the stream, to do proper async file downloading.
@@ -309,7 +309,7 @@ NS_ASSUME_NONNULL_BEGIN
  This method is like <getDataInBackground> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
- @discussion This can help applications with many large files avoid memory warnings.
+ This can help applications with many large files avoid memory warnings.
  @param progressBlock The block should have the following argument signature: ^(int percentDone)
 
  @returns The task, that encapsulates the work being done.
@@ -319,7 +319,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This method is like <getDataStreamInBackgroundWithProgrssBlock>, but yields a live-updating stream.
 
- @discussion Instead of <getDataStream>, which yields a stream that can be read from only after the request has
+ Instead of <getDataStream>, which yields a stream that can be read from only after the request has
  completed, this method gives you a stream directly written to by the HTTP session. As this stream is not pre-buffered,
  it is strongly advised to use the `NSStreamDelegate` methods, in combination with a run loop, to consume the data in
  the stream, to do proper async file downloading.
@@ -344,7 +344,7 @@ NS_ASSUME_NONNULL_BEGIN
  This method is like <getDataInBackgroundWithBlock:> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
- @discussion This can help applications with many large files avoid memory warnings.
+ This can help applications with many large files avoid memory warnings.
 
  @param block The block should have the following argument signature: `(NSInputStream *result, NSError *error)`
  */
@@ -353,7 +353,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *Asynchronously* gets the data from cache if available or fetches its contents from the network.
 
- @discussion This method will execute the progressBlock periodically with the percent progress.
+ This method will execute the progressBlock periodically with the percent progress.
  `progressBlock` will get called with `100` before `resultBlock` is called.
 
  @param resultBlock The block should have the following argument signature: ^(NSData *result, NSError *error)
@@ -366,7 +366,7 @@ NS_ASSUME_NONNULL_BEGIN
  This method is like <getDataInBackgroundWithBlock:progressBlock:> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
- @discussion This can help applications with many large files avoid memory warnings.
+ This can help applications with many large files avoid memory warnings.
 
  @param resultBlock The block should have the following argument signature: `^(NSInputStream *result, NSError *error)`.
  @param progressBlock The block should have the following argument signature: `^(int percentDone)`.

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -230,7 +230,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSData *)getData PF_SWIFT_UNAVAILABLE;
 
 /**
- This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
+ This method is like `-getData` but avoids ever holding the entire `PFFile` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.
 
@@ -249,7 +249,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSData *)getData:(NSError **)error;
 
 /**
- This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
+ This method is like `-getData` but avoids ever holding the entire `PFFile` contents in memory at once.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -259,7 +259,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSInputStream *)getDataStream:(NSError **)error;
 
 /**
- This method is like <getData> but it fetches asynchronously to avoid blocking the current thread.
+ This method is like `-getData` but it fetches asynchronously to avoid blocking the current thread.
 
  @see getData
 
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSData *)*)getDataInBackground;
 
 /**
- This method is like <getData> but it fetches asynchronously to avoid blocking the current thread.
+ This method is like `-getData` but it fetches asynchronously to avoid blocking the current thread.
 
  This can help applications with many large files avoid memory warnings.
 
@@ -281,8 +281,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSData *)*)getDataInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- This method is like <getDataInBackground> but avoids
- ever holding the entire `PFFile` contents in memory at once.
+ This method is like `-getDataInBackground` but avoids ever holding the entire `PFFile` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.
 
@@ -291,22 +290,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataStreamInBackground;
 
 /**
- This method is like <getDataStreamInBackground>, but yields a live-updating stream.
+ This method is like `-getDataStreamInBackground`, but yields a live-updating stream.
 
- Instead of <getDataStream>, which yields a stream that can be read from only after the request has
+ Instead of `-getDataStream`, which yields a stream that can be read from only after the request has
  completed, this method gives you a stream directly written to by the HTTP session. As this stream is not pre-buffered,
  it is strongly advised to use the `NSStreamDelegate` methods, in combination with a run loop, to consume the data in
  the stream, to do proper async file downloading.
 
  @note You MUST open this stream before reading from it.
- @note Do NOT call <waitUntilFinished> on this task from the main thread. It may result in a deadlock.
+ @note Do NOT call `waitUntilFinished` on this task from the main thread. It may result in a deadlock.
 
  @return A task that produces a *live* stream that is being written to with the data from the server.
  */
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataDownloadStreamInBackground;
 
 /**
- This method is like <getDataInBackground> but avoids
+ This method is like `-getDataInBackground` but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.
@@ -317,15 +316,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataStreamInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- This method is like <getDataStreamInBackgroundWithProgrssBlock>, but yields a live-updating stream.
+ This method is like `-getDataStreamInBackgroundWithProgressBlock:`, but yields a live-updating stream.
 
- Instead of <getDataStream>, which yields a stream that can be read from only after the request has
+ Instead of `-getDataStream`, which yields a stream that can be read from only after the request has
  completed, this method gives you a stream directly written to by the HTTP session. As this stream is not pre-buffered,
  it is strongly advised to use the `NSStreamDelegate` methods, in combination with a run loop, to consume the data in
  the stream, to do proper async file downloading.
 
  @note You MUST open this stream before reading from it.
- @note Do NOT call <waitUntilFinished> on this task from the main thread. It may result in a deadlock.
+ @note Do NOT call `waitUntilFinished` on this task from the main thread. It may result in a deadlock.
 
  @param progressBlock The block should have the following argument signature: `^(int percentDone)`
 
@@ -341,8 +340,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getDataInBackgroundWithBlock:(nullable PFDataResultBlock)block;
 
 /**
- This method is like <getDataInBackgroundWithBlock:> but avoids
- ever holding the entire `PFFile` contents in memory at once.
+ This method is like `-getDataInBackgroundWithBlock:` but avoids ever holding the entire `PFFile` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.
 
@@ -363,7 +361,7 @@ NS_ASSUME_NONNULL_BEGIN
                        progressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- This method is like <getDataInBackgroundWithBlock:progressBlock:> but avoids
+ This method is like `-getDataInBackgroundWithBlock:progressBlock:` but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
  This can help applications with many large files avoid memory warnings.

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  `PFFile` representes a file of binary data stored on the Parse servers.
  This can be a image, video, or anything else that an application needs to reference in a non-relational way.
  */
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-/*!
+/**
  @abstract Creates a file with given data. A name will be assigned to it by the server.
 
  @param data The contents of the new `PFFile`.
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable instancetype)fileWithData:(NSData *)data;
 
-/*!
+/**
  @abstract Creates a file with given data and name.
 
  @param name The name of the new PFFile. The file name must begin with and
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable instancetype)fileWithName:(nullable NSString *)name data:(NSData *)data;
 
-/*!
+/**
  @abstract Creates a file with the contents of another file.
 
  @warning This method raises an exception if the file at path is not accessible
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)fileWithName:(nullable NSString *)name
                        contentsAtPath:(NSString *)path PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Creates a file with the contents of another file.
 
  @param name  The name of the new `PFFile`. The file name must begin with and alphanumeric character,
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
                        contentsAtPath:(NSString *)path
                                 error:(NSError **)error;
 
-/*!
+/**
  @abstract Creates a file with given data, name and content type.
 
  @warning This method raises an exception if the data supplied is not accessible or could not be saved.
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
                                  data:(NSData *)data
                           contentType:(nullable NSString *)contentType PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Creates a file with given data, name and content type.
 
  @param name        The name of the new `PFFile`. The file name must begin with and alphanumeric character,
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
                           contentType:(nullable NSString *)contentType
                                 error:(NSError **)error;
 
-/*!
+/**
  @abstract Creates a file with given data and content type.
 
  @param data The contents of the new `PFFile`.
@@ -128,7 +128,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name File Properties
 ///--------------------------------------
 
-/*!
+/**
  @abstract The name of the file.
 
  @discussion Before the file is saved, this is the filename given by
@@ -137,12 +137,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, readonly) NSString *name;
 
-/*!
+/**
  @abstract The url of the file.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *url;
 
-/*!
+/**
  @abstract Whether the file has been uploaded for the first time.
  */
 @property (nonatomic, assign, readonly, getter=isDirty) BOOL dirty;
@@ -151,14 +151,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Storing Data with Parse
 ///--------------------------------------
 
-/*!
+/**
  @abstract Saves the file *synchronously*.
 
  @returns Returns whether the save succeeded.
  */
 - (BOOL)save PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Saves the file *synchronously* and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -167,14 +167,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)save:(NSError **)error;
 
-/*!
+/**
  @abstract Saves the file *asynchronously*.
 
  @returns The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveInBackground;
 
-/*!
+/**
  @abstract Saves the file *asynchronously*
 
  @param progressBlock The block should have the following argument signature: `^(int percentDone)`
@@ -183,14 +183,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
-/*!
+/**
  @abstract Saves the file *asynchronously* and executes the given block.
 
  @param block The block should have the following argument signature: `^(BOOL succeeded, NSError *error)`.
  */
 - (void)saveInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract Saves the file *asynchronously* and executes the given block.
 
  @discussion This method will execute the progressBlock periodically with the percent progress.
@@ -217,19 +217,19 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Getting Data from Parse
 ///--------------------------------------
 
-/*!
+/**
  @abstract Whether the data is available in memory or needs to be downloaded.
  */
 @property (nonatomic, assign, readonly, getter=isDataAvailable) BOOL dataAvailable;
 
-/*!
+/**
  @abstract *Synchronously* gets the data from cache if available or fetches its contents from the network.
 
  @returns The `NSData` object containing file data. Returns `nil` if there was an error in fetching.
  */
 - (nullable NSData *)getData PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
 
  @discussion This can help applications with many large files avoid memory warnings.
@@ -238,7 +238,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSInputStream *)getDataStream PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* gets the data from cache if available or fetches its contents from the network.
  Sets an error if it occurs.
 
@@ -248,7 +248,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSData *)getData:(NSError **)error;
 
-/*!
+/**
  @abstract This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -258,7 +258,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSInputStream *)getDataStream:(NSError **)error;
 
-/*!
+/**
  @abstract This method is like <getData> but it fetches asynchronously to avoid blocking the current thread.
 
  @see getData
@@ -267,7 +267,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask PF_GENERIC(NSData *)*)getDataInBackground;
 
-/*!
+/**
  @abstract This method is like <getData> but it fetches asynchronously to avoid blocking the current thread.
 
  @discussion This can help applications with many large files avoid memory warnings.
@@ -280,7 +280,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask PF_GENERIC(NSData *)*)getDataInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
-/*!
+/**
  @abstract This method is like <getDataInBackground> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
@@ -290,7 +290,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataStreamInBackground;
 
-/*!
+/**
  @abstract This method is like <getDataStreamInBackground>, but yields a live-updating stream.
 
  @discussion Instead of <getDataStream>, which yields a stream that can be read from only after the request has
@@ -305,7 +305,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataDownloadStreamInBackground;
 
-/*!
+/**
  @abstract This method is like <getDataInBackground> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
@@ -316,7 +316,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataStreamInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
-/*!
+/**
  @abstract This method is like <getDataStreamInBackgroundWithProgrssBlock>, but yields a live-updating stream.
 
  @discussion Instead of <getDataStream>, which yields a stream that can be read from only after the request has
@@ -333,14 +333,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataDownloadStreamInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
-/*!
+/**
  @abstract *Asynchronously* gets the data from cache if available or fetches its contents from the network.
 
  @param block The block should have the following argument signature: `^(NSData *result, NSError *error)`
  */
 - (void)getDataInBackgroundWithBlock:(nullable PFDataResultBlock)block;
 
-/*!
+/**
  @abstract This method is like <getDataInBackgroundWithBlock:> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
@@ -350,7 +350,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)getDataStreamInBackgroundWithBlock:(nullable PFDataStreamResultBlock)block;
 
-/*!
+/**
  @abstract *Asynchronously* gets the data from cache if available or fetches its contents from the network.
 
  @discussion This method will execute the progressBlock periodically with the percent progress.
@@ -362,7 +362,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getDataInBackgroundWithBlock:(nullable PFDataResultBlock)resultBlock
                        progressBlock:(nullable PFProgressBlock)progressBlock;
 
-/*!
+/**
  @abstract This method is like <getDataInBackgroundWithBlock:progressBlock:> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
@@ -384,7 +384,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)getDataInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
-/*!
+/**
  @abstract *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
 
  @note The file path may change between versions of SDK.
@@ -395,7 +395,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask PF_GENERIC(NSString *)*)getFilePathInBackground;
 
-/*!
+/**
  @abstract *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
 
  @note The file path may change between versions of SDK.
@@ -408,7 +408,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BFTask PF_GENERIC(NSString *)*)getFilePathInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
-/*!
+/**
  @abstract *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
 
  @note The file path may change between versions of SDK.
@@ -419,7 +419,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)getFilePathInBackgroundWithBlock:(nullable PFFilePathResultBlock)block;
 
-/*!
+/**
  @abstract *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
 
  @note The file path may change between versions of SDK.
@@ -436,7 +436,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Interrupting a Transfer
 ///--------------------------------------
 
-/*!
+/**
  @abstract Cancels the current request (upload or download of file).
  */
 - (void)cancel;

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- @abstract Creates a file with given data. A name will be assigned to it by the server.
+ Creates a file with given data. A name will be assigned to it by the server.
 
  @param data The contents of the new `PFFile`.
 
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)fileWithData:(NSData *)data;
 
 /**
- @abstract Creates a file with given data and name.
+ Creates a file with given data and name.
 
  @param name The name of the new PFFile. The file name must begin with and
  alphanumeric character, and consist of alphanumeric characters, periods,
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)fileWithName:(nullable NSString *)name data:(NSData *)data;
 
 /**
- @abstract Creates a file with the contents of another file.
+ Creates a file with the contents of another file.
 
  @warning This method raises an exception if the file at path is not accessible
  or if there is not enough disk space left.
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
                        contentsAtPath:(NSString *)path PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Creates a file with the contents of another file.
+ Creates a file with the contents of another file.
 
  @param name  The name of the new `PFFile`. The file name must begin with and alphanumeric character,
  and consist of alphanumeric characters, periods, spaces, underscores, or dashes.
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 error:(NSError **)error;
 
 /**
- @abstract Creates a file with given data, name and content type.
+ Creates a file with given data, name and content type.
 
  @warning This method raises an exception if the data supplied is not accessible or could not be saved.
 
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
                           contentType:(nullable NSString *)contentType PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Creates a file with given data, name and content type.
+ Creates a file with given data, name and content type.
 
  @param name        The name of the new `PFFile`. The file name must begin with and alphanumeric character,
  and consist of alphanumeric characters, periods, spaces, underscores, or dashes.
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 error:(NSError **)error;
 
 /**
- @abstract Creates a file with given data and content type.
+ Creates a file with given data and content type.
 
  @param data The contents of the new `PFFile`.
  @param contentType Represents MIME type of the data.
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract The name of the file.
+ The name of the file.
 
  @discussion Before the file is saved, this is the filename given by
  the user. After the file is saved, that name gets prefixed with a unique
@@ -138,12 +138,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *name;
 
 /**
- @abstract The url of the file.
+ The url of the file.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *url;
 
 /**
- @abstract Whether the file has been uploaded for the first time.
+ Whether the file has been uploaded for the first time.
  */
 @property (nonatomic, assign, readonly, getter=isDirty) BOOL dirty;
 
@@ -152,14 +152,14 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Saves the file *synchronously*.
+ Saves the file *synchronously*.
 
  @returns Returns whether the save succeeded.
  */
 - (BOOL)save PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Saves the file *synchronously* and sets an error if it occurs.
+ Saves the file *synchronously* and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -168,14 +168,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)save:(NSError **)error;
 
 /**
- @abstract Saves the file *asynchronously*.
+ Saves the file *asynchronously*.
 
  @returns The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveInBackground;
 
 /**
- @abstract Saves the file *asynchronously*
+ Saves the file *asynchronously*
 
  @param progressBlock The block should have the following argument signature: `^(int percentDone)`
 
@@ -184,14 +184,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSNumber *)*)saveInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- @abstract Saves the file *asynchronously* and executes the given block.
+ Saves the file *asynchronously* and executes the given block.
 
  @param block The block should have the following argument signature: `^(BOOL succeeded, NSError *error)`.
  */
 - (void)saveInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract Saves the file *asynchronously* and executes the given block.
+ Saves the file *asynchronously* and executes the given block.
 
  @discussion This method will execute the progressBlock periodically with the percent progress.
  `progressBlock` will get called with `100` before `resultBlock` is called.
@@ -203,7 +203,7 @@ NS_ASSUME_NONNULL_BEGIN
                     progressBlock:(nullable PFProgressBlock)progressBlock;
 
 /*
- @abstract Saves the file *asynchronously* and calls the given callback.
+ Saves the file *asynchronously* and calls the given callback.
 
  @param target The object to call selector on.
  @param selector The selector to call.
@@ -218,19 +218,19 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Whether the data is available in memory or needs to be downloaded.
+ Whether the data is available in memory or needs to be downloaded.
  */
 @property (nonatomic, assign, readonly, getter=isDataAvailable) BOOL dataAvailable;
 
 /**
- @abstract *Synchronously* gets the data from cache if available or fetches its contents from the network.
+ *Synchronously* gets the data from cache if available or fetches its contents from the network.
 
  @returns The `NSData` object containing file data. Returns `nil` if there was an error in fetching.
  */
 - (nullable NSData *)getData PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
+ This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
 
  @discussion This can help applications with many large files avoid memory warnings.
 
@@ -239,7 +239,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSInputStream *)getDataStream PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* gets the data from cache if available or fetches its contents from the network.
+ *Synchronously* gets the data from cache if available or fetches its contents from the network.
  Sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -249,7 +249,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSData *)getData:(NSError **)error;
 
 /**
- @abstract This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
+ This method is like <getData> but avoids ever holding the entire `PFFile` contents in memory at once.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -259,7 +259,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSInputStream *)getDataStream:(NSError **)error;
 
 /**
- @abstract This method is like <getData> but it fetches asynchronously to avoid blocking the current thread.
+ This method is like <getData> but it fetches asynchronously to avoid blocking the current thread.
 
  @see getData
 
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSData *)*)getDataInBackground;
 
 /**
- @abstract This method is like <getData> but it fetches asynchronously to avoid blocking the current thread.
+ This method is like <getData> but it fetches asynchronously to avoid blocking the current thread.
 
  @discussion This can help applications with many large files avoid memory warnings.
 
@@ -281,7 +281,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSData *)*)getDataInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- @abstract This method is like <getDataInBackground> but avoids
+ This method is like <getDataInBackground> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
  @discussion This can help applications with many large files avoid memory warnings.
@@ -291,7 +291,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataStreamInBackground;
 
 /**
- @abstract This method is like <getDataStreamInBackground>, but yields a live-updating stream.
+ This method is like <getDataStreamInBackground>, but yields a live-updating stream.
 
  @discussion Instead of <getDataStream>, which yields a stream that can be read from only after the request has
  completed, this method gives you a stream directly written to by the HTTP session. As this stream is not pre-buffered,
@@ -306,7 +306,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataDownloadStreamInBackground;
 
 /**
- @abstract This method is like <getDataInBackground> but avoids
+ This method is like <getDataInBackground> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
  @discussion This can help applications with many large files avoid memory warnings.
@@ -317,7 +317,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataStreamInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- @abstract This method is like <getDataStreamInBackgroundWithProgrssBlock>, but yields a live-updating stream.
+ This method is like <getDataStreamInBackgroundWithProgrssBlock>, but yields a live-updating stream.
 
  @discussion Instead of <getDataStream>, which yields a stream that can be read from only after the request has
  completed, this method gives you a stream directly written to by the HTTP session. As this stream is not pre-buffered,
@@ -334,14 +334,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSInputStream *)*)getDataDownloadStreamInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- @abstract *Asynchronously* gets the data from cache if available or fetches its contents from the network.
+ *Asynchronously* gets the data from cache if available or fetches its contents from the network.
 
  @param block The block should have the following argument signature: `^(NSData *result, NSError *error)`
  */
 - (void)getDataInBackgroundWithBlock:(nullable PFDataResultBlock)block;
 
 /**
- @abstract This method is like <getDataInBackgroundWithBlock:> but avoids
+ This method is like <getDataInBackgroundWithBlock:> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
  @discussion This can help applications with many large files avoid memory warnings.
@@ -351,7 +351,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getDataStreamInBackgroundWithBlock:(nullable PFDataStreamResultBlock)block;
 
 /**
- @abstract *Asynchronously* gets the data from cache if available or fetches its contents from the network.
+ *Asynchronously* gets the data from cache if available or fetches its contents from the network.
 
  @discussion This method will execute the progressBlock periodically with the percent progress.
  `progressBlock` will get called with `100` before `resultBlock` is called.
@@ -363,7 +363,7 @@ NS_ASSUME_NONNULL_BEGIN
                        progressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- @abstract This method is like <getDataInBackgroundWithBlock:progressBlock:> but avoids
+ This method is like <getDataInBackgroundWithBlock:progressBlock:> but avoids
  ever holding the entire `PFFile` contents in memory at once.
 
  @discussion This can help applications with many large files avoid memory warnings.
@@ -375,7 +375,7 @@ NS_ASSUME_NONNULL_BEGIN
                              progressBlock:(nullable PFProgressBlock)progressBlock;
 
 /*
- @abstract *Asynchronously* gets the data from cache if available or fetches its contents from the network.
+ *Asynchronously* gets the data from cache if available or fetches its contents from the network.
 
  @param target The object to call selector on.
  @param selector The selector to call.
@@ -385,7 +385,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getDataInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
 /**
- @abstract *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
+ *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
 
  @note The file path may change between versions of SDK.
  @note If you overwrite the contents of the file at returned path it will persist those change
@@ -396,7 +396,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSString *)*)getFilePathInBackground;
 
 /**
- @abstract *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
+ *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
 
  @note The file path may change between versions of SDK.
  @note If you overwrite the contents of the file at returned path it will persist those change
@@ -409,7 +409,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask PF_GENERIC(NSString *)*)getFilePathInBackgroundWithProgressBlock:(nullable PFProgressBlock)progressBlock;
 
 /**
- @abstract *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
+ *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
 
  @note The file path may change between versions of SDK.
  @note If you overwrite the contents of the file at returned path it will persist those change
@@ -420,7 +420,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getFilePathInBackgroundWithBlock:(nullable PFFilePathResultBlock)block;
 
 /**
- @abstract *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
+ *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.
 
  @note The file path may change between versions of SDK.
  @note If you overwrite the contents of the file at returned path it will persist those change
@@ -437,7 +437,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Cancels the current request (upload or download of file).
+ Cancels the current request (upload or download of file).
  */
 - (void)cancel;
 

--- a/Parse/PFGeoPoint.h
+++ b/Parse/PFGeoPoint.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *__nullable error);
 
-/*!
+/**
  `PFGeoPoint` may be used to embed a latitude / longitude point as the value for a key in a <PFObject>.
  It could be used to perform queries in a geospatial manner using <[PFQuery whereKey:nearGeoPoint:]>.
 
@@ -28,14 +28,14 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 /// @name Creating a Geo Point
 ///--------------------------------------
 
-/*!
+/**
  @abstract Create a PFGeoPoint object. Latitude and longitude are set to `0.0`.
 
  @returns Returns a new `PFGeoPoint`.
  */
 + (instancetype)geoPoint;
 
-/*!
+/**
  @abstract Creates a new `PFGeoPoint` object for the given `CLLocation`, set to the location's coordinates.
 
  @param location Instace of `CLLocation`, with set latitude and longitude.
@@ -44,7 +44,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
  */
 + (instancetype)geoPointWithLocation:(nullable CLLocation *)location;
 
-/*!
+/**
  @abstract Create a new `PFGeoPoint` object with the specified latitude and longitude.
 
  @param latitude Latitude of point in degrees.
@@ -54,7 +54,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
  */
 + (instancetype)geoPointWithLatitude:(double)latitude longitude:(double)longitude;
 
-/*!
+/**
  @abstract Fetches the current device location and executes a block with a new `PFGeoPoint` object.
 
  @param resultBlock A block which takes the newly created `PFGeoPoint` as an argument.
@@ -66,12 +66,12 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 /// @name Controlling Position
 ///--------------------------------------
 
-/*!
+/**
  @abstract Latitude of point in degrees. Valid range is from `-90.0` to `90.0`.
  */
 @property (nonatomic, assign) double latitude;
 
-/*!
+/**
  @abstract Longitude of point in degrees. Valid range is from `-180.0` to `180.0`.
  */
 @property (nonatomic, assign) double longitude;
@@ -80,7 +80,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 /// @name Calculating Distance
 ///--------------------------------------
 
-/*!
+/**
  @abstract Get distance in radians from this point to specified point.
 
  @param point `PFGeoPoint` that represents the location of other point.
@@ -89,7 +89,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
  */
 - (double)distanceInRadiansTo:(nullable PFGeoPoint *)point;
 
-/*!
+/**
  @abstract Get distance in miles from this point to specified point.
 
  @param point `PFGeoPoint` that represents the location of other point.
@@ -98,7 +98,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
  */
 - (double)distanceInMilesTo:(nullable PFGeoPoint *)point;
 
-/*!
+/**
  @abstract Get distance in kilometers from this point to specified point.
 
  @param point `PFGeoPoint` that represents the location of other point.

--- a/Parse/PFGeoPoint.h
+++ b/Parse/PFGeoPoint.h
@@ -31,7 +31,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 /**
  Create a PFGeoPoint object. Latitude and longitude are set to `0.0`.
 
- @returns Returns a new `PFGeoPoint`.
+ @return Returns a new `PFGeoPoint`.
  */
 + (instancetype)geoPoint;
 
@@ -40,7 +40,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 
  @param location Instace of `CLLocation`, with set latitude and longitude.
 
- @returns Returns a new PFGeoPoint at specified location.
+ @return Returns a new PFGeoPoint at specified location.
  */
 + (instancetype)geoPointWithLocation:(nullable CLLocation *)location;
 
@@ -50,7 +50,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
  @param latitude Latitude of point in degrees.
  @param longitude Longitude of point in degrees.
 
- @returns New point object with specified latitude and longitude.
+ @return New point object with specified latitude and longitude.
  */
 + (instancetype)geoPointWithLatitude:(double)latitude longitude:(double)longitude;
 
@@ -85,7 +85,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 
  @param point `PFGeoPoint` that represents the location of other point.
 
- @returns Distance in radians between the receiver and `point`.
+ @return Distance in radians between the receiver and `point`.
  */
 - (double)distanceInRadiansTo:(nullable PFGeoPoint *)point;
 
@@ -94,7 +94,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 
  @param point `PFGeoPoint` that represents the location of other point.
 
- @returns Distance in miles between the receiver and `point`.
+ @return Distance in miles between the receiver and `point`.
  */
 - (double)distanceInMilesTo:(nullable PFGeoPoint *)point;
 
@@ -103,7 +103,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 
  @param point `PFGeoPoint` that represents the location of other point.
 
- @returns Distance in kilometers between the receiver and `point`.
+ @return Distance in kilometers between the receiver and `point`.
  */
 - (double)distanceInKilometersTo:(nullable PFGeoPoint *)point;
 

--- a/Parse/PFGeoPoint.h
+++ b/Parse/PFGeoPoint.h
@@ -29,14 +29,14 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 ///--------------------------------------
 
 /**
- @abstract Create a PFGeoPoint object. Latitude and longitude are set to `0.0`.
+ Create a PFGeoPoint object. Latitude and longitude are set to `0.0`.
 
  @returns Returns a new `PFGeoPoint`.
  */
 + (instancetype)geoPoint;
 
 /**
- @abstract Creates a new `PFGeoPoint` object for the given `CLLocation`, set to the location's coordinates.
+ Creates a new `PFGeoPoint` object for the given `CLLocation`, set to the location's coordinates.
 
  @param location Instace of `CLLocation`, with set latitude and longitude.
 
@@ -45,7 +45,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 + (instancetype)geoPointWithLocation:(nullable CLLocation *)location;
 
 /**
- @abstract Create a new `PFGeoPoint` object with the specified latitude and longitude.
+ Create a new `PFGeoPoint` object with the specified latitude and longitude.
 
  @param latitude Latitude of point in degrees.
  @param longitude Longitude of point in degrees.
@@ -55,7 +55,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 + (instancetype)geoPointWithLatitude:(double)latitude longitude:(double)longitude;
 
 /**
- @abstract Fetches the current device location and executes a block with a new `PFGeoPoint` object.
+ Fetches the current device location and executes a block with a new `PFGeoPoint` object.
 
  @param resultBlock A block which takes the newly created `PFGeoPoint` as an argument.
  It should have the following argument signature: `^(PFGeoPoint *geoPoint, NSError *error)`
@@ -67,12 +67,12 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 ///--------------------------------------
 
 /**
- @abstract Latitude of point in degrees. Valid range is from `-90.0` to `90.0`.
+ Latitude of point in degrees. Valid range is from `-90.0` to `90.0`.
  */
 @property (nonatomic, assign) double latitude;
 
 /**
- @abstract Longitude of point in degrees. Valid range is from `-180.0` to `180.0`.
+ Longitude of point in degrees. Valid range is from `-180.0` to `180.0`.
  */
 @property (nonatomic, assign) double longitude;
 
@@ -81,7 +81,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 ///--------------------------------------
 
 /**
- @abstract Get distance in radians from this point to specified point.
+ Get distance in radians from this point to specified point.
 
  @param point `PFGeoPoint` that represents the location of other point.
 
@@ -90,7 +90,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 - (double)distanceInRadiansTo:(nullable PFGeoPoint *)point;
 
 /**
- @abstract Get distance in miles from this point to specified point.
+ Get distance in miles from this point to specified point.
 
  @param point `PFGeoPoint` that represents the location of other point.
 
@@ -99,7 +99,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 - (double)distanceInMilesTo:(nullable PFGeoPoint *)point;
 
 /**
- @abstract Get distance in kilometers from this point to specified point.
+ Get distance in kilometers from this point to specified point.
 
  @param point `PFGeoPoint` that represents the location of other point.
 

--- a/Parse/PFGeoPoint.h
+++ b/Parse/PFGeoPoint.h
@@ -17,10 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *__nullable error);
 
 /**
- `PFGeoPoint` may be used to embed a latitude / longitude point as the value for a key in a <PFObject>.
- It could be used to perform queries in a geospatial manner using <[PFQuery whereKey:nearGeoPoint:]>.
+ `PFGeoPoint` may be used to embed a latitude / longitude point as the value for a key in a `PFObject`.
+ It could be used to perform queries in a geospatial manner using `PFQuery.-whereKey:nearGeoPoint:`.
 
- Currently, instances of <PFObject> may only have one key associated with a `PFGeoPoint` type.
+ Currently, instances of `PFObject` may only have one key associated with a `PFGeoPoint` type.
  */
 @interface PFGeoPoint : NSObject <NSCopying, NSCoding>
 

--- a/Parse/PFInstallation.h
+++ b/Parse/PFInstallation.h
@@ -42,7 +42,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 ///--------------------------------------
 
 /**
- @abstract Gets the currently-running installation from disk and returns an instance of it.
+ Gets the currently-running installation from disk and returns an instance of it.
 
  @discussion If this installation is not stored on disk, returns a `PFInstallation`
  with <deviceType> and <installationId> fields set to those of the
@@ -57,37 +57,37 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 ///--------------------------------------
 
 /**
- @abstract The device type for the `PFInstallation`.
+ The device type for the `PFInstallation`.
  */
 @property (nonatomic, copy, readonly) NSString *deviceType;
 
 /**
- @abstract The installationId for the `PFInstallation`.
+ The installationId for the `PFInstallation`.
  */
 @property (nonatomic, copy, readonly) NSString *installationId;
 
 /**
- @abstract The device token for the `PFInstallation`.
+ The device token for the `PFInstallation`.
  */
 @property (nullable, nonatomic, copy) NSString *deviceToken;
 
 /**
- @abstract The badge for the `PFInstallation`.
+ The badge for the `PFInstallation`.
  */
 @property (nonatomic, assign) NSInteger badge;
 
 /**
- @abstract The name of the time zone for the `PFInstallation`.
+ The name of the time zone for the `PFInstallation`.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *timeZone;
 
 /**
- @abstract The channels for the `PFInstallation`.
+ The channels for the `PFInstallation`.
  */
 @property (nullable, nonatomic, copy) NSArray PF_GENERIC(NSString *)*channels;
 
 /**
- @abstract Sets the device token string property from an `NSData`-encoded token.
+ Sets the device token string property from an `NSData`-encoded token.
 
  @param deviceTokenData A token that identifies the device.
  */
@@ -98,7 +98,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 ///--------------------------------------
 
 /**
- @abstract Creates a <PFQuery> for `PFInstallation` objects.
+ Creates a <PFQuery> for `PFInstallation` objects.
 
  @discussion Only the following types of queries are allowed for installations:
 

--- a/Parse/PFInstallation.h
+++ b/Parse/PFInstallation.h
@@ -20,18 +20,18 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A Parse Framework Installation Object that is a local representation of an
  installation persisted to the Parse cloud. This class is a subclass of a
- <PFObject>, and retains the same functionality of a PFObject, but also extends
+ `PFObject`, and retains the same functionality of a PFObject, but also extends
  it with installation-specific fields and related immutability and validity
  checks.
 
  A valid `PFInstallation` can only be instantiated via
- <[PFInstallation currentInstallation]> because the required identifier fields
- are readonly. The <timeZone> and <badge> fields are also readonly properties which
+ `+currentInstallation` because the required identifier fields
+ are readonly. The `timeZone` and `badge` fields are also readonly properties which
  are automatically updated to match the device's time zone and application badge
  when the `PFInstallation` is saved, thus these fields might not reflect the
  latest device state if the installation has not recently been saved.
 
- `PFInstallation` objects which have a valid <deviceToken> and are saved to
+ `PFInstallation` objects which have a valid `deviceToken` and are saved to
  the Parse cloud can be used to target push notifications.
  */
 
@@ -45,7 +45,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
  Gets the currently-running installation from disk and returns an instance of it.
 
  If this installation is not stored on disk, returns a `PFInstallation`
- with <deviceType> and <installationId> fields set to those of the
+ with `deviceType` and `installationId` fields set to those of the
  current installation.
 
  @result Returns a `PFInstallation` that represents the currently-running installation.
@@ -98,7 +98,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 ///--------------------------------------
 
 /**
- Creates a <PFQuery> for `PFInstallation` objects.
+ Creates a `PFQuery` for `PFInstallation` objects.
 
  Only the following types of queries are allowed for installations:
 

--- a/Parse/PFInstallation.h
+++ b/Parse/PFInstallation.h
@@ -44,7 +44,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 /**
  Gets the currently-running installation from disk and returns an instance of it.
 
- @discussion If this installation is not stored on disk, returns a `PFInstallation`
+ If this installation is not stored on disk, returns a `PFInstallation`
  with <deviceType> and <installationId> fields set to those of the
  current installation.
 
@@ -100,7 +100,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 /**
  Creates a <PFQuery> for `PFInstallation` objects.
 
- @discussion Only the following types of queries are allowed for installations:
+ Only the following types of queries are allowed for installations:
 
  - `[query getObjectWithId:<value>]`
  - `[query whereKey:@"installationId" equalTo:<value>]`

--- a/Parse/PFInstallation.h
+++ b/Parse/PFInstallation.h
@@ -17,7 +17,7 @@ PF_WATCH_UNAVAILABLE_WARNING
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  A Parse Framework Installation Object that is a local representation of an
  installation persisted to the Parse cloud. This class is a subclass of a
  <PFObject>, and retains the same functionality of a PFObject, but also extends
@@ -41,7 +41,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 /// @name Accessing the Current Installation
 ///--------------------------------------
 
-/*!
+/**
  @abstract Gets the currently-running installation from disk and returns an instance of it.
 
  @discussion If this installation is not stored on disk, returns a `PFInstallation`
@@ -56,37 +56,37 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 /// @name Installation Properties
 ///--------------------------------------
 
-/*!
+/**
  @abstract The device type for the `PFInstallation`.
  */
 @property (nonatomic, copy, readonly) NSString *deviceType;
 
-/*!
+/**
  @abstract The installationId for the `PFInstallation`.
  */
 @property (nonatomic, copy, readonly) NSString *installationId;
 
-/*!
+/**
  @abstract The device token for the `PFInstallation`.
  */
 @property (nullable, nonatomic, copy) NSString *deviceToken;
 
-/*!
+/**
  @abstract The badge for the `PFInstallation`.
  */
 @property (nonatomic, assign) NSInteger badge;
 
-/*!
+/**
  @abstract The name of the time zone for the `PFInstallation`.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *timeZone;
 
-/*!
+/**
  @abstract The channels for the `PFInstallation`.
  */
 @property (nullable, nonatomic, copy) NSArray PF_GENERIC(NSString *)*channels;
 
-/*!
+/**
  @abstract Sets the device token string property from an `NSData`-encoded token.
 
  @param deviceTokenData A token that identifies the device.
@@ -97,7 +97,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 /// @name Querying for Installations
 ///--------------------------------------
 
-/*!
+/**
  @abstract Creates a <PFQuery> for `PFInstallation` objects.
 
  @discussion Only the following types of queries are allowed for installations:

--- a/Parse/PFInstallation.m
+++ b/Parse/PFInstallation.m
@@ -301,7 +301,7 @@ static NSSet *protectedKeys;
 /**
  Save localeIdentifier in the following format: [language code]-[COUNTRY CODE].
 
- @discussion The language codes are two-letter lowercase ISO language codes (such as "en") as defined by
+ The language codes are two-letter lowercase ISO language codes (such as "en") as defined by
  <a href="http://en.wikipedia.org/wiki/ISO_639-1">ISO 639-1</a>.
  The country codes are two-letter uppercase ISO country codes (such as "US") as defined by
  <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-3">ISO 3166-1</a>.

--- a/Parse/PFInstallation.m
+++ b/Parse/PFInstallation.m
@@ -298,7 +298,7 @@ static NSSet *protectedKeys;
     }
 }
 
-/*!
+/**
  @abstract Save localeIdentifier in the following format: [language code]-[COUNTRY CODE].
 
  @discussion The language codes are two-letter lowercase ISO language codes (such as "en") as defined by

--- a/Parse/PFInstallation.m
+++ b/Parse/PFInstallation.m
@@ -299,7 +299,7 @@ static NSSet *protectedKeys;
 }
 
 /**
- @abstract Save localeIdentifier in the following format: [language code]-[COUNTRY CODE].
+ Save localeIdentifier in the following format: [language code]-[COUNTRY CODE].
 
  @discussion The language codes are two-letter lowercase ISO language codes (such as "en") as defined by
  <a href="http://en.wikipedia.org/wiki/ISO_639-1">ISO 639-1</a>.

--- a/Parse/PFNetworkActivityIndicatorManager.h
+++ b/Parse/PFNetworkActivityIndicatorManager.h
@@ -48,7 +48,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFNetworkActivityIndicatorMana
 /**
  Returns the shared network activity indicator manager object for the system.
 
- @returns The systemwide network activity indicator manager.
+ @return The systemwide network activity indicator manager.
  */
 + (PFNetworkActivityIndicatorManager *)sharedManager;
 

--- a/Parse/PFNetworkActivityIndicatorManager.h
+++ b/Parse/PFNetworkActivityIndicatorManager.h
@@ -17,7 +17,7 @@ PF_WATCH_UNAVAILABLE_WARNING
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  `PFNetworkActivityIndicatorManager` manages the state of the network activity indicator in the status bar.
  When enabled, it will start managing the network activity indicator in the status bar,
  according to the network operations that are performed by Parse SDK.
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFNetworkActivityIndicatorManager : NSObject
 
-/*!
+/**
  A Boolean value indicating whether the manager is enabled.
  If `YES` - the manager will start managing the status bar network activity indicator,
  according to the network operations that are performed by Parse SDK.
@@ -35,24 +35,24 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFNetworkActivityIndicatorMana
  */
 @property (nonatomic, assign, getter = isEnabled) BOOL enabled;
 
-/*!
+/**
  A Boolean value indicating whether the network activity indicator is currently displayed in the status bar.
  */
 @property (nonatomic, assign, readonly, getter = isNetworkActivityIndicatorVisible) BOOL networkActivityIndicatorVisible;
 
-/*!
+/**
  The value that indicates current network activities count.
  */
 @property (nonatomic, assign, readonly) NSUInteger networkActivityCount;
 
-/*!
+/**
  @abstract Returns the shared network activity indicator manager object for the system.
 
  @returns The systemwide network activity indicator manager.
  */
 + (PFNetworkActivityIndicatorManager *)sharedManager;
 
-/*!
+/**
  @abstract Increments the number of active network requests.
 
  @discussion If this number was zero before incrementing,
@@ -60,7 +60,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFNetworkActivityIndicatorMana
  */
 - (void)incrementActivityCount;
 
-/*!
+/**
  @abstract Decrements the number of active network requests.
 
  @discussion If this number becomes zero after decrementing,

--- a/Parse/PFNetworkActivityIndicatorManager.h
+++ b/Parse/PFNetworkActivityIndicatorManager.h
@@ -55,7 +55,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFNetworkActivityIndicatorMana
 /**
  Increments the number of active network requests.
 
- @discussion If this number was zero before incrementing,
+ If this number was zero before incrementing,
  this will start animating network activity indicator in the status bar.
  */
 - (void)incrementActivityCount;
@@ -63,7 +63,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFNetworkActivityIndicatorMana
 /**
  Decrements the number of active network requests.
 
- @discussion If this number becomes zero after decrementing,
+ If this number becomes zero after decrementing,
  this will stop animating network activity indicator in the status bar.
  */
 - (void)decrementActivityCount;

--- a/Parse/PFNetworkActivityIndicatorManager.h
+++ b/Parse/PFNetworkActivityIndicatorManager.h
@@ -46,14 +46,14 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFNetworkActivityIndicatorMana
 @property (nonatomic, assign, readonly) NSUInteger networkActivityCount;
 
 /**
- @abstract Returns the shared network activity indicator manager object for the system.
+ Returns the shared network activity indicator manager object for the system.
 
  @returns The systemwide network activity indicator manager.
  */
 + (PFNetworkActivityIndicatorManager *)sharedManager;
 
 /**
- @abstract Increments the number of active network requests.
+ Increments the number of active network requests.
 
  @discussion If this number was zero before incrementing,
  this will start animating network activity indicator in the status bar.
@@ -61,7 +61,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFNetworkActivityIndicatorMana
 - (void)incrementActivityCount;
 
 /**
- @abstract Decrements the number of active network requests.
+ Decrements the number of active network requests.
 
  @discussion If this number becomes zero after decrementing,
  this will stop animating network activity indicator in the status bar.

--- a/Parse/PFObject+Subclass.h
+++ b/Parse/PFObject+Subclass.h
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param objectId The object id for the referenced object.
 
- @returns An instance of `PFObject` without data.
+ @return An instance of `PFObject` without data.
  */
 + (instancetype)objectWithoutDataWithObjectId:(nullable NSString *)objectId;
 
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param predicate The predicate to create conditions from.
 
- @returns An instance of <PFQuery>.
+ @return An instance of <PFQuery>.
 
  @see [PFQuery queryWithClassName:predicate:]
  */

--- a/Parse/PFObject+Subclass.h
+++ b/Parse/PFObject+Subclass.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Creates an instance of the registered subclass with this class's <parseClassName>.
+ Creates an instance of the registered subclass with this class's <parseClassName>.
 
  @discussion This helps a subclass ensure that it can be subclassed itself.
  For example, `[PFUser object]` will return a `MyUser` object if `MyUser` is a registered subclass of `PFUser`.
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)object;
 
 /**
- @abstract Creates a reference to an existing `PFObject` for use in creating associations between `PFObjects`.
+ Creates a reference to an existing `PFObject` for use in creating associations between `PFObjects`.
 
  @discussion Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> or <fetch> has been called.
  This method can only be called on subclasses which conform to <PFSubclassing>.
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)objectWithoutDataWithObjectId:(nullable NSString *)objectId;
 
 /**
- @abstract Registers an Objective-C class for Parse to use for representing a given Parse class.
+ Registers an Objective-C class for Parse to use for representing a given Parse class.
 
  @discussion Once this is called on a `PFObject` subclass, any `PFObject` Parse creates with a class name
  that matches `[self parseClassName]` will be an instance of subclass.
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)registerSubclass;
 
 /**
- @abstract Returns a query for objects of type <parseClassName>.
+ Returns a query for objects of type <parseClassName>.
 
  @discussion This method can only be called on subclasses which conform to <PFSubclassing>.
  A default implementation is provided by <PFObject> which should always be sufficient.
@@ -106,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable PFQuery *)query;
 
 /**
- @abstract Returns a query for objects of type <parseClassName> with a given predicate.
+ Returns a query for objects of type <parseClassName> with a given predicate.
 
  @discussion A default implementation is provided by <PFObject> which should always be sufficient.
  @warning This method can only be called on subclasses which conform to <PFSubclassing>.

--- a/Parse/PFObject+Subclass.h
+++ b/Parse/PFObject+Subclass.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  ### Subclassing Notes
 
  Developers can subclass `PFObject` for a more native object-oriented class structure.
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Methods for Subclasses
 ///--------------------------------------
 
-/*!
+/**
  @abstract Creates an instance of the registered subclass with this class's <parseClassName>.
 
  @discussion This helps a subclass ensure that it can be subclassed itself.
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)object;
 
-/*!
+/**
  @abstract Creates a reference to an existing `PFObject` for use in creating associations between `PFObjects`.
 
  @discussion Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> or <fetch> has been called.
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)objectWithoutDataWithObjectId:(nullable NSString *)objectId;
 
-/*!
+/**
  @abstract Registers an Objective-C class for Parse to use for representing a given Parse class.
 
  @discussion Once this is called on a `PFObject` subclass, any `PFObject` Parse creates with a class name
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)registerSubclass;
 
-/*!
+/**
  @abstract Returns a query for objects of type <parseClassName>.
 
  @discussion This method can only be called on subclasses which conform to <PFSubclassing>.
@@ -105,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable PFQuery *)query;
 
-/*!
+/**
  @abstract Returns a query for objects of type <parseClassName> with a given predicate.
 
  @discussion A default implementation is provided by <PFObject> which should always be sufficient.

--- a/Parse/PFObject+Subclass.h
+++ b/Parse/PFObject+Subclass.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates an instance of the registered subclass with this class's <parseClassName>.
 
- @discussion This helps a subclass ensure that it can be subclassed itself.
+ This helps a subclass ensure that it can be subclassed itself.
  For example, `[PFUser object]` will return a `MyUser` object if `MyUser` is a registered subclass of `PFUser`.
  For this reason, `[MyClass object]` is preferred to `[[MyClass alloc] init]`.
  This method can only be called on subclasses which conform to `PFSubclassing`.
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates a reference to an existing `PFObject` for use in creating associations between `PFObjects`.
 
- @discussion Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> or <fetch> has been called.
+ Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> or <fetch> has been called.
  This method can only be called on subclasses which conform to <PFSubclassing>.
  A default implementation is provided by `PFObject` which should always be sufficient.
  No network request will be made.
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Registers an Objective-C class for Parse to use for representing a given Parse class.
 
- @discussion Once this is called on a `PFObject` subclass, any `PFObject` Parse creates with a class name
+ Once this is called on a `PFObject` subclass, any `PFObject` Parse creates with a class name
  that matches `[self parseClassName]` will be an instance of subclass.
  This method can only be called on subclasses which conform to <PFSubclassing>.
  A default implementation is provided by `PFObject` which should always be sufficient.
@@ -100,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a query for objects of type <parseClassName>.
 
- @discussion This method can only be called on subclasses which conform to <PFSubclassing>.
+ This method can only be called on subclasses which conform to <PFSubclassing>.
  A default implementation is provided by <PFObject> which should always be sufficient.
  */
 + (nullable PFQuery *)query;
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns a query for objects of type <parseClassName> with a given predicate.
 
- @discussion A default implementation is provided by <PFObject> which should always be sufficient.
+ A default implementation is provided by <PFObject> which should always be sufficient.
  @warning This method can only be called on subclasses which conform to <PFSubclassing>.
 
  @param predicate The predicate to create conditions from.

--- a/Parse/PFObject+Subclass.h
+++ b/Parse/PFObject+Subclass.h
@@ -19,12 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
  ### Subclassing Notes
 
  Developers can subclass `PFObject` for a more native object-oriented class structure.
- Strongly-typed subclasses of `PFObject` must conform to the <PFSubclassing> protocol
- and must call <registerSubclass> before <[Parse setApplicationId:clientKey:]> is called.
- After this it will be returned by <PFQuery> and other `PFObject` factories.
+ Strongly-typed subclasses of `PFObject` must conform to the `PFSubclassing` protocol
+ and must call `PFSubclassing.+registerSubclass` before `Parse.+setApplicationId:clientKey:` is called.
+ After this it will be returned by `PFQuery` and other `PFObject` factories.
 
- All methods in <PFSubclassing> except for <[PFSubclassing parseClassName]>
- are already implemented in the `PFObject+Subclass` category.
+ All methods in `PFSubclassing` except for `PFSubclassing.+parseClassName`
+ are already implemented in the `PFObject(Subclass)` category.
 
  Including `PFObject+Subclass.h` in your implementation file provides these implementations automatically.
 
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- Creates an instance of the registered subclass with this class's <parseClassName>.
+ Creates an instance of the registered subclass with this class's `PFSubclassing.+parseClassName`.
 
  This helps a subclass ensure that it can be subclassed itself.
  For example, `[PFUser object]` will return a `MyUser` object if `MyUser` is a registered subclass of `PFUser`.
@@ -76,8 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates a reference to an existing `PFObject` for use in creating associations between `PFObjects`.
 
- Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> or <fetch> has been called.
- This method can only be called on subclasses which conform to <PFSubclassing>.
+ Calling `dataAvailable` on this object will return `NO` until `-fetchIfNeeded` or `-fetch` has been called.
+ This method can only be called on subclasses which conform to `PFSubclassing`.
  A default implementation is provided by `PFObject` which should always be sufficient.
  No network request will be made.
 
@@ -92,30 +92,32 @@ NS_ASSUME_NONNULL_BEGIN
 
  Once this is called on a `PFObject` subclass, any `PFObject` Parse creates with a class name
  that matches `[self parseClassName]` will be an instance of subclass.
- This method can only be called on subclasses which conform to <PFSubclassing>.
+ This method can only be called on subclasses which conform to `PFSubclassing`.
  A default implementation is provided by `PFObject` which should always be sufficient.
  */
 + (void)registerSubclass;
 
 /**
- Returns a query for objects of type <parseClassName>.
+ Returns a query for objects of type `PFSubclassing.+parseClassName`.
 
- This method can only be called on subclasses which conform to <PFSubclassing>.
- A default implementation is provided by <PFObject> which should always be sufficient.
+ This method can only be called on subclasses which conform to `PFSubclassing`.
+ A default implementation is provided by `PFObject` which should always be sufficient.
+ 
+ @see `PFQuery`
  */
 + (nullable PFQuery *)query;
 
 /**
- Returns a query for objects of type <parseClassName> with a given predicate.
+ Returns a query for objects of type `PFSubclassing.+parseClassName` with a given predicate.
 
- A default implementation is provided by <PFObject> which should always be sufficient.
- @warning This method can only be called on subclasses which conform to <PFSubclassing>.
+ A default implementation is provided by `PFObject` which should always be sufficient.
+ @warning This method can only be called on subclasses which conform to `PFSubclassing`.
 
  @param predicate The predicate to create conditions from.
 
- @return An instance of <PFQuery>.
+ @return An instance of `PFQuery`.
 
- @see [PFQuery queryWithClassName:predicate:]
+ @see `PFQuery.+queryWithClassName:predicate:`
  */
 + (nullable PFQuery *)queryWithPredicate:(nullable NSPredicate *)predicate;
 

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -47,7 +47,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract Initializes a new empty `PFObject` instance with a class name.
+ Initializes a new empty `PFObject` instance with a class name.
 
  @param newClassName A class name can be any alphanumeric string that begins with a letter.
  It represents an object in your app, like a 'User' or a 'Document'.
@@ -57,7 +57,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (instancetype)initWithClassName:(NSString *)newClassName;
 
 /**
- @abstract Creates a new PFObject with a class name.
+ Creates a new PFObject with a class name.
 
  @param className A class name can be any alphanumeric string that begins with a letter.
  It represents an object in your app, like a 'User' or a 'Document'.
@@ -67,7 +67,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (instancetype)objectWithClassName:(NSString *)className;
 
 /**
- @abstract Creates a new `PFObject` with a class name, initialized with data
+ Creates a new `PFObject` with a class name, initialized with data
  constructed from the specified set of objects and keys.
 
  @param className The object's class.
@@ -78,7 +78,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (instancetype)objectWithClassName:(NSString *)className dictionary:(nullable NSDictionary PF_GENERIC(NSString *, id)*)dictionary;
 
 /**
- @abstract Creates a reference to an existing PFObject for use in creating associations between PFObjects.
+ Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
  @discussion Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> has been called.
  No network request will be made.
@@ -95,32 +95,32 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract The class name of the object.
+ The class name of the object.
  */
 @property (nonatomic, strong, readonly) NSString *parseClassName;
 
 /**
- @abstract The id of the object.
+ The id of the object.
  */
 @property (nullable, nonatomic, strong) NSString *objectId;
 
 /**
- @abstract When the object was last updated.
+ When the object was last updated.
  */
 @property (nullable, nonatomic, strong, readonly) NSDate *updatedAt;
 
 /**
- @abstract When the object was created.
+ When the object was created.
  */
 @property (nullable, nonatomic, strong, readonly) NSDate *createdAt;
 
 /**
- @abstract The ACL for this object.
+ The ACL for this object.
  */
 @property (nullable, nonatomic, strong) PFACL *ACL;
 
 /**
- @abstract Returns an array of the keys contained in this object.
+ Returns an array of the keys contained in this object.
 
  @discussion This does not include `createdAt`, `updatedAt`, `authData`, or `objectId`.
  It does include things like username and ACL.
@@ -132,14 +132,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract Returns the value associated with a given key.
+ Returns the value associated with a given key.
 
  @param key The key for which to return the corresponding value.
  */
 - (nullable id)objectForKey:(NSString *)key;
 
 /**
- @abstract Sets the object associated with a given key.
+ Sets the object associated with a given key.
 
  @param object The object for `key`. A strong reference to the object is maintained by PFObject.
  Raises an `NSInvalidArgumentException` if `object` is `nil`.
@@ -152,14 +152,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)setObject:(id)object forKey:(NSString *)key;
 
 /**
- @abstract Unsets a key on the object.
+ Unsets a key on the object.
 
  @param key The key.
  */
 - (void)removeObjectForKey:(NSString *)key;
 
 /**
- @abstract Returns the value associated with a given key.
+ Returns the value associated with a given key.
 
  @discussion This method enables usage of literal syntax on `PFObject`.
  E.g. `NSString *value = object[@"key"];`
@@ -171,7 +171,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (nullable id)objectForKeyedSubscript:(NSString *)key;
 
 /**
- @abstract Returns the value associated with a given key.
+ Returns the value associated with a given key.
 
  @discussion This method enables usage of literal syntax on `PFObject`.
  E.g. `object[@"key"] = @"value";`
@@ -187,14 +187,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
 
 /**
- @abstract Returns the relation object associated with the given key.
+ Returns the relation object associated with the given key.
 
  @param key The key that the relation is associated with.
  */
 - (PFRelation *)relationForKey:(NSString *)key;
 
 /**
- @abstract Returns the relation object associated with the given key.
+ Returns the relation object associated with the given key.
 
  @param key The key that the relation is associated with.
 
@@ -203,12 +203,12 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (PFRelation *)relationforKey:(NSString *)key PARSE_DEPRECATED("Please use -relationForKey: instead.");
 
 /**
- @abstract Clears any changes to this object made since the last call to save and sets it back to the server state.
+ Clears any changes to this object made since the last call to save and sets it back to the server state.
  */
 - (void)revert;
 
 /**
- @abstract Clears any changes to this object's key that were done after last successful save and sets it back to the
+ Clears any changes to this object's key that were done after last successful save and sets it back to the
  server state.
 
  @param key The key to revert changes for.
@@ -220,7 +220,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract Adds an object to the end of the array associated with a given key.
+ Adds an object to the end of the array associated with a given key.
 
  @param object The object to add.
  @param key The key.
@@ -228,7 +228,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)addObject:(id)object forKey:(NSString *)key;
 
 /**
- @abstract Adds the objects contained in another array to the end of the array associated with a given key.
+ Adds the objects contained in another array to the end of the array associated with a given key.
 
  @param objects The array of objects to add.
  @param key The key.
@@ -236,7 +236,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)addObjectsFromArray:(NSArray *)objects forKey:(NSString *)key;
 
 /**
- @abstract Adds an object to the array associated with a given key, only if it is not already present in the array.
+ Adds an object to the array associated with a given key, only if it is not already present in the array.
 
  @discussion The position of the insert is not guaranteed.
 
@@ -246,7 +246,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)addUniqueObject:(id)object forKey:(NSString *)key;
 
 /**
- @abstract Adds the objects contained in another array to the array associated with a given key,
+ Adds the objects contained in another array to the array associated with a given key,
  only adding elements which are not already present in the array.
 
  @dicsussion The position of the insert is not guaranteed.
@@ -257,7 +257,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)addUniqueObjectsFromArray:(NSArray *)objects forKey:(NSString *)key;
 
 /**
- @abstract Removes all occurrences of an object from the array associated with a given key.
+ Removes all occurrences of an object from the array associated with a given key.
 
  @param object The object to remove.
  @param key The key.
@@ -265,7 +265,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)removeObject:(id)object forKey:(NSString *)key;
 
 /**
- @abstract Removes all occurrences of the objects contained in another array from the array associated with a given key.
+ Removes all occurrences of the objects contained in another array from the array associated with a given key.
 
  @param objects The array of objects to remove.
  @param key The key.
@@ -277,14 +277,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract Increments the given key by `1`.
+ Increments the given key by `1`.
 
  @param key The key.
  */
 - (void)incrementKey:(NSString *)key;
 
 /**
- @abstract Increments the given key by a number.
+ Increments the given key by a number.
 
  @param key The key.
  @param amount The amount to increment.
@@ -296,14 +296,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* saves the `PFObject`.
+ *Synchronously* saves the `PFObject`.
 
  @returns Returns whether the save succeeded.
  */
 - (BOOL)save PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* saves the `PFObject` and sets an error if it occurs.
+ *Synchronously* saves the `PFObject` and sets an error if it occurs.
 
  @param error Pointer to an NSError that will be set if necessary.
 
@@ -312,14 +312,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)save:(NSError **)error;
 
 /**
- @abstract Saves the `PFObject` *asynchronously*.
+ Saves the `PFObject` *asynchronously*.
 
  @returns The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveInBackground;
 
 /**
- @abstract Saves the `PFObject` *asynchronously* and executes the given callback block.
+ Saves the `PFObject` *asynchronously* and executes the given callback block.
 
  @param block The block to execute.
  It should have the following argument signature: `^(BOOL succeeded, NSError *error)`.
@@ -327,7 +327,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)saveInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
 /*
- @abstract Saves the `PFObject` asynchronously and calls the given callback.
+ Saves the `PFObject` asynchronously and calls the given callback.
 
  @param target The object to call selector on.
  @param selector The selector to call.
@@ -338,7 +338,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)saveInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
 /**
- @abstract Saves this object to the server at some unspecified time in the future,
+ Saves this object to the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
 
  @discussion Use this when you may not have a solid network connection, and don't need to know when the save completes.
@@ -357,7 +357,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask PF_GENERIC(NSNumber *)*)saveEventually PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE;
 
 /**
- @abstract Saves this object to the server at some unspecified time in the future,
+ Saves this object to the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
 
  @discussion Use this when you may not have a solid network connection, and don't need to know when the save completes.
@@ -381,7 +381,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract Saves a collection of objects *synchronously all at once.
+ Saves a collection of objects *synchronously all at once.
 
  @param objects The array of objects to save.
 
@@ -390,7 +390,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)saveAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Saves a collection of objects *synchronously* all at once and sets an error if necessary.
+ Saves a collection of objects *synchronously* all at once and sets an error if necessary.
 
  @param objects The array of objects to save.
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -400,7 +400,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)saveAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
 /**
- @abstract Saves a collection of objects all at once *asynchronously*.
+ Saves a collection of objects all at once *asynchronously*.
 
  @param objects The array of objects to save.
 
@@ -409,7 +409,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BFTask PF_GENERIC(NSNumber *)*)saveAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
 /**
- @abstract Saves a collection of objects all at once `asynchronously` and executes the block when done.
+ Saves a collection of objects all at once `asynchronously` and executes the block when done.
 
  @param objects The array of objects to save.
  @param block The block to execute.
@@ -419,7 +419,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                       block:(nullable PFBooleanResultBlock)block;
 
 /*
- @abstract Saves a collection of objects all at once *asynchronously* and calls a callback when done.
+ Saves a collection of objects all at once *asynchronously* and calls a callback when done.
 
  @param objects The array of objects to save.
  @param target The object to call selector on.
@@ -437,7 +437,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* deletes a collection of objects all at once.
+ *Synchronously* deletes a collection of objects all at once.
 
  @param objects The array of objects to delete.
 
@@ -446,7 +446,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)deleteAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* deletes a collection of objects all at once and sets an error if necessary.
+ *Synchronously* deletes a collection of objects all at once and sets an error if necessary.
 
  @param objects The array of objects to delete.
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -456,14 +456,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)deleteAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
 /**
- @abstract Deletes a collection of objects all at once asynchronously.
+ Deletes a collection of objects all at once asynchronously.
  @param objects The array of objects to delete.
  @returns The task that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)deleteAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
 /**
- @abstract Deletes a collection of objects all at once *asynchronously* and executes the block when done.
+ Deletes a collection of objects all at once *asynchronously* and executes the block when done.
 
  @param objects The array of objects to delete.
  @param block The block to execute.
@@ -473,7 +473,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                         block:(nullable PFBooleanResultBlock)block;
 
 /*
- @abstract Deletes a collection of objects all at once *asynchronously* and calls a callback when done.
+ Deletes a collection of objects all at once *asynchronously* and calls a callback when done.
 
  @param objects The array of objects to delete.
  @param target The object to call selector on.
@@ -491,7 +491,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract Gets whether the `PFObject` has been fetched.
+ Gets whether the `PFObject` has been fetched.
 
  @returns `YES` if the PFObject is new or has been fetched or refreshed, otherwise `NO`.
  */
@@ -500,14 +500,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 #if PARSE_IOS_ONLY
 
 /**
- @abstract Refreshes the PFObject with the current data from the server.
+ Refreshes the PFObject with the current data from the server.
 
  @deprecated Please use `-fetch` instead.
  */
 - (nullable instancetype)refresh PF_SWIFT_UNAVAILABLE PARSE_DEPRECATED("Please use `-fetch` instead.");
 
 /**
- @abstract *Synchronously* refreshes the `PFObject` with the current data from the server and sets an error if it occurs.
+ *Synchronously* refreshes the `PFObject` with the current data from the server and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -516,7 +516,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (nullable instancetype)refresh:(NSError **)error PARSE_DEPRECATED("Please use `-fetch:` instead.");
 
 /**
- @abstract *Asynchronously* refreshes the `PFObject` and executes the given callback block.
+ *Asynchronously* refreshes the `PFObject` and executes the given callback block.
 
  @param block The block to execute.
  The block should have the following argument signature: `^(PFObject *object, NSError *error)`
@@ -526,7 +526,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)refreshInBackgroundWithBlock:(nullable PFObjectResultBlock)block PARSE_DEPRECATED("Please use `-fetchInBackgroundWithBlock:` instead.");
 
 /*
- @abstract *Asynchronously* refreshes the `PFObject` and calls the given callback.
+ *Asynchronously* refreshes the `PFObject` and calls the given callback.
 
  @param target The target on which the selector will be called.
  @param selector The selector to call.
@@ -542,37 +542,37 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 #endif
 
 /**
- @abstract *Synchronously* fetches the PFObject with the current data from the server.
+ *Synchronously* fetches the PFObject with the current data from the server.
  */
 - (nullable instancetype)fetch PF_SWIFT_UNAVAILABLE;
 /**
- @abstract *Synchronously* fetches the PFObject with the current data from the server and sets an error if it occurs.
+ *Synchronously* fetches the PFObject with the current data from the server and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
  */
 - (nullable instancetype)fetch:(NSError **)error;
 
 /**
- @abstract *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
+ *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
  */
 - (nullable instancetype)fetchIfNeeded PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
+ *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
 
  @param error Pointer to an `NSError` that will be set if necessary.
  */
 - (nullable instancetype)fetchIfNeeded:(NSError **)error;
 
 /**
- @abstract Fetches the `PFObject` *asynchronously* and sets it as a result for the task.
+ Fetches the `PFObject` *asynchronously* and sets it as a result for the task.
 
  @returns The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchInBackground;
 
 /**
- @abstract Fetches the PFObject *asynchronously* and executes the given callback block.
+ Fetches the PFObject *asynchronously* and executes the given callback block.
 
  @param block The block to execute.
  It should have the following argument signature: `^(PFObject *object, NSError *error)`.
@@ -580,7 +580,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)fetchInBackgroundWithBlock:(nullable PFObjectResultBlock)block;
 
 /*
- @abstract Fetches the `PFObject *asynchronously* and calls the given callback.
+ Fetches the `PFObject *asynchronously* and calls the given callback.
 
  @param target The target on which the selector will be called.
  @param selector The selector to call.
@@ -591,7 +591,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)fetchInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
 /**
- @abstract Fetches the `PFObject` data *asynchronously* if isDataAvailable is `NO`,
+ Fetches the `PFObject` data *asynchronously* if isDataAvailable is `NO`,
  then sets it as a result for the task.
 
  @returns The task that encapsulates the work being done.
@@ -599,7 +599,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchIfNeededInBackground;
 
 /**
- @abstract Fetches the `PFObject` data *asynchronously* if <isDataAvailable> is `NO`, then calls the callback block.
+ Fetches the `PFObject` data *asynchronously* if <isDataAvailable> is `NO`, then calls the callback block.
 
  @param block The block to execute.
  It should have the following argument signature: `^(PFObject *object, NSError *error)`.
@@ -607,7 +607,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)fetchIfNeededInBackgroundWithBlock:(nullable PFObjectResultBlock)block;
 
 /*
- @abstract Fetches the PFObject's data asynchronously if isDataAvailable is false, then calls the callback.
+ Fetches the PFObject's data asynchronously if isDataAvailable is false, then calls the callback.
 
  @param target The target on which the selector will be called.
  @param selector The selector to call.
@@ -622,14 +622,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server.
+ *Synchronously* fetches all of the `PFObject` objects with the current data from the server.
 
  @param objects The list of objects to fetch.
  */
 + (nullable NSArray PF_GENERIC(__kindof PFObject *)*)fetchAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server
+ *Synchronously* fetches all of the `PFObject` objects with the current data from the server
  and sets an error if it occurs.
 
  @param objects The list of objects to fetch.
@@ -639,13 +639,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                                                         error:(NSError **)error;
 
 /**
- @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server.
+ *Synchronously* fetches all of the `PFObject` objects with the current data from the server.
  @param objects The list of objects to fetch.
  */
 + (nullable NSArray PF_GENERIC(__kindof PFObject *)*)fetchAllIfNeeded:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server
+ *Synchronously* fetches all of the `PFObject` objects with the current data from the server
  and sets an error if it occurs.
 
  @param objects The list of objects to fetch.
@@ -655,7 +655,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                                                                 error:(NSError **)error;
 
 /**
- @abstract Fetches all of the `PFObject` objects with the current data from the server *asynchronously*.
+ Fetches all of the `PFObject` objects with the current data from the server *asynchronously*.
 
  @param objects The list of objects to fetch.
 
@@ -664,7 +664,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BFTask PF_GENERIC(NSArray<__kindof PFObject *> *)*)fetchAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
 /**
- @abstract Fetches all of the `PFObject` objects with the current data from the server *asynchronously*
+ Fetches all of the `PFObject` objects with the current data from the server *asynchronously*
  and calls the given block.
 
  @param objects The list of objects to fetch.
@@ -675,7 +675,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                        block:(nullable PFArrayResultBlock)block;
 
 /*
- @abstract Fetches all of the `PFObject` objects with the current data from the server *asynchronously*
+ Fetches all of the `PFObject` objects with the current data from the server *asynchronously*
  and calls the given callback.
 
  @param objects The list of objects to fetch.
@@ -690,7 +690,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                     selector:(nullable SEL)selector;
 
 /**
- @abstract Fetches all of the `PFObject` objects with the current data from the server *asynchronously*.
+ Fetches all of the `PFObject` objects with the current data from the server *asynchronously*.
 
  @param objects The list of objects to fetch.
 
@@ -699,7 +699,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BFTask PF_GENERIC(NSArray<__kindof PFObject *> *)*)fetchAllIfNeededInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
 /**
- @abstract Fetches all of the PFObjects with the current data from the server *asynchronously*
+ Fetches all of the PFObjects with the current data from the server *asynchronously*
  and calls the given block.
 
  @param objects The list of objects to fetch.
@@ -710,7 +710,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                                block:(nullable PFArrayResultBlock)block;
 
 /*
- @abstract Fetches all of the PFObjects with the current data from the server *asynchronously*
+ Fetches all of the PFObjects with the current data from the server *asynchronously*
  and calls the given callback.
 
  @param objects The list of objects to fetch.
@@ -729,13 +729,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* loads data from the local datastore into this object,
+ *Synchronously* loads data from the local datastore into this object,
  if it has not been fetched from the server already.
  */
 - (nullable instancetype)fetchFromLocalDatastore PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* loads data from the local datastore into this object, if it has not been fetched
+ *Synchronously* loads data from the local datastore into this object, if it has not been fetched
  from the server already.
 
  @discussion If the object is not stored in the local datastore, this `error` will be set to
@@ -746,7 +746,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (nullable instancetype)fetchFromLocalDatastore:(NSError **)error;
 
 /**
- @abstract *Asynchronously* loads data from the local datastore into this object,
+ *Asynchronously* loads data from the local datastore into this object,
  if it has not been fetched from the server already.
 
  @returns The task that encapsulates the work being done.
@@ -754,7 +754,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchFromLocalDatastoreInBackground;
 
 /**
- @abstract *Asynchronously* loads data from the local datastore into this object,
+ *Asynchronously* loads data from the local datastore into this object,
  if it has not been fetched from the server already.
 
  @param block The block to execute.
@@ -767,14 +767,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* deletes the `PFObject`.
+ *Synchronously* deletes the `PFObject`.
 
  @returns Returns whether the delete succeeded.
  */
 - (BOOL)delete PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* deletes the `PFObject` and sets an error if it occurs.
+ *Synchronously* deletes the `PFObject` and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -783,14 +783,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)delete:(NSError **)error;
 
 /**
- @abstract Deletes the `PFObject` *asynchronously*.
+ Deletes the `PFObject` *asynchronously*.
 
  @returns The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)deleteInBackground;
 
 /**
- @abstract Deletes the `PFObject` *asynchronously* and executes the given callback block.
+ Deletes the `PFObject` *asynchronously* and executes the given callback block.
 
  @param block The block to execute.
  It should have the following argument signature: `^(BOOL succeeded, NSError *error)`.
@@ -798,7 +798,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)deleteInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
 /*
- @abstract Deletes the `PFObject` *asynchronously* and calls the given callback.
+ Deletes the `PFObject` *asynchronously* and calls the given callback.
 
  @param target The object to call selector on.
  @param selector The selector to call.
@@ -810,7 +810,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                             selector:(nullable SEL)selector;
 
 /**
- @abstract Deletes this object from the server at some unspecified time in the future,
+ Deletes this object from the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
 
  @discussion Use this when you may not have a solid network connection,
@@ -833,7 +833,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract Gets whether any key-value pair in this object (or its children)
+ Gets whether any key-value pair in this object (or its children)
  has been added/updated/removed and not saved yet.
 
  @returns Returns whether this object has been altered and not saved yet.
@@ -841,7 +841,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 @property (nonatomic, assign, readonly, getter=isDirty) BOOL dirty;
 
 /**
- @abstract Get whether a value associated with a key has been added/updated/removed and not saved yet.
+ Get whether a value associated with a key has been added/updated/removed and not saved yet.
 
  @param key The key to check for
 
@@ -854,7 +854,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively,
+ *Synchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -870,7 +870,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)pin PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively,
+ *Synchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -888,7 +888,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)pin:(NSError **)error;
 
 /**
- @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively.
+ *Synchronously* stores the object and every object it points to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
@@ -904,7 +904,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)pinWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively.
+ *Synchronously* stores the object and every object it points to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
@@ -922,7 +922,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
               error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* stores the object and every object it points to in the local datastore, recursively,
+ *Asynchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -938,7 +938,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask PF_GENERIC(NSNumber *)*)pinInBackground;
 
 /**
- @abstract *Asynchronously* stores the object and every object it points to in the local datastore, recursively,
+ *Asynchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -955,7 +955,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)pinInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract *Asynchronously* stores the object and every object it points to in the local datastore, recursively.
+ *Asynchronously* stores the object and every object it points to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
@@ -971,7 +971,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask PF_GENERIC(NSNumber *)*)pinInBackgroundWithName:(NSString *)name;
 
 /**
- @abstract *Asynchronously* stores the object and every object it points to in the local datastore, recursively.
+ *Asynchronously* stores the object and every object it points to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
@@ -991,7 +991,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively,
+ *Synchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -1009,7 +1009,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)pinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively,
+ *Synchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -1028,7 +1028,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)pinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
 /**
- @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively.
+ *Synchronously* stores the objects and every object they point to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
@@ -1045,7 +1045,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)pinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects withName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively.
+ *Synchronously* stores the objects and every object they point to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
@@ -1065,7 +1065,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
          error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* stores the objects and every object they point to in the local datastore, recursively,
+ *Asynchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -1083,7 +1083,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BFTask PF_GENERIC(NSNumber *)*)pinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
 /**
- @abstract *Asynchronously* stores the objects and every object they point to in the local datastore, recursively,
+ *Asynchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -1101,7 +1101,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (void)pinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects block:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract *Asynchronously* stores the objects and every object they point to in the local datastore, recursively.
+ *Asynchronously* stores the objects and every object they point to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
@@ -1118,7 +1118,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BFTask PF_GENERIC(NSNumber *)*)pinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects withName:(NSString *)name;
 
 /**
- @abstract *Asynchronously* stores the objects and every object they point to in the local datastore, recursively.
+ *Asynchronously* stores the objects and every object they point to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
@@ -1141,7 +1141,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively,
+ *Synchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @returns Returns whether the unpin succeeded.
@@ -1152,7 +1152,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)unpin PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively,
+ *Synchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -1165,7 +1165,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)unpin:(NSError **)error;
 
 /**
- @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively.
+ *Synchronously* removes the object and every object it points to in the local datastore, recursively.
 
  @param name The name of the pin.
 
@@ -1176,7 +1176,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)unpinWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively.
+ *Synchronously* removes the object and every object it points to in the local datastore, recursively.
 
  @param name    The name of the pin.
  @param error   Pointer to an `NSError` that will be set if necessary.
@@ -1189,7 +1189,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                 error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* removes the object and every object it points to in the local datastore, recursively,
+ *Asynchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @returns The task that encapsulates the work being done.
@@ -1200,7 +1200,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask PF_GENERIC(NSNumber *)*)unpinInBackground;
 
 /**
- @abstract *Asynchronously* removes the object and every object it points to in the local datastore, recursively,
+ *Asynchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @param block The block to execute.
@@ -1212,7 +1212,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)unpinInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract *Asynchronously* removes the object and every object it points to in the local datastore, recursively.
+ *Asynchronously* removes the object and every object it points to in the local datastore, recursively.
 
  @param name The name of the pin.
 
@@ -1223,7 +1223,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask PF_GENERIC(NSNumber *)*)unpinInBackgroundWithName:(NSString *)name;
 
 /**
- @abstract *Asynchronously* removes the object and every object it points to in the local datastore, recursively.
+ *Asynchronously* removes the object and every object it points to in the local datastore, recursively.
 
  @param name    The name of the pin.
  @param block   The block to execute.
@@ -1238,7 +1238,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* removes all objects in the local datastore
+ *Synchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
  @returns Returns whether the unpin succeeded.
@@ -1248,7 +1248,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)unpinAllObjects PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* removes all objects in the local datastore
+ *Synchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
  @param error   Pointer to an `NSError` that will be set if necessary.
@@ -1260,7 +1260,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)unpinAllObjects:(NSError **)error;
 
 /**
- @abstract *Synchronously* removes all objects with the specified pin name.
+ *Synchronously* removes all objects with the specified pin name.
 
  @param name    The name of the pin.
 
@@ -1269,7 +1269,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)unpinAllObjectsWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* removes all objects with the specified pin name.
+ *Synchronously* removes all objects with the specified pin name.
 
  @param name    The name of the pin.
  @param error   Pointer to an `NSError` that will be set if necessary.
@@ -1280,7 +1280,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                           error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* removes all objects in the local datastore
+ *Asynchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
  @returns The task that encapsulates the work being done.
@@ -1290,7 +1290,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllObjectsInBackground;
 
 /**
- @abstract *Asynchronously* removes all objects in the local datastore
+ *Asynchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
  @param block   The block to execute.
@@ -1301,7 +1301,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (void)unpinAllObjectsInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract *Asynchronously* removes all objects with the specified pin name.
+ *Asynchronously* removes all objects with the specified pin name.
 
  @param name    The name of the pin.
 
@@ -1310,7 +1310,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllObjectsInBackgroundWithName:(NSString *)name;
 
 /**
- @abstract *Asynchronously* removes all objects with the specified pin name.
+ *Asynchronously* removes all objects with the specified pin name.
 
  @param name    The name of the pin.
  @param block   The block to execute.
@@ -1319,7 +1319,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (void)unpinAllObjectsInBackgroundWithName:(NSString *)name block:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively,
+ *Synchronously* removes the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @param objects The objects.
@@ -1332,7 +1332,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)unpinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively,
+ *Synchronously* removes the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @param objects The objects.
@@ -1346,7 +1346,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)unpinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
 /**
- @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively.
+ *Synchronously* removes the objects and every object they point to in the local datastore, recursively.
 
  @param objects The objects.
  @param name    The name of the pin.
@@ -1358,7 +1358,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)unpinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects withName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively.
+ *Synchronously* removes the objects and every object they point to in the local datastore, recursively.
 
  @param objects The objects.
  @param name    The name of the pin.
@@ -1373,7 +1373,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
            error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* removes the objects and every object they point to in the local datastore, recursively,
+ *Asynchronously* removes the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @param objects The objects.
@@ -1386,7 +1386,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
 /**
- @abstract *Asynchronously* removes the objects and every object they point to in the local datastore, recursively,
+ *Asynchronously* removes the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
  @param objects The objects.
@@ -1399,7 +1399,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (void)unpinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects block:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract *Asynchronously* removes the objects and every object they point to in the local datastore, recursively.
+ *Asynchronously* removes the objects and every object they point to in the local datastore, recursively.
 
  @param objects The objects.
  @param name    The name of the pin.
@@ -1411,7 +1411,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects withName:(NSString *)name;
 
 /**
- @abstract *Asynchronously* removes the objects and every object they point to in the local datastore, recursively.
+ *Asynchronously* removes the objects and every object they point to in the local datastore, recursively.
 
  @param objects The objects.
  @param name    The name of the pin.

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -80,7 +80,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
- @discussion Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> has been called.
+ Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> has been called.
  No network request will be made.
 
  @param className The object's class.
@@ -122,7 +122,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  Returns an array of the keys contained in this object.
 
- @discussion This does not include `createdAt`, `updatedAt`, `authData`, or `objectId`.
+ This does not include `createdAt`, `updatedAt`, `authData`, or `objectId`.
  It does include things like username and ACL.
  */
 @property (nonatomic, copy, readonly) NSArray PF_GENERIC(NSString *)*allKeys;
@@ -161,7 +161,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  Returns the value associated with a given key.
 
- @discussion This method enables usage of literal syntax on `PFObject`.
+ This method enables usage of literal syntax on `PFObject`.
  E.g. `NSString *value = object[@"key"];`
 
  @param key The key for which to return the corresponding value.
@@ -173,7 +173,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  Returns the value associated with a given key.
 
- @discussion This method enables usage of literal syntax on `PFObject`.
+ This method enables usage of literal syntax on `PFObject`.
  E.g. `object[@"key"] = @"value";`
 
  @param object The object for `key`. A strong reference to the object is maintained by PFObject.
@@ -238,7 +238,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  Adds an object to the array associated with a given key, only if it is not already present in the array.
 
- @discussion The position of the insert is not guaranteed.
+ The position of the insert is not guaranteed.
 
  @param object The object to add.
  @param key The key.
@@ -341,7 +341,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  Saves this object to the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
 
- @discussion Use this when you may not have a solid network connection, and don't need to know when the save completes.
+ Use this when you may not have a solid network connection, and don't need to know when the save completes.
  If there is some problem with the object such that it can't be saved, it will be silently discarded. If the save
  completes successfully while the object is still in memory, then callback will be called.
 
@@ -360,7 +360,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  Saves this object to the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
 
- @discussion Use this when you may not have a solid network connection, and don't need to know when the save completes.
+ Use this when you may not have a solid network connection, and don't need to know when the save completes.
  If there is some problem with the object such that it can't be saved, it will be silently discarded. If the save
  completes successfully while the object is still in memory, then callback will be called.
 
@@ -738,7 +738,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Synchronously* loads data from the local datastore into this object, if it has not been fetched
  from the server already.
 
- @discussion If the object is not stored in the local datastore, this `error` will be set to
+ If the object is not stored in the local datastore, this `error` will be set to
  return kPFErrorCacheMiss.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -813,7 +813,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  Deletes this object from the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
 
- @discussion Use this when you may not have a solid network connection,
+ Use this when you may not have a solid network connection,
  and don't need to know when the delete completes. If there is some problem with the object
  such that it can't be deleted, the request will be silently discarded.
 
@@ -857,7 +857,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Synchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
@@ -873,7 +873,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Synchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
@@ -890,7 +890,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Synchronously* stores the object and every object it points to in the local datastore, recursively.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
@@ -906,7 +906,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Synchronously* stores the object and every object it points to in the local datastore, recursively.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
@@ -925,7 +925,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Asynchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
@@ -941,7 +941,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Asynchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
@@ -957,7 +957,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Asynchronously* stores the object and every object it points to in the local datastore, recursively.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
@@ -973,7 +973,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Asynchronously* stores the object and every object it points to in the local datastore, recursively.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
@@ -994,7 +994,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Synchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
@@ -1012,7 +1012,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Synchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
@@ -1030,7 +1030,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Synchronously* stores the objects and every object they point to in the local datastore, recursively.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
@@ -1047,7 +1047,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Synchronously* stores the objects and every object they point to in the local datastore, recursively.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
@@ -1068,7 +1068,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Asynchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
@@ -1086,7 +1086,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Asynchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
@@ -1103,7 +1103,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Asynchronously* stores the objects and every object they point to in the local datastore, recursively.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
@@ -1120,7 +1120,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Asynchronously* stores the objects and every object they point to in the local datastore, recursively.
 
- @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
+ If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -52,7 +52,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param newClassName A class name can be any alphanumeric string that begins with a letter.
  It represents an object in your app, like a 'User' or a 'Document'.
 
- @returns Returns the object that is instantiated with the given class name.
+ @return Returns the object that is instantiated with the given class name.
  */
 - (instancetype)initWithClassName:(NSString *)newClassName;
 
@@ -62,7 +62,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param className A class name can be any alphanumeric string that begins with a letter.
  It represents an object in your app, like a 'User' or a 'Document'.
 
- @returns Returns the object that is instantiated with the given class name.
+ @return Returns the object that is instantiated with the given class name.
  */
 + (instancetype)objectWithClassName:(NSString *)className;
 
@@ -73,7 +73,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param className The object's class.
  @param dictionary An `NSDictionary` of keys and objects to set on the new `PFObject`.
 
- @returns A PFObject with the given class name and set with the given data.
+ @return A PFObject with the given class name and set with the given data.
  */
 + (instancetype)objectWithClassName:(NSString *)className dictionary:(nullable NSDictionary PF_GENERIC(NSString *, id)*)dictionary;
 
@@ -86,7 +86,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param className The object's class.
  @param objectId The object id for the referenced object.
 
- @returns A `PFObject` instance without data.
+ @return A `PFObject` instance without data.
  */
 + (instancetype)objectWithoutDataWithClassName:(NSString *)className objectId:(nullable NSString *)objectId;
 
@@ -298,7 +298,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Synchronously* saves the `PFObject`.
 
- @returns Returns whether the save succeeded.
+ @return Returns whether the save succeeded.
  */
 - (BOOL)save PF_SWIFT_UNAVAILABLE;
 
@@ -307,14 +307,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param error Pointer to an NSError that will be set if necessary.
 
- @returns Returns whether the save succeeded.
+ @return Returns whether the save succeeded.
  */
 - (BOOL)save:(NSError **)error;
 
 /**
  Saves the `PFObject` *asynchronously*.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveInBackground;
 
@@ -352,7 +352,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  will cause old saves to be silently discarded until the connection can be re-established, and the queued objects
  can be saved.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveEventually PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE;
 
@@ -385,7 +385,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The array of objects to save.
 
- @returns Returns whether the save succeeded.
+ @return Returns whether the save succeeded.
  */
 + (BOOL)saveAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
@@ -395,7 +395,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param objects The array of objects to save.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the save succeeded.
+ @return Returns whether the save succeeded.
  */
 + (BOOL)saveAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
@@ -404,7 +404,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The array of objects to save.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)saveAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
@@ -441,7 +441,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The array of objects to delete.
 
- @returns Returns whether the delete succeeded.
+ @return Returns whether the delete succeeded.
  */
 + (BOOL)deleteAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
@@ -451,14 +451,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param objects The array of objects to delete.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the delete succeeded.
+ @return Returns whether the delete succeeded.
  */
 + (BOOL)deleteAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
 /**
  Deletes a collection of objects all at once asynchronously.
  @param objects The array of objects to delete.
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)deleteAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
@@ -493,7 +493,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  Gets whether the `PFObject` has been fetched.
 
- @returns `YES` if the PFObject is new or has been fetched or refreshed, otherwise `NO`.
+ @return `YES` if the PFObject is new or has been fetched or refreshed, otherwise `NO`.
  */
 @property (nonatomic, assign, readonly, getter=isDataAvailable) BOOL dataAvailable;
 
@@ -567,7 +567,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  Fetches the `PFObject` *asynchronously* and sets it as a result for the task.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchInBackground;
 
@@ -594,7 +594,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  Fetches the `PFObject` data *asynchronously* if isDataAvailable is `NO`,
  then sets it as a result for the task.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchIfNeededInBackground;
 
@@ -659,7 +659,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The list of objects to fetch.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSArray<__kindof PFObject *> *)*)fetchAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
@@ -694,7 +694,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The list of objects to fetch.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSArray<__kindof PFObject *> *)*)fetchAllIfNeededInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
@@ -749,7 +749,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Asynchronously* loads data from the local datastore into this object,
  if it has not been fetched from the server already.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchFromLocalDatastoreInBackground;
 
@@ -769,7 +769,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Synchronously* deletes the `PFObject`.
 
- @returns Returns whether the delete succeeded.
+ @return Returns whether the delete succeeded.
  */
 - (BOOL)delete PF_SWIFT_UNAVAILABLE;
 
@@ -778,14 +778,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the delete succeeded.
+ @return Returns whether the delete succeeded.
  */
 - (BOOL)delete:(NSError **)error;
 
 /**
  Deletes the `PFObject` *asynchronously*.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)deleteInBackground;
 
@@ -824,7 +824,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  to be sent, subsequent calls to <saveEventually> or <deleteEventually> will cause old requests to be silently discarded
  until the connection can be re-established, and the queued requests can go through.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)deleteEventually PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE;
 
@@ -836,7 +836,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  Gets whether any key-value pair in this object (or its children)
  has been added/updated/removed and not saved yet.
 
- @returns Returns whether this object has been altered and not saved yet.
+ @return Returns whether this object has been altered and not saved yet.
  */
 @property (nonatomic, assign, readonly, getter=isDirty) BOOL dirty;
 
@@ -845,7 +845,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param key The key to check for
 
- @returns Returns whether this key has been altered and not saved yet.
+ @return Returns whether this key has been altered and not saved yet.
  */
 - (BOOL)isDirtyForKey:(NSString *)key;
 
@@ -862,7 +862,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
 
- @returns Returns whether the pin succeeded.
+ @return Returns whether the pin succeeded.
 
  @see unpin:
  @see PFObjectDefaultPin
@@ -880,7 +880,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the pin succeeded.
+ @return Returns whether the pin succeeded.
 
  @see unpin:
  @see PFObjectDefaultPin
@@ -897,7 +897,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param name The name of the pin.
 
- @returns Returns whether the pin succeeded.
+ @return Returns whether the pin succeeded.
 
  @see unpinWithName:
  */
@@ -914,7 +914,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param name    The name of the pin.
  @param error   Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the pin succeeded.
+ @return Returns whether the pin succeeded.
 
  @see unpinWithName:
  */
@@ -930,7 +930,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
  <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
 
  @see unpinInBackground
  @see PFObjectDefaultPin
@@ -964,7 +964,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param name The name of the pin.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
 
  @see unpinInBackgroundWithName:
  */
@@ -1001,7 +1001,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The objects to be pinned.
 
- @returns Returns whether the pin succeeded.
+ @return Returns whether the pin succeeded.
 
  @see unpinAll:
  @see PFObjectDefaultPin
@@ -1020,7 +1020,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param objects The objects to be pinned.
  @param error   Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the pin succeeded.
+ @return Returns whether the pin succeeded.
 
  @see unpinAll:error:
  @see PFObjectDefaultPin
@@ -1038,7 +1038,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param objects The objects to be pinned.
  @param name    The name of the pin.
 
- @returns Returns whether the pin succeeded.
+ @return Returns whether the pin succeeded.
 
  @see unpinAll:withName:
  */
@@ -1056,7 +1056,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param name    The name of the pin.
  @param error   Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the pin succeeded.
+ @return Returns whether the pin succeeded.
 
  @see unpinAll:withName:error:
  */
@@ -1075,7 +1075,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The objects to be pinned.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
 
  @see unpinAllInBackground:
  @see PFObjectDefaultPin
@@ -1111,7 +1111,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param objects     The objects to be pinned.
  @param name        The name of the pin.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
 
  @see unpinAllInBackground:withName:
  */
@@ -1144,7 +1144,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Synchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see pin:
  @see PFObjectDefaultPin
@@ -1157,7 +1157,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see pin:
  @see PFObjectDefaultPin
@@ -1169,7 +1169,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param name The name of the pin.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see pinWithName:
  */
@@ -1181,7 +1181,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param name    The name of the pin.
  @param error   Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see pinWithName:error:
  */
@@ -1192,7 +1192,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Asynchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
 
  @see pinInBackground
  @see PFObjectDefaultPin
@@ -1216,7 +1216,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param name The name of the pin.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
 
  @see pinInBackgroundWithName:
  */
@@ -1241,7 +1241,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Synchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see PFObjectDefaultPin
  */
@@ -1253,7 +1253,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param error   Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see PFObjectDefaultPin
  */
@@ -1264,7 +1264,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param name    The name of the pin.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
  */
 + (BOOL)unpinAllObjectsWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
@@ -1274,7 +1274,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param name    The name of the pin.
  @param error   Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
  */
 + (BOOL)unpinAllObjectsWithName:(NSString *)name
                           error:(NSError **)error;
@@ -1283,7 +1283,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  *Asynchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
 
  @see PFObjectDefaultPin
  */
@@ -1305,7 +1305,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param name    The name of the pin.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllObjectsInBackgroundWithName:(NSString *)name;
 
@@ -1324,7 +1324,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The objects.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see pinAll:
  @see PFObjectDefaultPin
@@ -1338,7 +1338,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param objects The objects.
  @param error   Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see pinAll:error:
  @see PFObjectDefaultPin
@@ -1351,7 +1351,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param objects The objects.
  @param name    The name of the pin.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see pinAll:withName:
  */
@@ -1364,7 +1364,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param name    The name of the pin.
  @param error   Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the unpin succeeded.
+ @return Returns whether the unpin succeeded.
 
  @see pinAll:withName:error:
  */
@@ -1378,7 +1378,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param objects The objects.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
 
  @see pinAllInBackground:
  @see PFObjectDefaultPin
@@ -1404,7 +1404,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param objects The objects.
  @param name    The name of the pin.
 
- @returns The task that encapsulates the work being done.
+ @return The task that encapsulates the work being done.
 
  @see pinAllInBackground:withName:
  */

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -19,12 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol PFSubclassing;
 @class PFRelation;
 
-/*!
+/**
  The name of the default pin that for PFObject local data store.
  */
 extern NSString *const PFObjectDefaultPin;
 
-/*!
+/**
  The `PFObject` class is a local representation of data persisted to the Parse cloud.
  This is the main class that is used to interact with objects in your app.
  */
@@ -46,7 +46,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Creating a PFObject
 ///--------------------------------------
 
-/*!
+/**
  @abstract Initializes a new empty `PFObject` instance with a class name.
 
  @param newClassName A class name can be any alphanumeric string that begins with a letter.
@@ -56,7 +56,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (instancetype)initWithClassName:(NSString *)newClassName;
 
-/*!
+/**
  @abstract Creates a new PFObject with a class name.
 
  @param className A class name can be any alphanumeric string that begins with a letter.
@@ -66,7 +66,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (instancetype)objectWithClassName:(NSString *)className;
 
-/*!
+/**
  @abstract Creates a new `PFObject` with a class name, initialized with data
  constructed from the specified set of objects and keys.
 
@@ -77,7 +77,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (instancetype)objectWithClassName:(NSString *)className dictionary:(nullable NSDictionary PF_GENERIC(NSString *, id)*)dictionary;
 
-/*!
+/**
  @abstract Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
  @discussion Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> has been called.
@@ -94,32 +94,32 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Managing Object Properties
 ///--------------------------------------
 
-/*!
+/**
  @abstract The class name of the object.
  */
 @property (nonatomic, strong, readonly) NSString *parseClassName;
 
-/*!
+/**
  @abstract The id of the object.
  */
 @property (nullable, nonatomic, strong) NSString *objectId;
 
-/*!
+/**
  @abstract When the object was last updated.
  */
 @property (nullable, nonatomic, strong, readonly) NSDate *updatedAt;
 
-/*!
+/**
  @abstract When the object was created.
  */
 @property (nullable, nonatomic, strong, readonly) NSDate *createdAt;
 
-/*!
+/**
  @abstract The ACL for this object.
  */
 @property (nullable, nonatomic, strong) PFACL *ACL;
 
-/*!
+/**
  @abstract Returns an array of the keys contained in this object.
 
  @discussion This does not include `createdAt`, `updatedAt`, `authData`, or `objectId`.
@@ -131,14 +131,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Accessors
 ///--------------------------------------
 
-/*!
+/**
  @abstract Returns the value associated with a given key.
 
  @param key The key for which to return the corresponding value.
  */
 - (nullable id)objectForKey:(NSString *)key;
 
-/*!
+/**
  @abstract Sets the object associated with a given key.
 
  @param object The object for `key`. A strong reference to the object is maintained by PFObject.
@@ -151,14 +151,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)setObject:(id)object forKey:(NSString *)key;
 
-/*!
+/**
  @abstract Unsets a key on the object.
 
  @param key The key.
  */
 - (void)removeObjectForKey:(NSString *)key;
 
-/*!
+/**
  @abstract Returns the value associated with a given key.
 
  @discussion This method enables usage of literal syntax on `PFObject`.
@@ -170,7 +170,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (nullable id)objectForKeyedSubscript:(NSString *)key;
 
-/*!
+/**
  @abstract Returns the value associated with a given key.
 
  @discussion This method enables usage of literal syntax on `PFObject`.
@@ -186,14 +186,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
 
-/*!
+/**
  @abstract Returns the relation object associated with the given key.
 
  @param key The key that the relation is associated with.
  */
 - (PFRelation *)relationForKey:(NSString *)key;
 
-/*!
+/**
  @abstract Returns the relation object associated with the given key.
 
  @param key The key that the relation is associated with.
@@ -202,12 +202,12 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (PFRelation *)relationforKey:(NSString *)key PARSE_DEPRECATED("Please use -relationForKey: instead.");
 
-/*!
+/**
  @abstract Clears any changes to this object made since the last call to save and sets it back to the server state.
  */
 - (void)revert;
 
-/*!
+/**
  @abstract Clears any changes to this object's key that were done after last successful save and sets it back to the
  server state.
 
@@ -219,7 +219,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Array Accessors
 ///--------------------------------------
 
-/*!
+/**
  @abstract Adds an object to the end of the array associated with a given key.
 
  @param object The object to add.
@@ -227,7 +227,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)addObject:(id)object forKey:(NSString *)key;
 
-/*!
+/**
  @abstract Adds the objects contained in another array to the end of the array associated with a given key.
 
  @param objects The array of objects to add.
@@ -235,7 +235,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)addObjectsFromArray:(NSArray *)objects forKey:(NSString *)key;
 
-/*!
+/**
  @abstract Adds an object to the array associated with a given key, only if it is not already present in the array.
 
  @discussion The position of the insert is not guaranteed.
@@ -245,7 +245,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)addUniqueObject:(id)object forKey:(NSString *)key;
 
-/*!
+/**
  @abstract Adds the objects contained in another array to the array associated with a given key,
  only adding elements which are not already present in the array.
 
@@ -256,7 +256,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)addUniqueObjectsFromArray:(NSArray *)objects forKey:(NSString *)key;
 
-/*!
+/**
  @abstract Removes all occurrences of an object from the array associated with a given key.
 
  @param object The object to remove.
@@ -264,7 +264,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)removeObject:(id)object forKey:(NSString *)key;
 
-/*!
+/**
  @abstract Removes all occurrences of the objects contained in another array from the array associated with a given key.
 
  @param objects The array of objects to remove.
@@ -276,14 +276,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Increment
 ///--------------------------------------
 
-/*!
+/**
  @abstract Increments the given key by `1`.
 
  @param key The key.
  */
 - (void)incrementKey:(NSString *)key;
 
-/*!
+/**
  @abstract Increments the given key by a number.
 
  @param key The key.
@@ -295,14 +295,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Saving Objects
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* saves the `PFObject`.
 
  @returns Returns whether the save succeeded.
  */
 - (BOOL)save PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* saves the `PFObject` and sets an error if it occurs.
 
  @param error Pointer to an NSError that will be set if necessary.
@@ -311,14 +311,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BOOL)save:(NSError **)error;
 
-/*!
+/**
  @abstract Saves the `PFObject` *asynchronously*.
 
  @returns The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveInBackground;
 
-/*!
+/**
  @abstract Saves the `PFObject` *asynchronously* and executes the given callback block.
 
  @param block The block to execute.
@@ -337,7 +337,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)saveInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
-/*!
+/**
  @abstract Saves this object to the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
 
@@ -356,7 +356,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BFTask PF_GENERIC(NSNumber *)*)saveEventually PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE;
 
-/*!
+/**
  @abstract Saves this object to the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
 
@@ -380,7 +380,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Saving Many Objects
 ///--------------------------------------
 
-/*!
+/**
  @abstract Saves a collection of objects *synchronously all at once.
 
  @param objects The array of objects to save.
@@ -389,7 +389,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)saveAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Saves a collection of objects *synchronously* all at once and sets an error if necessary.
 
  @param objects The array of objects to save.
@@ -399,7 +399,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)saveAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
-/*!
+/**
  @abstract Saves a collection of objects all at once *asynchronously*.
 
  @param objects The array of objects to save.
@@ -408,7 +408,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BFTask PF_GENERIC(NSNumber *)*)saveAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
-/*!
+/**
  @abstract Saves a collection of objects all at once `asynchronously` and executes the block when done.
 
  @param objects The array of objects to save.
@@ -436,7 +436,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Deleting Many Objects
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* deletes a collection of objects all at once.
 
  @param objects The array of objects to delete.
@@ -445,7 +445,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)deleteAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* deletes a collection of objects all at once and sets an error if necessary.
 
  @param objects The array of objects to delete.
@@ -455,14 +455,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)deleteAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
-/*!
+/**
  @abstract Deletes a collection of objects all at once asynchronously.
  @param objects The array of objects to delete.
  @returns The task that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)deleteAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
-/*!
+/**
  @abstract Deletes a collection of objects all at once *asynchronously* and executes the block when done.
 
  @param objects The array of objects to delete.
@@ -490,7 +490,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Getting an Object
 ///--------------------------------------
 
-/*!
+/**
  @abstract Gets whether the `PFObject` has been fetched.
 
  @returns `YES` if the PFObject is new or has been fetched or refreshed, otherwise `NO`.
@@ -499,14 +499,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
 #if PARSE_IOS_ONLY
 
-/*!
+/**
  @abstract Refreshes the PFObject with the current data from the server.
 
  @deprecated Please use `-fetch` instead.
  */
 - (nullable instancetype)refresh PF_SWIFT_UNAVAILABLE PARSE_DEPRECATED("Please use `-fetch` instead.");
 
-/*!
+/**
  @abstract *Synchronously* refreshes the `PFObject` with the current data from the server and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -515,7 +515,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (nullable instancetype)refresh:(NSError **)error PARSE_DEPRECATED("Please use `-fetch:` instead.");
 
-/*!
+/**
  @abstract *Asynchronously* refreshes the `PFObject` and executes the given callback block.
 
  @param block The block to execute.
@@ -541,37 +541,37 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
 #endif
 
-/*!
+/**
  @abstract *Synchronously* fetches the PFObject with the current data from the server.
  */
 - (nullable instancetype)fetch PF_SWIFT_UNAVAILABLE;
-/*!
+/**
  @abstract *Synchronously* fetches the PFObject with the current data from the server and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
  */
 - (nullable instancetype)fetch:(NSError **)error;
 
-/*!
+/**
  @abstract *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
  */
 - (nullable instancetype)fetchIfNeeded PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
 
  @param error Pointer to an `NSError` that will be set if necessary.
  */
 - (nullable instancetype)fetchIfNeeded:(NSError **)error;
 
-/*!
+/**
  @abstract Fetches the `PFObject` *asynchronously* and sets it as a result for the task.
 
  @returns The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchInBackground;
 
-/*!
+/**
  @abstract Fetches the PFObject *asynchronously* and executes the given callback block.
 
  @param block The block to execute.
@@ -590,7 +590,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)fetchInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
-/*!
+/**
  @abstract Fetches the `PFObject` data *asynchronously* if isDataAvailable is `NO`,
  then sets it as a result for the task.
 
@@ -598,7 +598,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchIfNeededInBackground;
 
-/*!
+/**
  @abstract Fetches the `PFObject` data *asynchronously* if <isDataAvailable> is `NO`, then calls the callback block.
 
  @param block The block to execute.
@@ -621,14 +621,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Getting Many Objects
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server.
 
  @param objects The list of objects to fetch.
  */
 + (nullable NSArray PF_GENERIC(__kindof PFObject *)*)fetchAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server
  and sets an error if it occurs.
 
@@ -638,13 +638,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (nullable NSArray PF_GENERIC(__kindof PFObject *)*)fetchAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects
                                                         error:(NSError **)error;
 
-/*!
+/**
  @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server.
  @param objects The list of objects to fetch.
  */
 + (nullable NSArray PF_GENERIC(__kindof PFObject *)*)fetchAllIfNeeded:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* fetches all of the `PFObject` objects with the current data from the server
  and sets an error if it occurs.
 
@@ -654,7 +654,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (nullable NSArray PF_GENERIC(__kindof PFObject *)*)fetchAllIfNeeded:(nullable NSArray PF_GENERIC(PFObject *)*)objects
                                                                 error:(NSError **)error;
 
-/*!
+/**
  @abstract Fetches all of the `PFObject` objects with the current data from the server *asynchronously*.
 
  @param objects The list of objects to fetch.
@@ -663,7 +663,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BFTask PF_GENERIC(NSArray<__kindof PFObject *> *)*)fetchAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
-/*!
+/**
  @abstract Fetches all of the `PFObject` objects with the current data from the server *asynchronously*
  and calls the given block.
 
@@ -689,7 +689,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                       target:(nullable id)target
                     selector:(nullable SEL)selector;
 
-/*!
+/**
  @abstract Fetches all of the `PFObject` objects with the current data from the server *asynchronously*.
 
  @param objects The list of objects to fetch.
@@ -698,7 +698,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BFTask PF_GENERIC(NSArray<__kindof PFObject *> *)*)fetchAllIfNeededInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
-/*!
+/**
  @abstract Fetches all of the PFObjects with the current data from the server *asynchronously*
  and calls the given block.
 
@@ -728,13 +728,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Fetching From Local Datastore
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* loads data from the local datastore into this object,
  if it has not been fetched from the server already.
  */
 - (nullable instancetype)fetchFromLocalDatastore PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* loads data from the local datastore into this object, if it has not been fetched
  from the server already.
 
@@ -745,7 +745,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (nullable instancetype)fetchFromLocalDatastore:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* loads data from the local datastore into this object,
  if it has not been fetched from the server already.
 
@@ -753,7 +753,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchFromLocalDatastoreInBackground;
 
-/*!
+/**
  @abstract *Asynchronously* loads data from the local datastore into this object,
  if it has not been fetched from the server already.
 
@@ -766,14 +766,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Deleting an Object
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* deletes the `PFObject`.
 
  @returns Returns whether the delete succeeded.
  */
 - (BOOL)delete PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* deletes the `PFObject` and sets an error if it occurs.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -782,14 +782,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BOOL)delete:(NSError **)error;
 
-/*!
+/**
  @abstract Deletes the `PFObject` *asynchronously*.
 
  @returns The task that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)deleteInBackground;
 
-/*!
+/**
  @abstract Deletes the `PFObject` *asynchronously* and executes the given callback block.
 
  @param block The block to execute.
@@ -809,7 +809,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)deleteInBackgroundWithTarget:(nullable id)target
                             selector:(nullable SEL)selector;
 
-/*!
+/**
  @abstract Deletes this object from the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
 
@@ -832,7 +832,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Dirtiness
 ///--------------------------------------
 
-/*!
+/**
  @abstract Gets whether any key-value pair in this object (or its children)
  has been added/updated/removed and not saved yet.
 
@@ -840,7 +840,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 @property (nonatomic, assign, readonly, getter=isDirty) BOOL dirty;
 
-/*!
+/**
  @abstract Get whether a value associated with a key has been added/updated/removed and not saved yet.
 
  @param key The key to check for
@@ -853,7 +853,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Pinning
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -869,7 +869,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BOOL)pin PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -887,7 +887,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BOOL)pin:(NSError **)error;
 
-/*!
+/**
  @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -903,7 +903,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BOOL)pinWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* stores the object and every object it points to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -921,7 +921,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)pinWithName:(NSString *)name
               error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -937,7 +937,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BFTask PF_GENERIC(NSNumber *)*)pinInBackground;
 
-/*!
+/**
  @abstract *Asynchronously* stores the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -954,7 +954,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)pinInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract *Asynchronously* stores the object and every object it points to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -970,7 +970,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BFTask PF_GENERIC(NSNumber *)*)pinInBackgroundWithName:(NSString *)name;
 
-/*!
+/**
  @abstract *Asynchronously* stores the object and every object it points to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -990,7 +990,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Pinning Many Objects
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1008,7 +1008,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)pinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1027,7 +1027,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)pinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
-/*!
+/**
  @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -1044,7 +1044,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)pinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects withName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* stores the objects and every object they point to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -1064,7 +1064,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
       withName:(NSString *)name
          error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1082,7 +1082,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BFTask PF_GENERIC(NSNumber *)*)pinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
-/*!
+/**
  @abstract *Asynchronously* stores the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1100,7 +1100,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (void)pinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects block:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract *Asynchronously* stores the objects and every object they point to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -1117,7 +1117,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BFTask PF_GENERIC(NSNumber *)*)pinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects withName:(NSString *)name;
 
-/*!
+/**
  @abstract *Asynchronously* stores the objects and every object they point to in the local datastore, recursively.
 
  @discussion If those other objects have not been fetched from Parse, they will not be stored. However,
@@ -1140,7 +1140,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Unpinning
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1151,7 +1151,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BOOL)unpin PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1164,7 +1164,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BOOL)unpin:(NSError **)error;
 
-/*!
+/**
  @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively.
 
  @param name The name of the pin.
@@ -1175,7 +1175,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BOOL)unpinWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* removes the object and every object it points to in the local datastore, recursively.
 
  @param name    The name of the pin.
@@ -1188,7 +1188,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)unpinWithName:(NSString *)name
                 error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1199,7 +1199,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BFTask PF_GENERIC(NSNumber *)*)unpinInBackground;
 
-/*!
+/**
  @abstract *Asynchronously* removes the object and every object it points to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1211,7 +1211,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)unpinInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract *Asynchronously* removes the object and every object it points to in the local datastore, recursively.
 
  @param name The name of the pin.
@@ -1222,7 +1222,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (BFTask PF_GENERIC(NSNumber *)*)unpinInBackgroundWithName:(NSString *)name;
 
-/*!
+/**
  @abstract *Asynchronously* removes the object and every object it points to in the local datastore, recursively.
 
  @param name    The name of the pin.
@@ -1237,7 +1237,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /// @name Unpinning Many Objects
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1247,7 +1247,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)unpinAllObjects PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1259,7 +1259,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)unpinAllObjects:(NSError **)error;
 
-/*!
+/**
  @abstract *Synchronously* removes all objects with the specified pin name.
 
  @param name    The name of the pin.
@@ -1268,7 +1268,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)unpinAllObjectsWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* removes all objects with the specified pin name.
 
  @param name    The name of the pin.
@@ -1279,7 +1279,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (BOOL)unpinAllObjectsWithName:(NSString *)name
                           error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1289,7 +1289,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllObjectsInBackground;
 
-/*!
+/**
  @abstract *Asynchronously* removes all objects in the local datastore
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1300,7 +1300,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (void)unpinAllObjectsInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract *Asynchronously* removes all objects with the specified pin name.
 
  @param name    The name of the pin.
@@ -1309,7 +1309,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllObjectsInBackgroundWithName:(NSString *)name;
 
-/*!
+/**
  @abstract *Asynchronously* removes all objects with the specified pin name.
 
  @param name    The name of the pin.
@@ -1318,7 +1318,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (void)unpinAllObjectsInBackgroundWithName:(NSString *)name block:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1331,7 +1331,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)unpinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1345,7 +1345,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)unpinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects error:(NSError **)error;
 
-/*!
+/**
  @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively.
 
  @param objects The objects.
@@ -1357,7 +1357,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BOOL)unpinAll:(nullable NSArray PF_GENERIC(PFObject *)*)objects withName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* removes the objects and every object they point to in the local datastore, recursively.
 
  @param objects The objects.
@@ -1372,7 +1372,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
         withName:(NSString *)name
            error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* removes the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1385,7 +1385,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects;
 
-/*!
+/**
  @abstract *Asynchronously* removes the objects and every object they point to in the local datastore, recursively,
  using a default pin name: `PFObjectDefaultPin`.
 
@@ -1398,7 +1398,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (void)unpinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects block:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract *Asynchronously* removes the objects and every object they point to in the local datastore, recursively.
 
  @param objects The objects.
@@ -1410,7 +1410,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects withName:(NSString *)name;
 
-/*!
+/**
  @abstract *Asynchronously* removes the objects and every object they point to in the local datastore, recursively.
 
  @param objects The objects.

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -80,7 +80,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
- Calling <isDataAvailable> on this object will return `NO` until <fetchIfNeeded> has been called.
+ Calling `dataAvailable` on this object will return `NO` until `-fetchIfNeeded` has been called.
  No network request will be made.
 
  @param className The object's class.
@@ -135,6 +135,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  Returns the value associated with a given key.
 
  @param key The key for which to return the corresponding value.
+
+ @see -objectForKeyedSubscript:
  */
 - (nullable id)objectForKey:(NSString *)key;
 
@@ -147,7 +149,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param key The key for `object`.
  Raises an `NSInvalidArgumentException` if `key` is `nil`.
 
- @see setObject:forKeyedSubscript:
+ @see -setObject:forKeyedSubscript:
  */
 - (void)setObject:(id)object forKey:(NSString *)key;
 
@@ -166,7 +168,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @param key The key for which to return the corresponding value.
 
- @see objectForKey:
+ @see -objectForKey:
  */
 - (nullable id)objectForKeyedSubscript:(NSString *)key;
 
@@ -182,23 +184,23 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @param key The key for `object`.
  Raises an `NSInvalidArgumentException` if `key` is `nil`.
 
- @see setObject:forKey:
+ @see -setObject:forKey:
  */
 - (void)setObject:(id)object forKeyedSubscript:(NSString *)key;
 
 /**
- Returns the relation object associated with the given key.
+ Returns the instance of `PFRelation` class associated with the given key.
 
  @param key The key that the relation is associated with.
  */
 - (PFRelation *)relationForKey:(NSString *)key;
 
 /**
- Returns the relation object associated with the given key.
+ Returns the instance of `PFRelation` class associated with the given key.
 
  @param key The key that the relation is associated with.
 
- @deprecated Please use `[PFObject relationForKey:]` instead.
+ @deprecated Please use `PFObject.-relationForKey:` instead.
  */
 - (PFRelation *)relationforKey:(NSString *)key PARSE_DEPRECATED("Please use -relationForKey: instead.");
 
@@ -305,7 +307,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 /**
  *Synchronously* saves the `PFObject` and sets an error if it occurs.
 
- @param error Pointer to an NSError that will be set if necessary.
+ @param error Pointer to an `NSError` that will be set if necessary.
 
  @return Returns whether the save succeeded.
  */
@@ -348,7 +350,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  Objects saved with this method will be stored locally in an on-disk cache until they can be delivered to Parse.
  They will be sent immediately if possible. Otherwise, they will be sent the next time a network connection is
  available. Objects saved this way will persist even after the app is closed, in which case they will be sent the
- next time the app is opened. If more than 10MB of data is waiting to be sent, subsequent calls to <saveEventually>
+ next time the app is opened. If more than 10MB of data is waiting to be sent, subsequent calls to `-saveEventually`
  will cause old saves to be silently discarded until the connection can be re-established, and the queued objects
  can be saved.
 
@@ -367,7 +369,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  Objects saved with this method will be stored locally in an on-disk cache until they can be delivered to Parse.
  They will be sent immediately if possible. Otherwise, they will be sent the next time a network connection is
  available. Objects saved this way will persist even after the app is closed, in which case they will be sent the
- next time the app is opened. If more than 10MB of data is waiting to be sent, subsequent calls to <saveEventually>
+ next time the app is opened. If more than 10MB of data is waiting to be sent, subsequent calls to `-saveEventually:`
  will cause old saves to be silently discarded until the connection can be re-established, and the queued objects
  can be saved.
 
@@ -553,12 +555,12 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (nullable instancetype)fetch:(NSError **)error;
 
 /**
- *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
+ *Synchronously* fetches the `PFObject` data from the server if `dataAvailable` is `NO`.
  */
 - (nullable instancetype)fetchIfNeeded PF_SWIFT_UNAVAILABLE;
 
 /**
- *Synchronously* fetches the `PFObject` data from the server if <isDataAvailable> is `NO`.
+ *Synchronously* fetches the `PFObject` data from the server if `dataAvailable` is `NO`.
 
  @param error Pointer to an `NSError` that will be set if necessary.
  */
@@ -572,7 +574,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchInBackground;
 
 /**
- Fetches the PFObject *asynchronously* and executes the given callback block.
+ Fetches the `PFObject` *asynchronously* and executes the given callback block.
 
  @param block The block to execute.
  It should have the following argument signature: `^(PFObject *object, NSError *error)`.
@@ -591,7 +593,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)fetchInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
 /**
- Fetches the `PFObject` data *asynchronously* if isDataAvailable is `NO`,
+ Fetches the `PFObject` data *asynchronously* if `dataAvailable` is `NO`,
  then sets it as a result for the task.
 
  @return The task that encapsulates the work being done.
@@ -599,7 +601,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask PF_GENERIC(__kindof PFObject *)*)fetchIfNeededInBackground;
 
 /**
- Fetches the `PFObject` data *asynchronously* if <isDataAvailable> is `NO`, then calls the callback block.
+ Fetches the `PFObject` data *asynchronously* if `dataAvailable` is `NO`, then calls the callback block.
 
  @param block The block to execute.
  It should have the following argument signature: `^(PFObject *object, NSError *error)`.
@@ -607,7 +609,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)fetchIfNeededInBackgroundWithBlock:(nullable PFObjectResultBlock)block;
 
 /*
- Fetches the PFObject's data asynchronously if isDataAvailable is false, then calls the callback.
+ Fetches the PFObject's data asynchronously if `dataAvailable` is `NO`, then calls the callback.
 
  @param target The target on which the selector will be called.
  @param selector The selector to call.
@@ -739,7 +741,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  from the server already.
 
  If the object is not stored in the local datastore, this `error` will be set to
- return kPFErrorCacheMiss.
+ return `kPFErrorCacheMiss`.
 
  @param error Pointer to an `NSError` that will be set if necessary.
  */
@@ -820,8 +822,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  Delete instructions made with this method will be stored locally in an on-disk cache until they can be transmitted
  to Parse. They will be sent immediately if possible. Otherwise, they will be sent the next time a network connection
  is available. Delete requests will persist even after the app is closed, in which case they will be sent the
- next time the app is opened. If more than 10MB of <saveEventually> or <deleteEventually> commands are waiting
- to be sent, subsequent calls to <saveEventually> or <deleteEventually> will cause old requests to be silently discarded
+ next time the app is opened. If more than 10MB of `-saveEventually` or `-deleteEventually` commands are waiting
+ to be sent, subsequent calls to `-saveEventually` or `-deleteEventually` will cause old requests to be silently discarded
  until the connection can be re-established, and the queued requests can go through.
 
  @return The task that encapsulates the work being done.
@@ -859,13 +861,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `-fetchFromLocalDatastore` on it.
 
  @return Returns whether the pin succeeded.
 
- @see unpin:
- @see PFObjectDefaultPin
+ @see `-unpin:`
+ @see `PFObjectDefaultPin`
  */
 - (BOOL)pin PF_SWIFT_UNAVAILABLE;
 
@@ -875,15 +877,15 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `-fetchFromLocalDatastore` on it.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
  @return Returns whether the pin succeeded.
 
- @see unpin:
- @see PFObjectDefaultPin
+ @see `-unpin:`
+ @see `PFObjectDefaultPin`
  */
 - (BOOL)pin:(NSError **)error;
 
@@ -892,14 +894,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `-fetchFromLocalDatastore` on it.
 
  @param name The name of the pin.
 
  @return Returns whether the pin succeeded.
 
- @see unpinWithName:
+ @see `-unpinWithName:`
  */
 - (BOOL)pinWithName:(NSString *)name PF_SWIFT_UNAVAILABLE;
 
@@ -908,15 +910,15 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `-fetchFromLocalDatastore` on it.
 
  @param name    The name of the pin.
  @param error   Pointer to an `NSError` that will be set if necessary.
 
  @return Returns whether the pin succeeded.
 
- @see unpinWithName:
+ @see `-unpinWithName:`
  */
 - (BOOL)pinWithName:(NSString *)name
               error:(NSError **)error;
@@ -927,13 +929,13 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `-fetchFromLocalDatastore` on it.
 
  @return The task that encapsulates the work being done.
 
- @see unpinInBackground
- @see PFObjectDefaultPin
+ @see `-unpinInBackground`
+ @see `PFObjectDefaultPin`
  */
 - (BFTask PF_GENERIC(NSNumber *)*)pinInBackground;
 
@@ -943,14 +945,14 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `-fetchFromLocalDatastore` on it.
 
  @param block The block to execute.
  It should have the following argument signature: `^(BOOL succeeded, NSError *error)`.
 
- @see unpinInBackgroundWithBlock:
- @see PFObjectDefaultPin
+ @see `-unpinInBackgroundWithBlock:`
+ @see `PFObjectDefaultPin`
  */
 - (void)pinInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
@@ -959,8 +961,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `-fetchFromLocalDatastore on it.
 
  @param name The name of the pin.
 
@@ -975,8 +977,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- <[PFObject objectWithoutDataWithClassName:objectId:]> and then call <fetchFromLocalDatastore> on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `-fetchFromLocalDatastore` on it.
 
  @param name    The name of the pin.
  @param block   The block to execute.
@@ -996,8 +998,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `fetchFromLocalDatastore:` on it.
 
  @param objects The objects to be pinned.
 
@@ -1014,8 +1016,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `fetchFromLocalDatastore:` on it.
 
  @param objects The objects to be pinned.
  @param error   Pointer to an `NSError` that will be set if necessary.
@@ -1032,8 +1034,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `fetchFromLocalDatastore:` on it.
 
  @param objects The objects to be pinned.
  @param name    The name of the pin.
@@ -1049,8 +1051,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `fetchFromLocalDatastore:` on it.
 
  @param objects The objects to be pinned.
  @param name    The name of the pin.
@@ -1070,8 +1072,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `fetchFromLocalDatastore:` on it.
 
  @param objects The objects to be pinned.
 
@@ -1088,8 +1090,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `fetchFromLocalDatastore:` on it.
 
  @param objects The objects to be pinned.
  @param block   The block to execute.
@@ -1105,8 +1107,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `fetchFromLocalDatastore:` on it.
 
  @param objects     The objects to be pinned.
  @param name        The name of the pin.
@@ -1122,8 +1124,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  If those other objects have not been fetched from Parse, they will not be stored. However,
  if they have changed data, all the changes will be retained. To get the objects back later, you can
- use a <PFQuery> that uses <[PFQuery fromLocalDatastore]>, or you can create an unfetched pointer with
- `[PFObject objectWithoutDataWithClassName:objectId:]` and then call `fetchFromLocalDatastore:` on it.
+ use a `PFQuery` that uses `PFQuery.-fromLocalDatastore`, or you can create an unfetched pointer with
+ `+objectWithoutDataWithClassName:objectId:` and then call `fetchFromLocalDatastore:` on it.
 
  @param objects     The objects to be pinned.
  @param name        The name of the pin.

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -135,7 +135,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
  @param taskStart - A block that is called when all of the objects are ready.
  It can return a promise that all of the queues will then wait on.
  @param objects - The objects that this operation affects.
- @returns - Returns a promise that is fulfilled once the promise returned by the
+ @return - Returns a promise that is fulfilled once the promise returned by the
  block is fulfilled.
  */
 + (BFTask *)_enqueue:(BFTask *(^)(BFTask *toAwait))taskStart forObjects:(NSArray *)objects {
@@ -1058,7 +1058,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 /**
  Enqueues saveEventually operation asynchronously.
 
- @returns A task which result is a saveEventually task.
+ @return A task which result is a saveEventually task.
  */
 - (BFTask *)_enqueueSaveEventuallyWithChildren:(BOOL)saveChildren {
     return [_eventuallyTaskQueue enqueue:^BFTask *(BFTask *toAwait) {
@@ -1192,7 +1192,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 }
 
 /**
- @returns YES if there's unsaved changes in this object. This complements ivar `dirty` for `isDirty` check.
+ @return YES if there's unsaved changes in this object. This complements ivar `dirty` for `isDirty` check.
  */
 - (BOOL)_hasChanges {
     @synchronized (lock) {
@@ -1201,7 +1201,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 }
 
 /**
- @returns YES if this PFObject has operations in operationSetQueue that haven't been completed yet,
+ @return YES if this PFObject has operations in operationSetQueue that haven't been completed yet,
  NO if there are no operations in the operationSetQueue.
  */
 - (BOOL)_hasOutstandingOperations {

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -58,7 +58,7 @@
 #import "ParseInternal.h"
 #import "Parse_Private.h"
 
-/*!
+/**
  Checks if an object can be used as a value for PFObject.
  */
 static void PFObjectAssertValueIsKindOfValidClass(id object) {
@@ -113,14 +113,14 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     [[self subclassingController] unregisterSubclass:subclass];
 }
 
-/*!
+/**
  Returns the object that should be used to synchronize all internal data access.
  */
 - (NSObject *)lock {
     return lock;
 }
 
-/*!
+/**
  Blocks until all outstanding operations have completed.
  */
 - (void)waitUntilFinished {
@@ -129,7 +129,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }] waitForResult:nil];
 }
 
-/*!
+/**
  For operations that need to be put into multiple objects queues, like saveAll
  and fetchAll, this method does the nasty work.
  @param taskStart - A block that is called when all of the objects are ready.
@@ -193,7 +193,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 #pragma mark - Children helpers
 ///--------------------------------------
 
-/*!
+/**
  Finds all of the objects that are reachable from child, including child itself,
  and adds them to the given mutable array.  It traverses arrays and json objects.
  @param node  An kind object to search for children.
@@ -725,7 +725,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return;
 }
 
-/*!
+/**
  Checks if Parse class name could be used to initialize a given instance of PFObject or it's subclass.
  */
 + (void)_assertValidInstanceClassName:(NSString *)className {
@@ -792,7 +792,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return result;
 }
 
-/*!
+/**
  Creates a PFObject from a dictionary object.
 
  @param dictionary Undecoded dictionary.
@@ -815,7 +815,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return object;
 }
 
-/*!
+/**
  When the app was previously a non-LDS app and want to enable LDS, currentUser and currentInstallation
  will be discarded if we don't migrate them. This is a helper method to migrate user/installation
  from disk to pin.
@@ -828,7 +828,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return [self _migrateObjectInBackgroundFromFile:fileName toPin:pinName usingMigrationBlock:nil];
 }
 
-/*!
+/**
  When the app was previously a non-LDS app and want to enable LDS, currentUser and currentInstallation
  will be discarded if we don't migrate them. This is a helper method to migrate user/installation
  from disk to pin.
@@ -873,7 +873,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 #pragma mark - REST operations
 ///--------------------------------------
 
-/*!
+/**
  Encodes parse object into NSDictionary suitable for persisting into LDS.
  */
 - (NSDictionary *)RESTDictionaryWithObjectEncoder:(PFEncoder *)objectEncoder
@@ -1055,7 +1055,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 #pragma mark - Eventually Helper
 ///--------------------------------------
 
-/*!
+/**
  Enqueues saveEventually operation asynchronously.
 
  @returns A task which result is a saveEventually task.
@@ -1118,7 +1118,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 }
 
 
-/*!
+/**
  Enqueues the saveEventually PFOperationSet in PFObject taskQueue
  */
 - (BFTask *)_enqueueSaveEventuallyOperationAsync:(PFOperationSet *)operationSet {
@@ -1155,7 +1155,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }
 }
 
-/*!
+/**
  performOperation:forKey: is like setObject:forKey, but instead of just taking a
  new value, it takes a PFFieldOperation that modifies the value.
  */
@@ -1182,7 +1182,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return NO;
 }
 
-/*!
+/**
  Returns the set of PFFieldOperations that will be sent in the next save.
  */
 - (PFOperationSet *)unsavedChanges {
@@ -1191,7 +1191,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }
 }
 
-/*!
+/**
  @returns YES if there's unsaved changes in this object. This complements ivar `dirty` for `isDirty` check.
  */
 - (BOOL)_hasChanges {
@@ -1200,7 +1200,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }
 }
 
-/*!
+/**
  @returns YES if this PFObject has operations in operationSetQueue that haven't been completed yet,
  NO if there are no operations in the operationSetQueue.
  */

--- a/Parse/PFProduct.h
+++ b/Parse/PFProduct.h
@@ -32,36 +32,36 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFProduct : PFObject<PFSubcla
 ///--------------------------------------
 
 /**
- @abstract The product identifier of the product.
+ The product identifier of the product.
 
  @discussion This should match the product identifier in iTunes Connect exactly.
  */
 @property (nullable, nonatomic, strong) NSString *productIdentifier;
 
 /**
- @abstract The icon of the product.
+ The icon of the product.
  */
 @property (nullable, nonatomic, strong) PFFile *icon;
 
 /**
- @abstract The title of the product.
+ The title of the product.
  */
 @property (nullable, nonatomic, strong) NSString *title;
 
 /**
- @abstract The subtitle of the product.
+ The subtitle of the product.
  */
 @property (nullable, nonatomic, strong) NSString *subtitle;
 
 /**
- @abstract The order in which the product information is displayed in <PFProductTableViewController>.
+ The order in which the product information is displayed in <PFProductTableViewController>.
 
  @discussion The product with a smaller order is displayed earlier in the <PFProductTableViewController>.
  */
 @property (nullable, nonatomic, strong) NSNumber *order;
 
 /**
- @abstract The name of the associated download.
+ The name of the associated download.
 
  @discussion If there is no downloadable asset, it should be `nil`.
  */

--- a/Parse/PFProduct.h
+++ b/Parse/PFProduct.h
@@ -54,9 +54,9 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFProduct : PFObject<PFSubcla
 @property (nullable, nonatomic, strong) NSString *subtitle;
 
 /**
- The order in which the product information is displayed in <PFProductTableViewController>.
+ The order in which the product information is displayed in `PFProductTableViewController`.
 
- The product with a smaller order is displayed earlier in the <PFProductTableViewController>.
+ The product with a smaller order is displayed earlier in the `PFProductTableViewController`.
  */
 @property (nullable, nonatomic, strong) NSNumber *order;
 

--- a/Parse/PFProduct.h
+++ b/Parse/PFProduct.h
@@ -34,7 +34,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFProduct : PFObject<PFSubcla
 /**
  The product identifier of the product.
 
- @discussion This should match the product identifier in iTunes Connect exactly.
+ This should match the product identifier in iTunes Connect exactly.
  */
 @property (nullable, nonatomic, strong) NSString *productIdentifier;
 
@@ -56,14 +56,14 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFProduct : PFObject<PFSubcla
 /**
  The order in which the product information is displayed in <PFProductTableViewController>.
 
- @discussion The product with a smaller order is displayed earlier in the <PFProductTableViewController>.
+ The product with a smaller order is displayed earlier in the <PFProductTableViewController>.
  */
 @property (nullable, nonatomic, strong) NSNumber *order;
 
 /**
  The name of the associated download.
 
- @discussion If there is no downloadable asset, it should be `nil`.
+ If there is no downloadable asset, it should be `nil`.
  */
 @property (nullable, nonatomic, strong, readonly) NSString *downloadName;
 

--- a/Parse/PFProduct.h
+++ b/Parse/PFProduct.h
@@ -18,7 +18,7 @@ PF_WATCH_UNAVAILABLE_WARNING
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  The `PFProduct` class represents an in-app purchase product on the Parse server.
  By default, products can only be created via the Data Browser. Saving a `PFProduct` will result in error.
  However, the products' metadata information can be queried and viewed.
@@ -31,36 +31,36 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFProduct : PFObject<PFSubcla
 /// @name Product-specific Properties
 ///--------------------------------------
 
-/*!
+/**
  @abstract The product identifier of the product.
 
  @discussion This should match the product identifier in iTunes Connect exactly.
  */
 @property (nullable, nonatomic, strong) NSString *productIdentifier;
 
-/*!
+/**
  @abstract The icon of the product.
  */
 @property (nullable, nonatomic, strong) PFFile *icon;
 
-/*!
+/**
  @abstract The title of the product.
  */
 @property (nullable, nonatomic, strong) NSString *title;
 
-/*!
+/**
  @abstract The subtitle of the product.
  */
 @property (nullable, nonatomic, strong) NSString *subtitle;
 
-/*!
+/**
  @abstract The order in which the product information is displayed in <PFProductTableViewController>.
 
  @discussion The product with a smaller order is displayed earlier in the <PFProductTableViewController>.
  */
 @property (nullable, nonatomic, strong) NSNumber *order;
 
-/*!
+/**
  @abstract The name of the associated download.
 
  @discussion If there is no downloadable asset, it should be `nil`.

--- a/Parse/PFPurchase.h
+++ b/Parse/PFPurchase.h
@@ -23,14 +23,14 @@ typedef void (^PFPurchaseProductObservationBlock)(SKPaymentTransaction *transact
 typedef void (^PFPurchaseBuyProductResultBlock)(NSError *__nullable error);
 typedef void (^PFPurchaseDownloadAssetResultBlock)(NSString *__nullable filePath, NSError *__nullable error);
 
-/*!
+/**
  `PFPurchase` provides a set of APIs for working with in-app purchases.
 
  This class is currently for iOS only.
  */
 PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 
-/*!
+/**
  @abstract Add application logic block which is run when buying a product.
 
  @discussion This method should be called once for each product, and should be called before
@@ -43,7 +43,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
  */
 + (void)addObserverForProduct:(NSString *)productIdentifier block:(PFPurchaseProductObservationBlock)block;
 
-/*!
+/**
  @abstract *Asynchronously* initiates the purchase for the product.
 
  @param productIdentifier the product identifier
@@ -51,7 +51,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
  */
 + (void)buyProduct:(NSString *)productIdentifier block:(nullable PFPurchaseBuyProductResultBlock)block;
 
-/*!
+/**
  @abstract *Asynchronously* download the purchased asset, which is stored on Parse's server.
 
  @discussion Parse verifies the receipt with Apple and delivers the content only if the receipt is valid.
@@ -62,7 +62,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 + (void)downloadAssetForTransaction:(SKPaymentTransaction *)transaction
                          completion:(PFPurchaseDownloadAssetResultBlock)completion;
 
-/*!
+/**
  @abstract *Asynchronously* download the purchased asset, which is stored on Parse's server.
 
  @discussion Parse verifies the receipt with Apple and delivers the content only if the receipt is valid.
@@ -75,7 +75,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
                          completion:(PFPurchaseDownloadAssetResultBlock)completion
                            progress:(nullable PFProgressBlock)progress;
 
-/*!
+/**
  @abstract *Asynchronously* restore completed transactions for the current user.
 
  @discussion Only nonconsumable purchases are restored. If observers for the products have been added before
@@ -86,7 +86,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
  */
 + (void)restore;
 
-/*!
+/**
  @abstract Returns a content path of the asset of a product, if it was purchased and downloaded.
 
  @discussion To download and verify purchases use <downloadAssetForTransaction:completion:>.

--- a/Parse/PFPurchase.h
+++ b/Parse/PFPurchase.h
@@ -34,7 +34,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
  Add application logic block which is run when buying a product.
 
  This method should be called once for each product, and should be called before
- calling <buyProduct:block:>. All invocations to <addObserverForProduct:block:> should happen within
+ calling `+buyProduct:block:`. All invocations to `+addObserverForProduct:block:` should happen within
  the same method, and on the main thread. It is recommended to place all invocations of this method
  in `application:didFinishLaunchingWithOptions:`.
 
@@ -89,7 +89,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 /**
  Returns a content path of the asset of a product, if it was purchased and downloaded.
 
- To download and verify purchases use <downloadAssetForTransaction:completion:>.
+ To download and verify purchases use `+downloadAssetForTransaction:completion:`.
 
  @warning This method will return `nil`, if the purchase wasn't verified or if the asset was not downloaded.
  */

--- a/Parse/PFPurchase.h
+++ b/Parse/PFPurchase.h
@@ -33,7 +33,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 /**
  Add application logic block which is run when buying a product.
 
- @discussion This method should be called once for each product, and should be called before
+ This method should be called once for each product, and should be called before
  calling <buyProduct:block:>. All invocations to <addObserverForProduct:block:> should happen within
  the same method, and on the main thread. It is recommended to place all invocations of this method
  in `application:didFinishLaunchingWithOptions:`.
@@ -54,7 +54,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 /**
  *Asynchronously* download the purchased asset, which is stored on Parse's server.
 
- @discussion Parse verifies the receipt with Apple and delivers the content only if the receipt is valid.
+ Parse verifies the receipt with Apple and delivers the content only if the receipt is valid.
 
  @param transaction the transaction, which contains the receipt.
  @param completion the completion block.
@@ -65,7 +65,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 /**
  *Asynchronously* download the purchased asset, which is stored on Parse's server.
 
- @discussion Parse verifies the receipt with Apple and delivers the content only if the receipt is valid.
+ Parse verifies the receipt with Apple and delivers the content only if the receipt is valid.
 
  @param transaction the transaction, which contains the receipt.
  @param completion the completion block.
@@ -78,7 +78,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 /**
  *Asynchronously* restore completed transactions for the current user.
 
- @discussion Only nonconsumable purchases are restored. If observers for the products have been added before
+ Only nonconsumable purchases are restored. If observers for the products have been added before
  calling this method, invoking the method reruns the application logic associated with the purchase.
 
  @warning This method is only important to developers who want to preserve purchase states across
@@ -89,7 +89,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 /**
  Returns a content path of the asset of a product, if it was purchased and downloaded.
 
- @discussion To download and verify purchases use <downloadAssetForTransaction:completion:>.
+ To download and verify purchases use <downloadAssetForTransaction:completion:>.
 
  @warning This method will return `nil`, if the purchase wasn't verified or if the asset was not downloaded.
  */

--- a/Parse/PFPurchase.h
+++ b/Parse/PFPurchase.h
@@ -31,7 +31,7 @@ typedef void (^PFPurchaseDownloadAssetResultBlock)(NSString *__nullable filePath
 PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 
 /**
- @abstract Add application logic block which is run when buying a product.
+ Add application logic block which is run when buying a product.
 
  @discussion This method should be called once for each product, and should be called before
  calling <buyProduct:block:>. All invocations to <addObserverForProduct:block:> should happen within
@@ -44,7 +44,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 + (void)addObserverForProduct:(NSString *)productIdentifier block:(PFPurchaseProductObservationBlock)block;
 
 /**
- @abstract *Asynchronously* initiates the purchase for the product.
+ *Asynchronously* initiates the purchase for the product.
 
  @param productIdentifier the product identifier
  @param block the completion block.
@@ -52,7 +52,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 + (void)buyProduct:(NSString *)productIdentifier block:(nullable PFPurchaseBuyProductResultBlock)block;
 
 /**
- @abstract *Asynchronously* download the purchased asset, which is stored on Parse's server.
+ *Asynchronously* download the purchased asset, which is stored on Parse's server.
 
  @discussion Parse verifies the receipt with Apple and delivers the content only if the receipt is valid.
 
@@ -63,7 +63,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
                          completion:(PFPurchaseDownloadAssetResultBlock)completion;
 
 /**
- @abstract *Asynchronously* download the purchased asset, which is stored on Parse's server.
+ *Asynchronously* download the purchased asset, which is stored on Parse's server.
 
  @discussion Parse verifies the receipt with Apple and delivers the content only if the receipt is valid.
 
@@ -76,7 +76,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
                            progress:(nullable PFProgressBlock)progress;
 
 /**
- @abstract *Asynchronously* restore completed transactions for the current user.
+ *Asynchronously* restore completed transactions for the current user.
 
  @discussion Only nonconsumable purchases are restored. If observers for the products have been added before
  calling this method, invoking the method reruns the application logic associated with the purchase.
@@ -87,7 +87,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchase : NSObject
 + (void)restore;
 
 /**
- @abstract Returns a content path of the asset of a product, if it was purchased and downloaded.
+ Returns a content path of the asset of a product, if it was purchased and downloaded.
 
  @discussion To download and verify purchases use <downloadAssetForTransaction:completion:>.
 

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -155,7 +155,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  @param message The message to send.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the send succeeded.
+ @return Returns whether the send succeeded.
  */
 + (BOOL)sendPushMessageToChannel:(NSString *)channel
                      withMessage:(NSString *)message
@@ -168,7 +168,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  a letter and contain only letters, numbers, dashes, and underscores.
  @param message The message to send.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)sendPushMessageToChannelInBackground:(NSString *)channel
                                                            withMessage:(NSString *)message;
@@ -210,7 +210,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  @param message The message to send.
  @param error Pointer to an NSError that will be set if necessary.
 
- @returns Returns whether the send succeeded.
+ @return Returns whether the send succeeded.
  */
 + (BOOL)sendPushMessageToQuery:(PFQuery PF_GENERIC(PFInstallation *)*)query
                    withMessage:(NSString *)message
@@ -222,7 +222,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  @param query The query to send to. The query must be a <PFInstallation> query created with <[PFInstallation query]>.
  @param message The message to send.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)sendPushMessageToQueryInBackground:(PFQuery PF_GENERIC(PFInstallation *)*)query
                                                          withMessage:(NSString *)message;
@@ -245,13 +245,13 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the send succeeded.
+ @return Returns whether the send succeeded.
  */
 - (BOOL)sendPush:(NSError **)error;
 
 /**
  *Asynchronously* send this push message.
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)sendPushInBackground;
 
@@ -284,7 +284,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  @param data The data to send.
  @param error Pointer to an NSError that will be set if necessary.
 
- @returns Returns whether the send succeeded.
+ @return Returns whether the send succeeded.
  */
 + (BOOL)sendPushDataToChannel:(NSString *)channel
                      withData:(NSDictionary *)data
@@ -299,7 +299,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  a letter and contain only letters, numbers, dashes, and underscores.
  @param data The data to send.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)sendPushDataToChannelInBackground:(NSString *)channel
                                                            withData:(NSDictionary *)data;
@@ -348,7 +348,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  @param data The data to send.
  @param error Pointer to an NSError that will be set if necessary.
 
- @returns Returns whether the send succeeded.
+ @return Returns whether the send succeeded.
  */
 + (BOOL)sendPushDataToQuery:(PFQuery PF_GENERIC(PFInstallation *)*)query
                    withData:(NSDictionary *)data
@@ -363,7 +363,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  created with <[PFInstallation query]>.
  @param data The data to send.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)sendPushDataToQueryInBackground:(PFQuery PF_GENERIC(PFInstallation *)*)query
                                                          withData:(NSDictionary *)data;
@@ -420,14 +420,14 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns an `NSSet` containing all the channel names this device is subscribed to.
+ @return Returns an `NSSet` containing all the channel names this device is subscribed to.
  */
 + (nullable NSSet PF_GENERIC(NSString *)*)getSubscribedChannels:(NSError **)error;
 
 /**
  *Asynchronously* get all the channels that this device is subscribed to.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSSet<NSString *> *)*)getSubscribedChannelsInBackground;
 
@@ -455,7 +455,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  a letter and contain only letters, numbers, dashes, and underscores.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the subscribe succeeded.
+ @return Returns whether the subscribe succeeded.
  */
 + (BOOL)subscribeToChannel:(NSString *)channel error:(NSError **)error;
 
@@ -465,7 +465,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  @param channel The channel to subscribe to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)subscribeToChannelInBackground:(NSString *)channel;
 
@@ -501,7 +501,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  @param channel The channel to unsubscribe from.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns whether the unsubscribe succeeded.
+ @return Returns whether the unsubscribe succeeded.
  */
 + (BOOL)unsubscribeFromChannel:(NSString *)channel error:(NSError **)error;
 
@@ -510,7 +510,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
  @param channel The channel to unsubscribe from.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)unsubscribeFromChannelInBackground:(NSString *)channel;
 

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -58,7 +58,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Sets an installation query to which this push notification will be sent.
 
- @discussion The query should be created via <[PFInstallation query]> and should not specify a skip, limit, or order.
+ The query should be created via <[PFInstallation query]> and should not specify a skip, limit, or order.
 
  @param query The installation query to set for this push.
  */
@@ -76,7 +76,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Sets an arbitrary data payload for this push notification.
 
- @discussion See the guide for information about the dictionary structure.
+ See the guide for information about the dictionary structure.
 
  @warning This will overwrite any data specified in setMessage.
 
@@ -105,7 +105,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Sets the expiration time for this notification.
 
- @discussion The notification will be sent to devices which are either online
+ The notification will be sent to devices which are either online
  at the time the notification is sent, or which come online before the expiration time is reached.
  Because device clocks are not guaranteed to be accurate,
  most applications should instead use <expireAfterTimeInterval:>.
@@ -119,7 +119,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Sets the time interval after which this notification should expire.
 
- @discussion This notification will be sent to devices which are either online at
+ This notification will be sent to devices which are either online at
  the time the notification is sent, or which come online within the given
  time interval of the notification being received by Parse's server.
  An interval which is less than or equal to zero indicates that the
@@ -137,7 +137,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Date at which to send this push notification. 
  
- @discussion Push notificaitons with this date will be delivered at the local time matching the <PFInstallation.timeZone>.
+ Push notificaitons with this date will be delivered at the local time matching the <PFInstallation.timeZone>.
  
  @warning The date cannot be in the past, and can be up to two weeks in the future.
  */
@@ -277,7 +277,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  *Synchronously* send a push message with arbitrary data to a channel.
 
- @discussion See the guide for information about the dictionary structure.
+ See the guide for information about the dictionary structure.
 
  @param channel The channel to send to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -293,7 +293,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  *Asynchronously* send a push message with arbitrary data to a channel.
 
- @discussion See the guide for information about the dictionary structure.
+ See the guide for information about the dictionary structure.
 
  @param channel The channel to send to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -307,7 +307,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Asynchronously sends a push message with arbitrary data to a channel and calls the given block.
 
- @discussion See the guide for information about the dictionary structure.
+ See the guide for information about the dictionary structure.
 
  @param channel The channel to send to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -322,7 +322,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /*
  *Asynchronously* send a push message with arbitrary data to a channel.
 
- @discussion See the guide for information about the dictionary structure.
+ See the guide for information about the dictionary structure.
 
  @param channel The channel to send to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -341,7 +341,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  *Synchronously* send a push message with arbitrary data to a query.
 
- @discussion See the guide for information about the dictionary structure.
+ See the guide for information about the dictionary structure.
 
  @param query The query to send to. The query must be a <PFInstallation> query
  created with <[PFInstallation query]>.
@@ -357,7 +357,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Asynchronously send a push message with arbitrary data to a query.
 
- @discussion See the guide for information about the dictionary structure.
+ See the guide for information about the dictionary structure.
 
  @param query The query to send to. The query must be a <PFInstallation> query
  created with <[PFInstallation query]>.
@@ -371,7 +371,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  *Asynchronously* sends a push message with arbitrary data to a query and calls the given block.
 
- @discussion See the guide for information about the dictionary structure.
+ See the guide for information about the dictionary structure.
 
  @param query The query to send to. The query must be a <PFInstallation> query
  created with <[PFInstallation query]>.
@@ -391,7 +391,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  A default handler for push notifications while the app is active that
  could be used to mimic the behavior of iOS push notifications while the app is backgrounded or not running.
 
- @discussion Call this from `application:didReceiveRemoteNotification:`.
+ Call this from `application:didReceiveRemoteNotification:`.
  If push has a dictionary containing loc-key and loc-args in the alert,
  we support up to 10 items in loc-args (`NSRangeException` if limit exceeded).
 
@@ -408,7 +408,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Store the device token locally for push notifications.
 
- @discussion Usually called from you main app delegate's `didRegisterForRemoteNotificationsWithDeviceToken:`.
+ Usually called from you main app delegate's `didRegisterForRemoteNotificationsWithDeviceToken:`.
 
  @param deviceToken Either as an `NSData` straight from `application:didRegisterForRemoteNotificationsWithDeviceToken:`
  or as an `NSString` if you converted it yourself.

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  The `PFPush` class defines a push notification that can be sent from a client device.
 
  The preferred way of modifying or retrieving channel subscriptions is to use
- the <PFInstallation> class, instead of the class methods in `PFPush`.
+ the `PFInstallation` class, instead of the class methods in `PFPush`.
  */
 PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
@@ -58,7 +58,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Sets an installation query to which this push notification will be sent.
 
- The query should be created via <[PFInstallation query]> and should not specify a skip, limit, or order.
+ The query should be created via `PFInstallation.+query` and should not specify a skip, limit, or order.
 
  @param query The installation query to set for this push.
  */
@@ -89,7 +89,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
  @param pushToAndroid Whether this push will go to Android devices.
 
- @deprecated Please use a `[PFInstallation query]` with a constraint on deviceType instead.
+ @deprecated Please use a `PFInstallation.+query` with a constraint on deviceType instead.
  */
 - (void)setPushToAndroid:(BOOL)pushToAndroid PARSE_DEPRECATED("Please use a [PFInstallation query] with a constraint on deviceType. This method is deprecated and won't do anything.");
 
@@ -98,7 +98,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
  @param pushToIOS Whether this push will go to iOS devices.
 
- @deprecated Please use a `[PFInstallation query]` with a constraint on deviceType instead.
+ @deprecated Please use a `PFInstallation.+query` with a constraint on deviceType instead.
  */
 - (void)setPushToIOS:(BOOL)pushToIOS PARSE_DEPRECATED("Please use a [PFInstallation query] with a constraint on deviceType. This method is deprecated and won't do anything.");
 
@@ -108,7 +108,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  The notification will be sent to devices which are either online
  at the time the notification is sent, or which come online before the expiration time is reached.
  Because device clocks are not guaranteed to be accurate,
- most applications should instead use <expireAfterTimeInterval:>.
+ most applications should instead use `-expireAfterTimeInterval:`.
 
  @see expireAfterTimeInterval:
 
@@ -135,10 +135,10 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)clearExpiration;
 
 /**
- Date at which to send this push notification. 
- 
- Push notificaitons with this date will be delivered at the local time matching the <PFInstallation.timeZone>.
- 
+ Date at which to send this push notification.
+
+ Push notificaitons with this date will be delivered at the local time matching the `PFInstallation.timeZone`.
+
  @warning The date cannot be in the past, and can be up to two weeks in the future.
  */
 @property (nullable, nonatomic, strong) NSDate *pushDate;
@@ -206,7 +206,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  Send a push message to a query.
 
- @param query The query to send to. The query must be a <PFInstallation> query created with <[PFInstallation query]>.
+ @param query The query to send to. The query must be a `PFInstallation` query created with `PFInstallation.+query`.
  @param message The message to send.
  @param error Pointer to an NSError that will be set if necessary.
 
@@ -219,7 +219,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /**
  *Asynchronously* send a push message to a query.
 
- @param query The query to send to. The query must be a <PFInstallation> query created with <[PFInstallation query]>.
+ @param query The query to send to. The query must be a `PFInstallation` query created with `PFInstallation.+query`.
  @param message The message to send.
 
  @return The task, that encapsulates the work being done.
@@ -343,8 +343,8 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
  See the guide for information about the dictionary structure.
 
- @param query The query to send to. The query must be a <PFInstallation> query
- created with <[PFInstallation query]>.
+ @param query The query to send to. The query must be a `PFInstallation` query
+ created with `PFInstallation.+query`.
  @param data The data to send.
  @param error Pointer to an NSError that will be set if necessary.
 
@@ -359,8 +359,8 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
  See the guide for information about the dictionary structure.
 
- @param query The query to send to. The query must be a <PFInstallation> query
- created with <[PFInstallation query]>.
+ @param query The query to send to. The query must be a `PFInstallation` query
+ created with `PFInstallation.+query`.
  @param data The data to send.
 
  @return The task, that encapsulates the work being done.
@@ -373,8 +373,8 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 
  See the guide for information about the dictionary structure.
 
- @param query The query to send to. The query must be a <PFInstallation> query
- created with <[PFInstallation query]>.
+ @param query The query to send to. The query must be a `PFInstallation` query
+ created with `PFInstallation.+query`.
  @param data The data to send.
  @param block The block to execute.
  It should have the following argument signature: `^(BOOL succeeded, NSError *error)`.

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -40,7 +40,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 ///--------------------------------------
 
 /**
- @abstract Sets the channel on which this push notification will be sent.
+ Sets the channel on which this push notification will be sent.
 
  @param channel The channel to set for this push.
  The channel name must start with a letter and contain only letters, numbers, dashes, and underscores.
@@ -48,7 +48,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)setChannel:(nullable NSString *)channel;
 
 /**
- @abstract Sets the array of channels on which this push notification will be sent.
+ Sets the array of channels on which this push notification will be sent.
 
  @param channels The array of channels to set for this push.
  Each channel name must start with a letter and contain only letters, numbers, dashes, and underscores.
@@ -56,7 +56,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)setChannels:(nullable NSArray PF_GENERIC(NSString *)*)channels;
 
 /**
- @abstract Sets an installation query to which this push notification will be sent.
+ Sets an installation query to which this push notification will be sent.
 
  @discussion The query should be created via <[PFInstallation query]> and should not specify a skip, limit, or order.
 
@@ -65,7 +65,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)setQuery:(nullable PFQuery PF_GENERIC(PFInstallation *)*)query;
 
 /**
- @abstract Sets an alert message for this push notification.
+ Sets an alert message for this push notification.
 
  @warning This will overwrite any data specified in setData.
 
@@ -74,7 +74,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)setMessage:(nullable NSString *)message;
 
 /**
- @abstract Sets an arbitrary data payload for this push notification.
+ Sets an arbitrary data payload for this push notification.
 
  @discussion See the guide for information about the dictionary structure.
 
@@ -85,7 +85,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)setData:(nullable NSDictionary *)data;
 
 /**
- @abstract Sets whether this push will go to Android devices.
+ Sets whether this push will go to Android devices.
 
  @param pushToAndroid Whether this push will go to Android devices.
 
@@ -94,7 +94,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)setPushToAndroid:(BOOL)pushToAndroid PARSE_DEPRECATED("Please use a [PFInstallation query] with a constraint on deviceType. This method is deprecated and won't do anything.");
 
 /**
- @abstract Sets whether this push will go to iOS devices.
+ Sets whether this push will go to iOS devices.
 
  @param pushToIOS Whether this push will go to iOS devices.
 
@@ -103,7 +103,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)setPushToIOS:(BOOL)pushToIOS PARSE_DEPRECATED("Please use a [PFInstallation query] with a constraint on deviceType. This method is deprecated and won't do anything.");
 
 /**
- @abstract Sets the expiration time for this notification.
+ Sets the expiration time for this notification.
 
  @discussion The notification will be sent to devices which are either online
  at the time the notification is sent, or which come online before the expiration time is reached.
@@ -117,7 +117,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)expireAtDate:(nullable NSDate *)date;
 
 /**
- @abstract Sets the time interval after which this notification should expire.
+ Sets the time interval after which this notification should expire.
 
  @discussion This notification will be sent to devices which are either online at
  the time the notification is sent, or which come online within the given
@@ -130,12 +130,12 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)expireAfterTimeInterval:(NSTimeInterval)timeInterval;
 
 /**
- @abstract Clears both expiration values, indicating that the notification should never expire.
+ Clears both expiration values, indicating that the notification should never expire.
  */
 - (void)clearExpiration;
 
 /**
- @abstract Date at which to send this push notification. 
+ Date at which to send this push notification. 
  
  @discussion Push notificaitons with this date will be delivered at the local time matching the <PFInstallation.timeZone>.
  
@@ -148,7 +148,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* send a push message to a channel.
+ *Synchronously* send a push message to a channel.
 
  @param channel The channel to send to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -162,7 +162,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                            error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* send a push message to a channel.
+ *Asynchronously* send a push message to a channel.
 
  @param channel The channel to send to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -174,7 +174,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                                            withMessage:(NSString *)message;
 
 /**
- @abstract *Asynchronously* sends a push message to a channel and calls the given block.
+ *Asynchronously* sends a push message to a channel and calls the given block.
 
  @param channel The channel to send to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -187,7 +187,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                        block:(nullable PFBooleanResultBlock)block;
 
 /*
- @abstract *Asynchronously* send a push message to a channel.
+ *Asynchronously* send a push message to a channel.
 
  @param channel The channel to send to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -204,7 +204,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                     selector:(__nullable SEL)selector;
 
 /**
- @abstract Send a push message to a query.
+ Send a push message to a query.
 
  @param query The query to send to. The query must be a <PFInstallation> query created with <[PFInstallation query]>.
  @param message The message to send.
@@ -217,7 +217,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                          error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* send a push message to a query.
+ *Asynchronously* send a push message to a query.
 
  @param query The query to send to. The query must be a <PFInstallation> query created with <[PFInstallation query]>.
  @param message The message to send.
@@ -228,7 +228,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                                          withMessage:(NSString *)message;
 
 /**
- @abstract *Asynchronously* sends a push message to a query and calls the given block.
+ *Asynchronously* sends a push message to a query and calls the given block.
 
  @param query The query to send to. The query must be a PFInstallation query
  created with [PFInstallation query].
@@ -241,7 +241,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                      block:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract *Synchronously* send this push message.
+ *Synchronously* send this push message.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -250,13 +250,13 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (BOOL)sendPush:(NSError **)error;
 
 /**
- @abstract *Asynchronously* send this push message.
+ *Asynchronously* send this push message.
  @returns The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)sendPushInBackground;
 
 /**
- @abstract *Asynchronously* send this push message and executes the given callback block.
+ *Asynchronously* send this push message and executes the given callback block.
 
  @param block The block to execute.
  It should have the following argument signature: `^(BOOL succeeded, NSError *error)`.
@@ -264,7 +264,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)sendPushInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
 /*
- @abstract *Asynchronously* send this push message and calls the given callback.
+ *Asynchronously* send this push message and calls the given callback.
 
  @param target The object to call selector on.
  @param selector The selector to call.
@@ -275,7 +275,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 - (void)sendPushInBackgroundWithTarget:(__nullable id)target selector:(__nullable SEL)selector;
 
 /**
- @abstract *Synchronously* send a push message with arbitrary data to a channel.
+ *Synchronously* send a push message with arbitrary data to a channel.
 
  @discussion See the guide for information about the dictionary structure.
 
@@ -291,7 +291,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                         error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* send a push message with arbitrary data to a channel.
+ *Asynchronously* send a push message with arbitrary data to a channel.
 
  @discussion See the guide for information about the dictionary structure.
 
@@ -305,7 +305,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                                            withData:(NSDictionary *)data;
 
 /**
- @abstract Asynchronously sends a push message with arbitrary data to a channel and calls the given block.
+ Asynchronously sends a push message with arbitrary data to a channel and calls the given block.
 
  @discussion See the guide for information about the dictionary structure.
 
@@ -320,7 +320,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                     block:(nullable PFBooleanResultBlock)block;
 
 /*
- @abstract *Asynchronously* send a push message with arbitrary data to a channel.
+ *Asynchronously* send a push message with arbitrary data to a channel.
 
  @discussion See the guide for information about the dictionary structure.
 
@@ -339,7 +339,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                  selector:(__nullable SEL)selector;
 
 /**
- @abstract *Synchronously* send a push message with arbitrary data to a query.
+ *Synchronously* send a push message with arbitrary data to a query.
 
  @discussion See the guide for information about the dictionary structure.
 
@@ -355,7 +355,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                       error:(NSError **)error;
 
 /**
- @abstract Asynchronously send a push message with arbitrary data to a query.
+ Asynchronously send a push message with arbitrary data to a query.
 
  @discussion See the guide for information about the dictionary structure.
 
@@ -369,7 +369,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                                          withData:(NSDictionary *)data;
 
 /**
- @abstract *Asynchronously* sends a push message with arbitrary data to a query and calls the given block.
+ *Asynchronously* sends a push message with arbitrary data to a query and calls the given block.
 
  @discussion See the guide for information about the dictionary structure.
 
@@ -388,7 +388,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 ///--------------------------------------
 
 /**
- @abstract A default handler for push notifications while the app is active that
+ A default handler for push notifications while the app is active that
  could be used to mimic the behavior of iOS push notifications while the app is backgrounded or not running.
 
  @discussion Call this from `application:didReceiveRemoteNotification:`.
@@ -406,7 +406,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 ///--------------------------------------
 
 /**
- @abstract Store the device token locally for push notifications.
+ Store the device token locally for push notifications.
 
  @discussion Usually called from you main app delegate's `didRegisterForRemoteNotificationsWithDeviceToken:`.
 
@@ -416,7 +416,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (void)storeDeviceToken:(id)deviceToken;
 
 /**
- @abstract *Synchronously* get all the channels that this device is subscribed to.
+ *Synchronously* get all the channels that this device is subscribed to.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -425,21 +425,21 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (nullable NSSet PF_GENERIC(NSString *)*)getSubscribedChannels:(NSError **)error;
 
 /**
- @abstract *Asynchronously* get all the channels that this device is subscribed to.
+ *Asynchronously* get all the channels that this device is subscribed to.
 
  @returns The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSSet<NSString *> *)*)getSubscribedChannelsInBackground;
 
 /**
- @abstract *Asynchronously* get all the channels that this device is subscribed to.
+ *Asynchronously* get all the channels that this device is subscribed to.
  @param block The block to execute.
  It should have the following argument signature: `^(NSSet *channels, NSError *error)`.
  */
 + (void)getSubscribedChannelsInBackgroundWithBlock:(PFSetResultBlock)block;
 
 /*
- @abstract *Asynchronously* get all the channels that this device is subscribed to.
+ *Asynchronously* get all the channels that this device is subscribed to.
 
  @param target The object to call selector on.
  @param selector The selector to call.
@@ -449,7 +449,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (void)getSubscribedChannelsInBackgroundWithTarget:(id)target selector:(SEL)selector;
 
 /**
- @abstract *Synchrnously* subscribes the device to a channel of push notifications.
+ *Synchrnously* subscribes the device to a channel of push notifications.
 
  @param channel The channel to subscribe to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -460,7 +460,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (BOOL)subscribeToChannel:(NSString *)channel error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* subscribes the device to a channel of push notifications.
+ *Asynchronously* subscribes the device to a channel of push notifications.
 
  @param channel The channel to subscribe to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -470,7 +470,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (BFTask PF_GENERIC(NSNumber *)*)subscribeToChannelInBackground:(NSString *)channel;
 
 /**
- @abstract *Asynchronously* subscribes the device to a channel of push notifications and calls the given block.
+ *Asynchronously* subscribes the device to a channel of push notifications and calls the given block.
 
  @param channel The channel to subscribe to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -481,7 +481,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                  block:(nullable PFBooleanResultBlock)block;
 
 /*
- @abstract *Asynchronously* subscribes the device to a channel of push notifications and calls the given callback.
+ *Asynchronously* subscribes the device to a channel of push notifications and calls the given callback.
 
  @param channel The channel to subscribe to. The channel name must start with
  a letter and contain only letters, numbers, dashes, and underscores.
@@ -496,7 +496,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                               selector:(nullable SEL)selector;
 
 /**
- @abstract *Synchronously* unsubscribes the device to a channel of push notifications.
+ *Synchronously* unsubscribes the device to a channel of push notifications.
 
  @param channel The channel to unsubscribe from.
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -506,7 +506,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (BOOL)unsubscribeFromChannel:(NSString *)channel error:(NSError **)error;
 
 /**
- @abstract *Asynchronously* unsubscribes the device from a channel of push notifications.
+ *Asynchronously* unsubscribes the device from a channel of push notifications.
 
  @param channel The channel to unsubscribe from.
 
@@ -515,7 +515,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (BFTask PF_GENERIC(NSNumber *)*)unsubscribeFromChannelInBackground:(NSString *)channel;
 
 /**
- @abstract *Asynchronously* unsubscribes the device from a channel of push notifications and calls the given block.
+ *Asynchronously* unsubscribes the device from a channel of push notifications and calls the given block.
 
  @param channel The channel to unsubscribe from.
  @param block The block to execute.
@@ -525,7 +525,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                      block:(nullable PFBooleanResultBlock)block;
 
 /*
- @abstract *Asynchronously* unsubscribes the device from a channel of push notifications and calls the given callback.
+ *Asynchronously* unsubscribes the device from a channel of push notifications and calls the given callback.
 
  @param channel The channel to unsubscribe from.
  @param target The object to call selector on.

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -21,7 +21,7 @@ PF_WATCH_UNAVAILABLE_WARNING
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  The `PFPush` class defines a push notification that can be sent from a client device.
 
  The preferred way of modifying or retrieving channel subscriptions is to use
@@ -39,7 +39,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /// @name Configuring a Push Notification
 ///--------------------------------------
 
-/*!
+/**
  @abstract Sets the channel on which this push notification will be sent.
 
  @param channel The channel to set for this push.
@@ -47,7 +47,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)setChannel:(nullable NSString *)channel;
 
-/*!
+/**
  @abstract Sets the array of channels on which this push notification will be sent.
 
  @param channels The array of channels to set for this push.
@@ -55,7 +55,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)setChannels:(nullable NSArray PF_GENERIC(NSString *)*)channels;
 
-/*!
+/**
  @abstract Sets an installation query to which this push notification will be sent.
 
  @discussion The query should be created via <[PFInstallation query]> and should not specify a skip, limit, or order.
@@ -64,7 +64,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)setQuery:(nullable PFQuery PF_GENERIC(PFInstallation *)*)query;
 
-/*!
+/**
  @abstract Sets an alert message for this push notification.
 
  @warning This will overwrite any data specified in setData.
@@ -73,7 +73,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)setMessage:(nullable NSString *)message;
 
-/*!
+/**
  @abstract Sets an arbitrary data payload for this push notification.
 
  @discussion See the guide for information about the dictionary structure.
@@ -84,7 +84,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)setData:(nullable NSDictionary *)data;
 
-/*!
+/**
  @abstract Sets whether this push will go to Android devices.
 
  @param pushToAndroid Whether this push will go to Android devices.
@@ -93,7 +93,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)setPushToAndroid:(BOOL)pushToAndroid PARSE_DEPRECATED("Please use a [PFInstallation query] with a constraint on deviceType. This method is deprecated and won't do anything.");
 
-/*!
+/**
  @abstract Sets whether this push will go to iOS devices.
 
  @param pushToIOS Whether this push will go to iOS devices.
@@ -102,7 +102,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)setPushToIOS:(BOOL)pushToIOS PARSE_DEPRECATED("Please use a [PFInstallation query] with a constraint on deviceType. This method is deprecated and won't do anything.");
 
-/*!
+/**
  @abstract Sets the expiration time for this notification.
 
  @discussion The notification will be sent to devices which are either online
@@ -116,7 +116,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)expireAtDate:(nullable NSDate *)date;
 
-/*!
+/**
  @abstract Sets the time interval after which this notification should expire.
 
  @discussion This notification will be sent to devices which are either online at
@@ -129,12 +129,12 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)expireAfterTimeInterval:(NSTimeInterval)timeInterval;
 
-/*!
+/**
  @abstract Clears both expiration values, indicating that the notification should never expire.
  */
 - (void)clearExpiration;
 
-/*!
+/**
  @abstract Date at which to send this push notification. 
  
  @discussion Push notificaitons with this date will be delivered at the local time matching the <PFInstallation.timeZone>.
@@ -147,7 +147,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /// @name Sending Push Notifications
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* send a push message to a channel.
 
  @param channel The channel to send to. The channel name must start with
@@ -161,7 +161,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                      withMessage:(NSString *)message
                            error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* send a push message to a channel.
 
  @param channel The channel to send to. The channel name must start with
@@ -173,7 +173,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (BFTask PF_GENERIC(NSNumber *)*)sendPushMessageToChannelInBackground:(NSString *)channel
                                                            withMessage:(NSString *)message;
 
-/*!
+/**
  @abstract *Asynchronously* sends a push message to a channel and calls the given block.
 
  @param channel The channel to send to. The channel name must start with
@@ -203,7 +203,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                       target:(__nullable id)target
                                     selector:(__nullable SEL)selector;
 
-/*!
+/**
  @abstract Send a push message to a query.
 
  @param query The query to send to. The query must be a <PFInstallation> query created with <[PFInstallation query]>.
@@ -216,7 +216,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                    withMessage:(NSString *)message
                          error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* send a push message to a query.
 
  @param query The query to send to. The query must be a <PFInstallation> query created with <[PFInstallation query]>.
@@ -227,7 +227,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (BFTask PF_GENERIC(NSNumber *)*)sendPushMessageToQueryInBackground:(PFQuery PF_GENERIC(PFInstallation *)*)query
                                                          withMessage:(NSString *)message;
 
-/*!
+/**
  @abstract *Asynchronously* sends a push message to a query and calls the given block.
 
  @param query The query to send to. The query must be a PFInstallation query
@@ -240,7 +240,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                withMessage:(NSString *)message
                                      block:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract *Synchronously* send this push message.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -249,13 +249,13 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (BOOL)sendPush:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* send this push message.
  @returns The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)sendPushInBackground;
 
-/*!
+/**
  @abstract *Asynchronously* send this push message and executes the given callback block.
 
  @param block The block to execute.
@@ -274,7 +274,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)sendPushInBackgroundWithTarget:(__nullable id)target selector:(__nullable SEL)selector;
 
-/*!
+/**
  @abstract *Synchronously* send a push message with arbitrary data to a channel.
 
  @discussion See the guide for information about the dictionary structure.
@@ -290,7 +290,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                      withData:(NSDictionary *)data
                         error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* send a push message with arbitrary data to a channel.
 
  @discussion See the guide for information about the dictionary structure.
@@ -304,7 +304,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (BFTask PF_GENERIC(NSNumber *)*)sendPushDataToChannelInBackground:(NSString *)channel
                                                            withData:(NSDictionary *)data;
 
-/*!
+/**
  @abstract Asynchronously sends a push message with arbitrary data to a channel and calls the given block.
 
  @discussion See the guide for information about the dictionary structure.
@@ -338,7 +338,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                    target:(__nullable id)target
                                  selector:(__nullable SEL)selector;
 
-/*!
+/**
  @abstract *Synchronously* send a push message with arbitrary data to a query.
 
  @discussion See the guide for information about the dictionary structure.
@@ -354,7 +354,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                    withData:(NSDictionary *)data
                       error:(NSError **)error;
 
-/*!
+/**
  @abstract Asynchronously send a push message with arbitrary data to a query.
 
  @discussion See the guide for information about the dictionary structure.
@@ -368,7 +368,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (BFTask PF_GENERIC(NSNumber *)*)sendPushDataToQueryInBackground:(PFQuery PF_GENERIC(PFInstallation *)*)query
                                                          withData:(NSDictionary *)data;
 
-/*!
+/**
  @abstract *Asynchronously* sends a push message with arbitrary data to a query and calls the given block.
 
  @discussion See the guide for information about the dictionary structure.
@@ -387,7 +387,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /// @name Handling Notifications
 ///--------------------------------------
 
-/*!
+/**
  @abstract A default handler for push notifications while the app is active that
  could be used to mimic the behavior of iOS push notifications while the app is backgrounded or not running.
 
@@ -405,7 +405,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 /// @name Managing Channel Subscriptions
 ///--------------------------------------
 
-/*!
+/**
  @abstract Store the device token locally for push notifications.
 
  @discussion Usually called from you main app delegate's `didRegisterForRemoteNotificationsWithDeviceToken:`.
@@ -415,7 +415,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 + (void)storeDeviceToken:(id)deviceToken;
 
-/*!
+/**
  @abstract *Synchronously* get all the channels that this device is subscribed to.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -424,14 +424,14 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 + (nullable NSSet PF_GENERIC(NSString *)*)getSubscribedChannels:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* get all the channels that this device is subscribed to.
 
  @returns The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSSet<NSString *> *)*)getSubscribedChannelsInBackground;
 
-/*!
+/**
  @abstract *Asynchronously* get all the channels that this device is subscribed to.
  @param block The block to execute.
  It should have the following argument signature: `^(NSSet *channels, NSError *error)`.
@@ -448,7 +448,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 + (void)getSubscribedChannelsInBackgroundWithTarget:(id)target selector:(SEL)selector;
 
-/*!
+/**
  @abstract *Synchrnously* subscribes the device to a channel of push notifications.
 
  @param channel The channel to subscribe to. The channel name must start with
@@ -459,7 +459,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 + (BOOL)subscribeToChannel:(NSString *)channel error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* subscribes the device to a channel of push notifications.
 
  @param channel The channel to subscribe to. The channel name must start with
@@ -469,7 +469,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 + (BFTask PF_GENERIC(NSNumber *)*)subscribeToChannelInBackground:(NSString *)channel;
 
-/*!
+/**
  @abstract *Asynchronously* subscribes the device to a channel of push notifications and calls the given block.
 
  @param channel The channel to subscribe to. The channel name must start with
@@ -495,7 +495,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                 target:(nullable id)target
                               selector:(nullable SEL)selector;
 
-/*!
+/**
  @abstract *Synchronously* unsubscribes the device to a channel of push notifications.
 
  @param channel The channel to unsubscribe from.
@@ -505,7 +505,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 + (BOOL)unsubscribeFromChannel:(NSString *)channel error:(NSError **)error;
 
-/*!
+/**
  @abstract *Asynchronously* unsubscribes the device from a channel of push notifications.
 
  @param channel The channel to unsubscribe from.
@@ -514,7 +514,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 + (BFTask PF_GENERIC(NSNumber *)*)unsubscribeFromChannelInBackground:(NSString *)channel;
 
-/*!
+/**
  @abstract *Asynchronously* unsubscribes the device from a channel of push notifications and calls the given block.
 
  @param channel The channel to unsubscribe from.

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -52,7 +52,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Creates a PFQuery with the constraints given by predicate.
 
- @discussion The following types of predicates are supported:
+ The following types of predicates are supported:
 
  - Simple comparisons such as `=`, `!=`, `<`, `>`, `<=`, `>=`, and `BETWEEN` with a key and a constant.
  - Containment predicates, such as `x IN {1, 2, 3}`.
@@ -85,7 +85,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Make the query include PFObjects that have a reference stored at the provided key.
 
- @discussion This has an effect similar to a join.  You can use dot notation to specify which fields in
+ This has an effect similar to a join.  You can use dot notation to specify which fields in
  the included object are also fetch.
 
  @param key The key to load child <PFObject>s for.
@@ -97,7 +97,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Make the query restrict the fields of the returned <PFObject>s to include only the provided keys.
 
- @discussion If this is called multiple times, then all of the keys specified in each of the calls will be included.
+ If this is called multiple times, then all of the keys specified in each of the calls will be included.
 
  @param keys The keys to include in the result.
 
@@ -228,7 +228,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
  be near a reference point.
 
- @discussion Distance is calculated based on angular distance on a sphere. Results will be sorted by distance
+ Distance is calculated based on angular distance on a sphere. Results will be sorted by distance
  from reference point.
 
  @param key The key to be constrained.
@@ -242,7 +242,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
  be near a reference point and within the maximum distance specified (in miles).
 
- @discussion Distance is calculated based on a spherical coordinate system.
+ Distance is calculated based on a spherical coordinate system.
  Results will be sorted by distance (nearest to farthest) from the reference point.
 
  @param key The key to be constrained.
@@ -259,7 +259,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
  be near a reference point and within the maximum distance specified (in kilometers).
 
- @discussion Distance is calculated based on a spherical coordinate system.
+ Distance is calculated based on a spherical coordinate system.
  Results will be sorted by distance (nearest to farthest) from the reference point.
 
  @param key The key to be constrained.
@@ -347,7 +347,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Add a constraint for finding string values that start with a provided prefix.
 
- @discussion This will use smart indexing, so it will be fast for large datasets.
+ This will use smart indexing, so it will be fast for large datasets.
 
  @param key The key that the string to match is stored in.
  @param prefix The substring that the value must start with.
@@ -449,7 +449,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Additionally sort in *ascending* order by the given key.
 
- @discussion The previous keys provided will precedence over this key.
+ The previous keys provided will precedence over this key.
 
  @param key The key to order by.
  */
@@ -467,7 +467,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Additionally sort in *descending* order by the given key.
 
- @discussion The previous keys provided will precedence over this key.
+ The previous keys provided will precedence over this key.
 
  @param key The key to order by.
  */
@@ -868,7 +868,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Ignore ACLs when querying from the Local Datastore.
 
- @discussion This is particularly useful when querying for objects with Role based ACLs set on them.
+ This is particularly useful when querying for objects with Role based ACLs set on them.
 
  @warning Requires Local Datastore to be enabled.
 

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -18,7 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  The `PFQuery` class defines a query that is used to query for <PFObject>s.
  */
 @interface PFQuery PF_GENERIC(PFGenericObject : PFObject *) : NSObject<NSCopying>
@@ -33,14 +33,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Creating a Query for a Class
 ///--------------------------------------
 
-/*!
+/**
  @abstract Initializes the query with a class name.
 
  @param className The class name.
  */
 - (instancetype)initWithClassName:(NSString *)className;
 
-/*!
+/**
  @abstract Returns a `PFQuery` for a given class.
 
  @param className The class to query on.
@@ -49,7 +49,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 + (instancetype)queryWithClassName:(NSString *)className;
 
-/*!
+/**
  @abstract Creates a PFQuery with the constraints given by predicate.
 
  @discussion The following types of predicates are supported:
@@ -73,7 +73,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 + (instancetype)queryWithClassName:(NSString *)className predicate:(nullable NSPredicate *)predicate;
 
-/*!
+/**
  The class name to query for.
  */
 @property (nonatomic, strong) NSString *parseClassName;
@@ -82,7 +82,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Adding Basic Constraints
 ///--------------------------------------
 
-/*!
+/**
  @abstract Make the query include PFObjects that have a reference stored at the provided key.
 
  @discussion This has an effect similar to a join.  You can use dot notation to specify which fields in
@@ -94,7 +94,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)includeKey:(NSString *)key;
 
-/*!
+/**
  @abstract Make the query restrict the fields of the returned <PFObject>s to include only the provided keys.
 
  @discussion If this is called multiple times, then all of the keys specified in each of the calls will be included.
@@ -105,7 +105,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)selectKeys:(NSArray PF_GENERIC(NSString *)*)keys;
 
-/*!
+/**
  @abstract Add a constraint that requires a particular key exists.
 
  @param key The key that should exist.
@@ -114,7 +114,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKeyExists:(NSString *)key;
 
-/*!
+/**
  @abstract Add a constraint that requires a key not exist.
 
  @param key The key that should not exist.
@@ -123,7 +123,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKeyDoesNotExist:(NSString *)key;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's object to be equal to the provided object.
 
  @param key The key to be constrained.
@@ -133,7 +133,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key equalTo:(id)object;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's object to be less than the provided object.
 
  @param key The key to be constrained.
@@ -143,7 +143,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key lessThan:(id)object;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's object
  to be less than or equal to the provided object.
 
@@ -154,7 +154,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key lessThanOrEqualTo:(id)object;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's object
  to be greater than the provided object.
 
@@ -165,7 +165,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key greaterThan:(id)object;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's
  object to be greater than or equal to the provided object.
 
@@ -176,7 +176,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key greaterThanOrEqualTo:(id)object;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's object
  to be not equal to the provided object.
 
@@ -187,7 +187,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key notEqualTo:(id)object;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's object
  to be contained in the provided array.
 
@@ -198,7 +198,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key containedIn:(NSArray *)array;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's object
  not be contained in the provided array.
 
@@ -209,7 +209,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key notContainedIn:(NSArray *)array;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's array
  contains every element of the provided array.
 
@@ -224,7 +224,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Adding Location Constraints
 ///--------------------------------------
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
  be near a reference point.
 
@@ -238,7 +238,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key nearGeoPoint:(PFGeoPoint *)geopoint;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
  be near a reference point and within the maximum distance specified (in miles).
 
@@ -255,7 +255,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
             nearGeoPoint:(PFGeoPoint *)geopoint
              withinMiles:(double)maxDistance;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
  be near a reference point and within the maximum distance specified (in kilometers).
 
@@ -272,7 +272,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
             nearGeoPoint:(PFGeoPoint *)geopoint
         withinKilometers:(double)maxDistance;
 
-/*!
+/**
  Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>) be near
  a reference point and within the maximum distance specified (in radians).  Distance is calculated based on
  angular distance on a sphere.  Results will be sorted by distance (nearest to farthest) from the reference point.
@@ -287,7 +287,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
             nearGeoPoint:(PFGeoPoint *)geopoint
            withinRadians:(double)maxDistance;
 
-/*!
+/**
  @abstract Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>) be
  contained within a given rectangular geographic bounding box.
 
@@ -303,7 +303,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Adding String Constraints
 ///--------------------------------------
 
-/*!
+/**
  @abstract Add a regular expression constraint for finding string values that match the provided regular expression.
 
  @warning This may be slow for large datasets.
@@ -315,7 +315,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key matchesRegex:(NSString *)regex;
 
-/*!
+/**
  @abstract Add a regular expression constraint for finding string values that match the provided regular expression.
 
  @warning This may be slow for large datasets.
@@ -332,7 +332,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
             matchesRegex:(NSString *)regex
                modifiers:(nullable NSString *)modifiers;
 
-/*!
+/**
  @abstract Add a constraint for finding string values that contain a provided substring.
 
  @warning This will be slow for large datasets.
@@ -344,7 +344,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key containsString:(nullable NSString *)substring;
 
-/*!
+/**
  @abstract Add a constraint for finding string values that start with a provided prefix.
 
  @discussion This will use smart indexing, so it will be fast for large datasets.
@@ -356,7 +356,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key hasPrefix:(nullable NSString *)prefix;
 
-/*!
+/**
  @abstract Add a constraint for finding string values that end with a provided suffix.
 
  @warning This will be slow for large datasets.
@@ -372,7 +372,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Adding Subqueries
 ///--------------------------------------
 
-/*!
+/**
  Returns a `PFQuery` that is the `or` of the passed in queries.
 
  @param queries The list of queries to or together.
@@ -381,7 +381,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 + (instancetype)orQueryWithSubqueries:(NSArray PF_GENERIC(PFQuery *)*)queries;
 
-/*!
+/**
  @abstract Adds a constraint that requires that a key's value matches a value in another key
  in objects returned by a sub query.
 
@@ -395,7 +395,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
               matchesKey:(NSString *)otherKey
                  inQuery:(PFQuery *)query;
 
-/*!
+/**
  @abstract Adds a constraint that requires that a key's value `NOT` match a value in another key
  in objects returned by a sub query.
 
@@ -409,7 +409,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
          doesNotMatchKey:(NSString *)otherKey
                  inQuery:(PFQuery *)query;
 
-/*!
+/**
  @abstract Add a constraint that requires that a key's value matches a `PFQuery` constraint.
 
  @warning This only works where the key's values are <PFObject>s or arrays of <PFObject>s.
@@ -421,7 +421,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)whereKey:(NSString *)key matchesQuery:(PFQuery *)query;
 
-/*!
+/**
  @abstract Add a constraint that requires that a key's value to not match a `PFQuery` constraint.
 
  @warning This only works where the key's values are <PFObject>s or arrays of <PFObject>s.
@@ -437,7 +437,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Sorting
 ///--------------------------------------
 
-/*!
+/**
  @abstract Sort the results in *ascending* order with the given key.
 
  @param key The key to order by.
@@ -446,7 +446,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)orderByAscending:(NSString *)key;
 
-/*!
+/**
  @abstract Additionally sort in *ascending* order by the given key.
 
  @discussion The previous keys provided will precedence over this key.
@@ -455,7 +455,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)addAscendingOrder:(NSString *)key;
 
-/*!
+/**
  @abstract Sort the results in *descending* order with the given key.
 
  @param key The key to order by.
@@ -464,7 +464,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)orderByDescending:(NSString *)key;
 
-/*!
+/**
  @abstract Additionally sort in *descending* order by the given key.
 
  @discussion The previous keys provided will precedence over this key.
@@ -473,7 +473,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)addDescendingOrder:(NSString *)key;
 
-/*!
+/**
  @abstract Sort the results using a given sort descriptor.
 
  @warning If a `sortDescriptor` has custom `selector` or `comparator` - they aren't going to be used.
@@ -484,7 +484,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)orderBySortDescriptor:(NSSortDescriptor *)sortDescriptor;
 
-/*!
+/**
  @abstract Sort the results using a given array of sort descriptors.
 
  @warning If a `sortDescriptor` has custom `selector` or `comparator` - they aren't going to be used.
@@ -499,7 +499,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Getting Objects by ID
 ///--------------------------------------
 
-/*!
+/**
  @abstract Returns a <PFObject> with a given class and id.
 
  @param objectClass The class name for the object that is being requested.
@@ -510,7 +510,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 + (nullable PFGenericObject)getObjectOfClass:(NSString *)objectClass
                                     objectId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Returns a <PFObject> with a given class and id and sets an error if necessary.
 
  @param objectClass The class name for the object that is being requested.
@@ -523,7 +523,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
                                     objectId:(NSString *)objectId
                                        error:(NSError **)error;
 
-/*!
+/**
  @abstract Returns a <PFObject> with the given id.
 
  @warning This method mutates the query.
@@ -535,7 +535,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (nullable PFGenericObject)getObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Returns a <PFObject> with the given id and sets an error if necessary.
 
  @warning This method mutates the query.
@@ -548,7 +548,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (nullable PFGenericObject)getObjectWithId:(NSString *)objectId error:(NSError **)error;
 
-/*!
+/**
  @abstract Gets a <PFObject> asynchronously and calls the given block with the result.
 
  @warning This method mutates the query.
@@ -560,7 +560,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (BFTask PF_GENERIC(PFGenericObject) *)getObjectInBackgroundWithId:(NSString *)objectId;
 
-/*!
+/**
  @abstract Gets a <PFObject> asynchronously and calls the given block with the result.
 
  @warning This method mutates the query.
@@ -592,7 +592,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Getting User Objects
 ///--------------------------------------
 
-/*!
+/**
  @abstract Returns a <PFUser> with a given id.
 
  @param objectId The id of the object that is being requested.
@@ -601,7 +601,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 + (nullable PFUser *)getUserObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  Returns a PFUser with a given class and id and sets an error if necessary.
  @param objectId The id of the object that is being requested.
  @param error Pointer to an NSError that will be set if necessary.
@@ -609,7 +609,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 + (nullable PFUser *)getUserObjectWithId:(NSString *)objectId error:(NSError **)error;
 
-/*!
+/**
  @deprecated Please use [PFUser query] instead.
  */
 + (instancetype)queryForUser PARSE_DEPRECATED("Use [PFUser query] instead.");
@@ -618,14 +618,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Getting all Matches for a Query
 ///--------------------------------------
 
-/*!
+/**
  @abstract Finds objects *synchronously* based on the constructed query.
 
  @returns Returns an array of <PFObject> objects that were found.
  */
 - (nullable NSArray PF_GENERIC(PFGenericObject) *)findObjects PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Finds objects *synchronously* based on the constructed query and sets an error if there was one.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -634,14 +634,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (nullable NSArray PF_GENERIC(PFGenericObject) *)findObjects:(NSError **)error;
 
-/*!
+/**
  @abstract Finds objects *asynchronously* and sets the `NSArray` of <PFObject> objects as a result of the task.
 
  @returns The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSArray<PFGenericObject> *)*)findObjectsInBackground;
 
-/*!
+/**
  @abstract Finds objects *asynchronously* and calls the given block with the results.
 
  @param block The block to execute.
@@ -663,7 +663,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Getting the First Match in a Query
 ///--------------------------------------
 
-/*!
+/**
  @abstract Gets an object *synchronously* based on the constructed query.
 
  @warning This method mutates the query. It will reset the limit to `1`.
@@ -672,7 +672,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (nullable PFGenericObject)getFirstObject PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Gets an object *synchronously* based on the constructed query and sets an error if any occurred.
 
  @warning This method mutates the query. It will reset the limit to `1`.
@@ -683,7 +683,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (nullable PFGenericObject)getFirstObject:(NSError **)error;
 
-/*!
+/**
  @abstract Gets an object *asynchronously* and sets it as a result of the task.
 
  @warning This method mutates the query. It will reset the limit to `1`.
@@ -692,7 +692,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (BFTask PF_GENERIC(PFGenericObject) *)getFirstObjectInBackground;
 
-/*!
+/**
  @abstract Gets an object *asynchronously* and calls the given block with the result.
 
  @warning This method mutates the query. It will reset the limit to `1`.
@@ -721,14 +721,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Counting the Matches in a Query
 ///--------------------------------------
 
-/*!
+/**
  @abstract Counts objects *synchronously* based on the constructed query.
 
  @returns Returns the number of <PFObject> objects that match the query, or `-1` if there is an error.
  */
 - (NSInteger)countObjects PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Counts objects *synchronously* based on the constructed query and sets an error if there was one.
 
  @param error Pointer to an `NSError` that will be set if necessary.
@@ -737,14 +737,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (NSInteger)countObjects:(NSError **)error;
 
-/*!
+/**
  @abstract Counts objects *asynchronously* and sets `NSNumber` with count as a result of the task.
 
  @returns The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)countObjectsInBackground;
 
-/*!
+/**
  @abstract Counts objects *asynchronously* and calls the given block with the counts.
 
  @param block The block to execute.
@@ -765,7 +765,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Cancelling a Query
 ///--------------------------------------
 
-/*!
+/**
  @abstract Cancels the current network request (if any). Ensures that callbacks won't be called.
  */
 - (void)cancel;
@@ -774,7 +774,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Paginating Results
 ///--------------------------------------
 
-/*!
+/**
  @abstract A limit on the number of objects to return. The default limit is `100`, with a
  maximum of 1000 results being returned at a time.
 
@@ -782,7 +782,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 @property (nonatomic, assign) NSInteger limit;
 
-/*!
+/**
  @abstract The number of objects to skip before returning any.
  */
 @property (nonatomic, assign) NSInteger skip;
@@ -791,7 +791,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Controlling Caching Behavior
 ///--------------------------------------
 
-/*!
+/**
  @abstract The cache policy to use for requests.
 
  Not allowed when Pinning is enabled.
@@ -802,24 +802,24 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 @property (nonatomic, assign) PFCachePolicy cachePolicy;
 
-/*!
+/**
  @abstract The age after which a cached value will be ignored
  */
 @property (nonatomic, assign) NSTimeInterval maxCacheAge;
 
-/*!
+/**
  @abstract Returns whether there is a cached result for this query.
 
  @result `YES` if there is a cached result for this query, otherwise `NO`.
  */
 - (BOOL)hasCachedResult;
 
-/*!
+/**
  @abstract Clears the cached result for this query. If there is no cached result, this is a noop.
  */
 - (void)clearCachedResult;
 
-/*!
+/**
  @abstract Clears the cached results for all queries.
  */
 + (void)clearAllCachedResults;
@@ -828,7 +828,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Query Source
 ///--------------------------------------
 
-/*!
+/**
  @abstract Change the source of this query to all pinned objects.
 
  @warning Requires Local Datastore to be enabled.
@@ -839,7 +839,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)fromLocalDatastore;
 
-/*!
+/**
  @abstract Change the source of this query to the default group of pinned objects.
 
  @warning Requires Local Datastore to be enabled.
@@ -851,7 +851,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)fromPin;
 
-/*!
+/**
  @abstract Change the source of this query to a specific group of pinned objects.
 
  @warning Requires Local Datastore to be enabled.
@@ -865,7 +865,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (instancetype)fromPinWithName:(nullable NSString *)name;
 
-/*!
+/**
  @abstract Ignore ACLs when querying from the Local Datastore.
 
  @discussion This is particularly useful when querying for objects with Role based ACLs set on them.
@@ -880,7 +880,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /// @name Advanced Settings
 ///--------------------------------------
 
-/*!
+/**
  @abstract Whether or not performance tracing should be done on the query.
 
  @warning This should not be set to `YES` in most cases.

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -19,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- The `PFQuery` class defines a query that is used to query for <PFObject>s.
+ The `PFQuery` class defines a query that is used to query for `PFObject`s.
  */
 @interface PFQuery PF_GENERIC(PFGenericObject : PFObject *) : NSObject<NSCopying>
 
@@ -88,14 +88,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  This has an effect similar to a join.  You can use dot notation to specify which fields in
  the included object are also fetch.
 
- @param key The key to load child <PFObject>s for.
+ @param key The key to load child `PFObject`s for.
 
  @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)includeKey:(NSString *)key;
 
 /**
- Make the query restrict the fields of the returned <PFObject>s to include only the provided keys.
+ Make the query restrict the fields of the returned `PFObject`s to include only the provided keys.
 
  If this is called multiple times, then all of the keys specified in each of the calls will be included.
 
@@ -225,28 +225,28 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
+ Add a constraint to the query that requires a particular key's coordinates (specified via `PFGeoPoint`)
  be near a reference point.
 
  Distance is calculated based on angular distance on a sphere. Results will be sorted by distance
  from reference point.
 
  @param key The key to be constrained.
- @param geopoint The reference point represented as a <PFGeoPoint>.
+ @param geopoint The reference point represented as a `PFGeoPoint`.
 
  @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key nearGeoPoint:(PFGeoPoint *)geopoint;
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
+ Add a constraint to the query that requires a particular key's coordinates (specified via `PFGeoPoint`)
  be near a reference point and within the maximum distance specified (in miles).
 
  Distance is calculated based on a spherical coordinate system.
  Results will be sorted by distance (nearest to farthest) from the reference point.
 
  @param key The key to be constrained.
- @param geopoint The reference point represented as a <PFGeoPoint>.
+ @param geopoint The reference point represented as a `PFGeoPoint`.
  @param maxDistance Maximum distance in miles.
 
  @return The same instance of `PFQuery` as the receiver. This allows method chaining.
@@ -256,14 +256,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
              withinMiles:(double)maxDistance;
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
+ Add a constraint to the query that requires a particular key's coordinates (specified via `PFGeoPoint`)
  be near a reference point and within the maximum distance specified (in kilometers).
 
  Distance is calculated based on a spherical coordinate system.
  Results will be sorted by distance (nearest to farthest) from the reference point.
 
  @param key The key to be constrained.
- @param geopoint The reference point represented as a <PFGeoPoint>.
+ @param geopoint The reference point represented as a `PFGeoPoint`.
  @param maxDistance Maximum distance in kilometers.
 
  @return The same instance of `PFQuery` as the receiver. This allows method chaining.
@@ -273,12 +273,12 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
         withinKilometers:(double)maxDistance;
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>) be near
+ Add a constraint to the query that requires a particular key's coordinates (specified via `PFGeoPoint`) be near
  a reference point and within the maximum distance specified (in radians).  Distance is calculated based on
  angular distance on a sphere.  Results will be sorted by distance (nearest to farthest) from the reference point.
 
  @param key The key to be constrained.
- @param geopoint The reference point as a <PFGeoPoint>.
+ @param geopoint The reference point as a `PFGeoPoint`.
  @param maxDistance Maximum distance in radians.
 
  @return The same instance of `PFQuery` as the receiver. This allows method chaining.
@@ -288,7 +288,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
            withinRadians:(double)maxDistance;
 
 /**
- Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>) be
+ Add a constraint to the query that requires a particular key's coordinates (specified via `PFGeoPoint`) be
  contained within a given rectangular geographic bounding box.
 
  @param key The key to be constrained.
@@ -412,7 +412,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Add a constraint that requires that a key's value matches a `PFQuery` constraint.
 
- @warning This only works where the key's values are <PFObject>s or arrays of <PFObject>s.
+ @warning This only works where the key's values are `PFObject`s or arrays of `PFObject`s.
 
  @param key The key that the value is stored in
  @param query The query the value should match
@@ -424,7 +424,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Add a constraint that requires that a key's value to not match a `PFQuery` constraint.
 
- @warning This only works where the key's values are <PFObject>s or arrays of <PFObject>s.
+ @warning This only works where the key's values are `PFObject`s or arrays of `PFObject`s.
 
  @param key The key that the value is stored in
  @param query The query the value should not match
@@ -500,43 +500,43 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- Returns a <PFObject> with a given class and id.
+ Returns a `PFObject` with a given class and id.
 
  @param objectClass The class name for the object that is being requested.
  @param objectId The id of the object that is being requested.
 
- @return The <PFObject> if found. Returns `nil` if the object isn't found, or if there was an error.
+ @return The `PFObject` if found. Returns `nil` if the object isn't found, or if there was an error.
  */
 + (nullable PFGenericObject)getObjectOfClass:(NSString *)objectClass
                                     objectId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
 /**
- Returns a <PFObject> with a given class and id and sets an error if necessary.
+ Returns a `PFObject` with a given class and id and sets an error if necessary.
 
  @param objectClass The class name for the object that is being requested.
  @param objectId The id of the object that is being requested.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @return The <PFObject> if found. Returns `nil` if the object isn't found, or if there was an `error`.
+ @return The `PFObject` if found. Returns `nil` if the object isn't found, or if there was an `error`.
  */
 + (nullable PFGenericObject)getObjectOfClass:(NSString *)objectClass
                                     objectId:(NSString *)objectId
                                        error:(NSError **)error;
 
 /**
- Returns a <PFObject> with the given id.
+ Returns a `PFObject` with the given id.
 
  @warning This method mutates the query.
  It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
 
  @param objectId The id of the object that is being requested.
 
- @return The <PFObject> if found. Returns nil if the object isn't found, or if there was an error.
+ @return The `PFObject` if found. Returns nil if the object isn't found, or if there was an error.
  */
 - (nullable PFGenericObject)getObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
 /**
- Returns a <PFObject> with the given id and sets an error if necessary.
+ Returns a `PFObject` with the given id and sets an error if necessary.
 
  @warning This method mutates the query.
  It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
@@ -544,12 +544,12 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param objectId The id of the object that is being requested.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @return The <PFObject> if found. Returns nil if the object isn't found, or if there was an error.
+ @return The `PFObject` if found. Returns nil if the object isn't found, or if there was an error.
  */
 - (nullable PFGenericObject)getObjectWithId:(NSString *)objectId error:(NSError **)error;
 
 /**
- Gets a <PFObject> asynchronously and calls the given block with the result.
+ Gets a `PFObject` asynchronously and calls the given block with the result.
 
  @warning This method mutates the query.
  It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
@@ -561,7 +561,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (BFTask PF_GENERIC(PFGenericObject) *)getObjectInBackgroundWithId:(NSString *)objectId;
 
 /**
- Gets a <PFObject> asynchronously and calls the given block with the result.
+ Gets a `PFObject` asynchronously and calls the given block with the result.
 
  @warning This method mutates the query.
  It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
@@ -574,7 +574,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
                               block:(nullable void (^)(PFGenericObject __nullable object, NSError *__nullable error))block;
 
 /*
- Gets a <PFObject> asynchronously.
+ Gets a `PFObject` asynchronously.
 
  This mutates the PFQuery. It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
 
@@ -593,7 +593,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- Returns a <PFUser> with a given id.
+ Returns a `PFUser` with a given id.
 
  @param objectId The id of the object that is being requested.
 
@@ -621,7 +621,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Finds objects *synchronously* based on the constructed query.
 
- @return Returns an array of <PFObject> objects that were found.
+ @return Returns an array of `PFObject` objects that were found.
  */
 - (nullable NSArray PF_GENERIC(PFGenericObject) *)findObjects PF_SWIFT_UNAVAILABLE;
 
@@ -630,12 +630,12 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @return Returns an array of <PFObject> objects that were found.
+ @return Returns an array of `PFObject` objects that were found.
  */
 - (nullable NSArray PF_GENERIC(PFGenericObject) *)findObjects:(NSError **)error;
 
 /**
- Finds objects *asynchronously* and sets the `NSArray` of <PFObject> objects as a result of the task.
+ Finds objects *asynchronously* and sets the `NSArray` of `PFObject` objects as a result of the task.
 
  @return The task, that encapsulates the work being done.
  */
@@ -668,7 +668,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @warning This method mutates the query. It will reset the limit to `1`.
 
- @return Returns a <PFObject>, or `nil` if none was found.
+ @return Returns a `PFObject`, or `nil` if none was found.
  */
 - (nullable PFGenericObject)getFirstObject PF_SWIFT_UNAVAILABLE;
 
@@ -679,7 +679,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @return Returns a <PFObject>, or `nil` if none was found.
+ @return Returns a `PFObject`, or `nil` if none was found.
  */
 - (nullable PFGenericObject)getFirstObject:(NSError **)error;
 
@@ -724,7 +724,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Counts objects *synchronously* based on the constructed query.
 
- @return Returns the number of <PFObject> objects that match the query, or `-1` if there is an error.
+ @return Returns the number of `PFObject` objects that match the query, or `-1` if there is an error.
  */
 - (NSInteger)countObjects PF_SWIFT_UNAVAILABLE;
 
@@ -733,7 +733,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @return Returns the number of <PFObject> objects that match the query, or `-1` if there is an error.
+ @return Returns the number of `PFObject` objects that match the query, or `-1` if there is an error.
  */
 - (NSInteger)countObjects:(NSError **)error;
 

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -34,14 +34,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Initializes the query with a class name.
+ Initializes the query with a class name.
 
  @param className The class name.
  */
 - (instancetype)initWithClassName:(NSString *)className;
 
 /**
- @abstract Returns a `PFQuery` for a given class.
+ Returns a `PFQuery` for a given class.
 
  @param className The class to query on.
 
@@ -50,7 +50,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 + (instancetype)queryWithClassName:(NSString *)className;
 
 /**
- @abstract Creates a PFQuery with the constraints given by predicate.
+ Creates a PFQuery with the constraints given by predicate.
 
  @discussion The following types of predicates are supported:
 
@@ -83,7 +83,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Make the query include PFObjects that have a reference stored at the provided key.
+ Make the query include PFObjects that have a reference stored at the provided key.
 
  @discussion This has an effect similar to a join.  You can use dot notation to specify which fields in
  the included object are also fetch.
@@ -95,7 +95,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)includeKey:(NSString *)key;
 
 /**
- @abstract Make the query restrict the fields of the returned <PFObject>s to include only the provided keys.
+ Make the query restrict the fields of the returned <PFObject>s to include only the provided keys.
 
  @discussion If this is called multiple times, then all of the keys specified in each of the calls will be included.
 
@@ -106,7 +106,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)selectKeys:(NSArray PF_GENERIC(NSString *)*)keys;
 
 /**
- @abstract Add a constraint that requires a particular key exists.
+ Add a constraint that requires a particular key exists.
 
  @param key The key that should exist.
 
@@ -115,7 +115,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKeyExists:(NSString *)key;
 
 /**
- @abstract Add a constraint that requires a key not exist.
+ Add a constraint that requires a key not exist.
 
  @param key The key that should not exist.
 
@@ -124,7 +124,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKeyDoesNotExist:(NSString *)key;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's object to be equal to the provided object.
+ Add a constraint to the query that requires a particular key's object to be equal to the provided object.
 
  @param key The key to be constrained.
  @param object The object that must be equalled.
@@ -134,7 +134,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key equalTo:(id)object;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's object to be less than the provided object.
+ Add a constraint to the query that requires a particular key's object to be less than the provided object.
 
  @param key The key to be constrained.
  @param object The object that provides an upper bound.
@@ -144,7 +144,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key lessThan:(id)object;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's object
+ Add a constraint to the query that requires a particular key's object
  to be less than or equal to the provided object.
 
  @param key The key to be constrained.
@@ -155,7 +155,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key lessThanOrEqualTo:(id)object;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's object
+ Add a constraint to the query that requires a particular key's object
  to be greater than the provided object.
 
  @param key The key to be constrained.
@@ -166,7 +166,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key greaterThan:(id)object;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's
+ Add a constraint to the query that requires a particular key's
  object to be greater than or equal to the provided object.
 
  @param key The key to be constrained.
@@ -177,7 +177,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key greaterThanOrEqualTo:(id)object;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's object
+ Add a constraint to the query that requires a particular key's object
  to be not equal to the provided object.
 
  @param key The key to be constrained.
@@ -188,7 +188,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key notEqualTo:(id)object;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's object
+ Add a constraint to the query that requires a particular key's object
  to be contained in the provided array.
 
  @param key The key to be constrained.
@@ -199,7 +199,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key containedIn:(NSArray *)array;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's object
+ Add a constraint to the query that requires a particular key's object
  not be contained in the provided array.
 
  @param key The key to be constrained.
@@ -210,7 +210,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key notContainedIn:(NSArray *)array;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's array
+ Add a constraint to the query that requires a particular key's array
  contains every element of the provided array.
 
  @param key The key to be constrained.
@@ -225,7 +225,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
+ Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
  be near a reference point.
 
  @discussion Distance is calculated based on angular distance on a sphere. Results will be sorted by distance
@@ -239,7 +239,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key nearGeoPoint:(PFGeoPoint *)geopoint;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
+ Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
  be near a reference point and within the maximum distance specified (in miles).
 
  @discussion Distance is calculated based on a spherical coordinate system.
@@ -256,7 +256,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
              withinMiles:(double)maxDistance;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
+ Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>)
  be near a reference point and within the maximum distance specified (in kilometers).
 
  @discussion Distance is calculated based on a spherical coordinate system.
@@ -288,7 +288,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
            withinRadians:(double)maxDistance;
 
 /**
- @abstract Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>) be
+ Add a constraint to the query that requires a particular key's coordinates (specified via <PFGeoPoint>) be
  contained within a given rectangular geographic bounding box.
 
  @param key The key to be constrained.
@@ -304,7 +304,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Add a regular expression constraint for finding string values that match the provided regular expression.
+ Add a regular expression constraint for finding string values that match the provided regular expression.
 
  @warning This may be slow for large datasets.
 
@@ -316,7 +316,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key matchesRegex:(NSString *)regex;
 
 /**
- @abstract Add a regular expression constraint for finding string values that match the provided regular expression.
+ Add a regular expression constraint for finding string values that match the provided regular expression.
 
  @warning This may be slow for large datasets.
 
@@ -333,7 +333,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
                modifiers:(nullable NSString *)modifiers;
 
 /**
- @abstract Add a constraint for finding string values that contain a provided substring.
+ Add a constraint for finding string values that contain a provided substring.
 
  @warning This will be slow for large datasets.
 
@@ -345,7 +345,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key containsString:(nullable NSString *)substring;
 
 /**
- @abstract Add a constraint for finding string values that start with a provided prefix.
+ Add a constraint for finding string values that start with a provided prefix.
 
  @discussion This will use smart indexing, so it will be fast for large datasets.
 
@@ -357,7 +357,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key hasPrefix:(nullable NSString *)prefix;
 
 /**
- @abstract Add a constraint for finding string values that end with a provided suffix.
+ Add a constraint for finding string values that end with a provided suffix.
 
  @warning This will be slow for large datasets.
 
@@ -382,7 +382,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 + (instancetype)orQueryWithSubqueries:(NSArray PF_GENERIC(PFQuery *)*)queries;
 
 /**
- @abstract Adds a constraint that requires that a key's value matches a value in another key
+ Adds a constraint that requires that a key's value matches a value in another key
  in objects returned by a sub query.
 
  @param key The key that the value is stored.
@@ -396,7 +396,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
                  inQuery:(PFQuery *)query;
 
 /**
- @abstract Adds a constraint that requires that a key's value `NOT` match a value in another key
+ Adds a constraint that requires that a key's value `NOT` match a value in another key
  in objects returned by a sub query.
 
  @param key The key that the value is stored.
@@ -410,7 +410,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
                  inQuery:(PFQuery *)query;
 
 /**
- @abstract Add a constraint that requires that a key's value matches a `PFQuery` constraint.
+ Add a constraint that requires that a key's value matches a `PFQuery` constraint.
 
  @warning This only works where the key's values are <PFObject>s or arrays of <PFObject>s.
 
@@ -422,7 +422,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)whereKey:(NSString *)key matchesQuery:(PFQuery *)query;
 
 /**
- @abstract Add a constraint that requires that a key's value to not match a `PFQuery` constraint.
+ Add a constraint that requires that a key's value to not match a `PFQuery` constraint.
 
  @warning This only works where the key's values are <PFObject>s or arrays of <PFObject>s.
 
@@ -438,7 +438,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Sort the results in *ascending* order with the given key.
+ Sort the results in *ascending* order with the given key.
 
  @param key The key to order by.
 
@@ -447,7 +447,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)orderByAscending:(NSString *)key;
 
 /**
- @abstract Additionally sort in *ascending* order by the given key.
+ Additionally sort in *ascending* order by the given key.
 
  @discussion The previous keys provided will precedence over this key.
 
@@ -456,7 +456,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)addAscendingOrder:(NSString *)key;
 
 /**
- @abstract Sort the results in *descending* order with the given key.
+ Sort the results in *descending* order with the given key.
 
  @param key The key to order by.
 
@@ -465,7 +465,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)orderByDescending:(NSString *)key;
 
 /**
- @abstract Additionally sort in *descending* order by the given key.
+ Additionally sort in *descending* order by the given key.
 
  @discussion The previous keys provided will precedence over this key.
 
@@ -474,7 +474,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)addDescendingOrder:(NSString *)key;
 
 /**
- @abstract Sort the results using a given sort descriptor.
+ Sort the results using a given sort descriptor.
 
  @warning If a `sortDescriptor` has custom `selector` or `comparator` - they aren't going to be used.
 
@@ -485,7 +485,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)orderBySortDescriptor:(NSSortDescriptor *)sortDescriptor;
 
 /**
- @abstract Sort the results using a given array of sort descriptors.
+ Sort the results using a given array of sort descriptors.
 
  @warning If a `sortDescriptor` has custom `selector` or `comparator` - they aren't going to be used.
 
@@ -500,7 +500,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Returns a <PFObject> with a given class and id.
+ Returns a <PFObject> with a given class and id.
 
  @param objectClass The class name for the object that is being requested.
  @param objectId The id of the object that is being requested.
@@ -511,7 +511,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
                                     objectId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Returns a <PFObject> with a given class and id and sets an error if necessary.
+ Returns a <PFObject> with a given class and id and sets an error if necessary.
 
  @param objectClass The class name for the object that is being requested.
  @param objectId The id of the object that is being requested.
@@ -524,7 +524,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
                                        error:(NSError **)error;
 
 /**
- @abstract Returns a <PFObject> with the given id.
+ Returns a <PFObject> with the given id.
 
  @warning This method mutates the query.
  It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
@@ -536,7 +536,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (nullable PFGenericObject)getObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Returns a <PFObject> with the given id and sets an error if necessary.
+ Returns a <PFObject> with the given id and sets an error if necessary.
 
  @warning This method mutates the query.
  It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
@@ -549,7 +549,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (nullable PFGenericObject)getObjectWithId:(NSString *)objectId error:(NSError **)error;
 
 /**
- @abstract Gets a <PFObject> asynchronously and calls the given block with the result.
+ Gets a <PFObject> asynchronously and calls the given block with the result.
 
  @warning This method mutates the query.
  It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
@@ -561,7 +561,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (BFTask PF_GENERIC(PFGenericObject) *)getObjectInBackgroundWithId:(NSString *)objectId;
 
 /**
- @abstract Gets a <PFObject> asynchronously and calls the given block with the result.
+ Gets a <PFObject> asynchronously and calls the given block with the result.
 
  @warning This method mutates the query.
  It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
@@ -574,7 +574,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
                               block:(nullable void (^)(PFGenericObject __nullable object, NSError *__nullable error))block;
 
 /*
- @abstract Gets a <PFObject> asynchronously.
+ Gets a <PFObject> asynchronously.
 
  This mutates the PFQuery. It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
 
@@ -593,7 +593,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Returns a <PFUser> with a given id.
+ Returns a <PFUser> with a given id.
 
  @param objectId The id of the object that is being requested.
 
@@ -619,14 +619,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Finds objects *synchronously* based on the constructed query.
+ Finds objects *synchronously* based on the constructed query.
 
  @returns Returns an array of <PFObject> objects that were found.
  */
 - (nullable NSArray PF_GENERIC(PFGenericObject) *)findObjects PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Finds objects *synchronously* based on the constructed query and sets an error if there was one.
+ Finds objects *synchronously* based on the constructed query and sets an error if there was one.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -635,14 +635,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (nullable NSArray PF_GENERIC(PFGenericObject) *)findObjects:(NSError **)error;
 
 /**
- @abstract Finds objects *asynchronously* and sets the `NSArray` of <PFObject> objects as a result of the task.
+ Finds objects *asynchronously* and sets the `NSArray` of <PFObject> objects as a result of the task.
 
  @returns The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSArray<PFGenericObject> *)*)findObjectsInBackground;
 
 /**
- @abstract Finds objects *asynchronously* and calls the given block with the results.
+ Finds objects *asynchronously* and calls the given block with the results.
 
  @param block The block to execute.
  It should have the following argument signature: `^(NSArray *objects, NSError *error)`
@@ -650,7 +650,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (void)findObjectsInBackgroundWithBlock:(nullable PFQueryArrayResultBlock)block;
 
 /*
- @abstract Finds objects *asynchronously* and calls the given callback with the results.
+ Finds objects *asynchronously* and calls the given callback with the results.
 
  @param target The object to call the selector on.
  @param selector The selector to call.
@@ -664,7 +664,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Gets an object *synchronously* based on the constructed query.
+ Gets an object *synchronously* based on the constructed query.
 
  @warning This method mutates the query. It will reset the limit to `1`.
 
@@ -673,7 +673,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (nullable PFGenericObject)getFirstObject PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Gets an object *synchronously* based on the constructed query and sets an error if any occurred.
+ Gets an object *synchronously* based on the constructed query and sets an error if any occurred.
 
  @warning This method mutates the query. It will reset the limit to `1`.
 
@@ -684,7 +684,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (nullable PFGenericObject)getFirstObject:(NSError **)error;
 
 /**
- @abstract Gets an object *asynchronously* and sets it as a result of the task.
+ Gets an object *asynchronously* and sets it as a result of the task.
 
  @warning This method mutates the query. It will reset the limit to `1`.
 
@@ -693,7 +693,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (BFTask PF_GENERIC(PFGenericObject) *)getFirstObjectInBackground;
 
 /**
- @abstract Gets an object *asynchronously* and calls the given block with the result.
+ Gets an object *asynchronously* and calls the given block with the result.
 
  @warning This method mutates the query. It will reset the limit to `1`.
 
@@ -705,7 +705,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (void)getFirstObjectInBackgroundWithBlock:(nullable void (^)(PFGenericObject __nullable object, NSError *__nullable error))block;
 
 /*
- @abstract Gets an object *asynchronously* and calls the given callback with the results.
+ Gets an object *asynchronously* and calls the given callback with the results.
 
  @warning This method mutates the query. It will reset the limit to `1`.
 
@@ -722,14 +722,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Counts objects *synchronously* based on the constructed query.
+ Counts objects *synchronously* based on the constructed query.
 
  @returns Returns the number of <PFObject> objects that match the query, or `-1` if there is an error.
  */
 - (NSInteger)countObjects PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Counts objects *synchronously* based on the constructed query and sets an error if there was one.
+ Counts objects *synchronously* based on the constructed query and sets an error if there was one.
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
@@ -738,14 +738,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (NSInteger)countObjects:(NSError **)error;
 
 /**
- @abstract Counts objects *asynchronously* and sets `NSNumber` with count as a result of the task.
+ Counts objects *asynchronously* and sets `NSNumber` with count as a result of the task.
 
  @returns The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)countObjectsInBackground;
 
 /**
- @abstract Counts objects *asynchronously* and calls the given block with the counts.
+ Counts objects *asynchronously* and calls the given block with the counts.
 
  @param block The block to execute.
  It should have the following argument signature: `^(int count, NSError *error)`
@@ -753,7 +753,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (void)countObjectsInBackgroundWithBlock:(nullable PFIntegerResultBlock)block;
 
 /*
- @abstract Counts objects *asynchronously* and calls the given callback with the count.
+ Counts objects *asynchronously* and calls the given callback with the count.
 
  @param target The object to call the selector on.
  @param selector The selector to call.
@@ -766,7 +766,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Cancels the current network request (if any). Ensures that callbacks won't be called.
+ Cancels the current network request (if any). Ensures that callbacks won't be called.
  */
 - (void)cancel;
 
@@ -775,7 +775,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract A limit on the number of objects to return. The default limit is `100`, with a
+ A limit on the number of objects to return. The default limit is `100`, with a
  maximum of 1000 results being returned at a time.
 
  @warning If you are calling `findObjects` with `limit = 1`, you may find it easier to use `getFirst` instead.
@@ -783,7 +783,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 @property (nonatomic, assign) NSInteger limit;
 
 /**
- @abstract The number of objects to skip before returning any.
+ The number of objects to skip before returning any.
  */
 @property (nonatomic, assign) NSInteger skip;
 
@@ -792,7 +792,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract The cache policy to use for requests.
+ The cache policy to use for requests.
 
  Not allowed when Pinning is enabled.
 
@@ -803,24 +803,24 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 @property (nonatomic, assign) PFCachePolicy cachePolicy;
 
 /**
- @abstract The age after which a cached value will be ignored
+ The age after which a cached value will be ignored
  */
 @property (nonatomic, assign) NSTimeInterval maxCacheAge;
 
 /**
- @abstract Returns whether there is a cached result for this query.
+ Returns whether there is a cached result for this query.
 
  @result `YES` if there is a cached result for this query, otherwise `NO`.
  */
 - (BOOL)hasCachedResult;
 
 /**
- @abstract Clears the cached result for this query. If there is no cached result, this is a noop.
+ Clears the cached result for this query. If there is no cached result, this is a noop.
  */
 - (void)clearCachedResult;
 
 /**
- @abstract Clears the cached results for all queries.
+ Clears the cached results for all queries.
  */
 + (void)clearAllCachedResults;
 
@@ -829,7 +829,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Change the source of this query to all pinned objects.
+ Change the source of this query to all pinned objects.
 
  @warning Requires Local Datastore to be enabled.
 
@@ -840,7 +840,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)fromLocalDatastore;
 
 /**
- @abstract Change the source of this query to the default group of pinned objects.
+ Change the source of this query to the default group of pinned objects.
 
  @warning Requires Local Datastore to be enabled.
 
@@ -852,7 +852,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)fromPin;
 
 /**
- @abstract Change the source of this query to a specific group of pinned objects.
+ Change the source of this query to a specific group of pinned objects.
 
  @warning Requires Local Datastore to be enabled.
 
@@ -866,7 +866,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (instancetype)fromPinWithName:(nullable NSString *)name;
 
 /**
- @abstract Ignore ACLs when querying from the Local Datastore.
+ Ignore ACLs when querying from the Local Datastore.
 
  @discussion This is particularly useful when querying for objects with Role based ACLs set on them.
 
@@ -881,7 +881,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 ///--------------------------------------
 
 /**
- @abstract Whether or not performance tracing should be done on the query.
+ Whether or not performance tracing should be done on the query.
 
  @warning This should not be set to `YES` in most cases.
  */

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -45,7 +45,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param className The class to query on.
 
- @returns A `PFQuery` object.
+ @return A `PFQuery` object.
  */
 + (instancetype)queryWithClassName:(NSString *)className;
 
@@ -90,7 +90,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param key The key to load child <PFObject>s for.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)includeKey:(NSString *)key;
 
@@ -101,7 +101,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param keys The keys to include in the result.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)selectKeys:(NSArray PF_GENERIC(NSString *)*)keys;
 
@@ -110,7 +110,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param key The key that should exist.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKeyExists:(NSString *)key;
 
@@ -119,7 +119,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param key The key that should not exist.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKeyDoesNotExist:(NSString *)key;
 
@@ -129,7 +129,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param object The object that must be equalled.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key equalTo:(id)object;
 
@@ -139,7 +139,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param object The object that provides an upper bound.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key lessThan:(id)object;
 
@@ -150,7 +150,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param object The object that must be equalled.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key lessThanOrEqualTo:(id)object;
 
@@ -161,7 +161,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param object The object that must be equalled.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key greaterThan:(id)object;
 
@@ -172,7 +172,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param object The object that must be equalled.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key greaterThanOrEqualTo:(id)object;
 
@@ -183,7 +183,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param object The object that must not be equalled.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key notEqualTo:(id)object;
 
@@ -194,7 +194,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param array The possible values for the key's object.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key containedIn:(NSArray *)array;
 
@@ -205,7 +205,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param array The list of values the key's object should not be.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key notContainedIn:(NSArray *)array;
 
@@ -216,7 +216,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param array The array of values to search for.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key containsAllObjectsInArray:(NSArray *)array;
 
@@ -234,7 +234,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key to be constrained.
  @param geopoint The reference point represented as a <PFGeoPoint>.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key nearGeoPoint:(PFGeoPoint *)geopoint;
 
@@ -249,7 +249,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param geopoint The reference point represented as a <PFGeoPoint>.
  @param maxDistance Maximum distance in miles.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key
             nearGeoPoint:(PFGeoPoint *)geopoint
@@ -266,7 +266,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param geopoint The reference point represented as a <PFGeoPoint>.
  @param maxDistance Maximum distance in kilometers.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key
             nearGeoPoint:(PFGeoPoint *)geopoint
@@ -281,7 +281,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param geopoint The reference point as a <PFGeoPoint>.
  @param maxDistance Maximum distance in radians.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key
             nearGeoPoint:(PFGeoPoint *)geopoint
@@ -295,7 +295,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param southwest The lower-left inclusive corner of the box.
  @param northeast The upper-right inclusive corner of the box.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key withinGeoBoxFromSouthwest:(PFGeoPoint *)southwest toNortheast:(PFGeoPoint *)northeast;
 
@@ -311,7 +311,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key that the string to match is stored in.
  @param regex The regular expression pattern to match.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key matchesRegex:(NSString *)regex;
 
@@ -326,7 +326,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  - `i` - Case insensitive search
  - `m` - Search across multiple lines of input
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key
             matchesRegex:(NSString *)regex
@@ -340,7 +340,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key that the string to match is stored in.
  @param substring The substring that the value must contain.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key containsString:(nullable NSString *)substring;
 
@@ -352,7 +352,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key that the string to match is stored in.
  @param prefix The substring that the value must start with.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key hasPrefix:(nullable NSString *)prefix;
 
@@ -364,7 +364,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key that the string to match is stored in.
  @param suffix The substring that the value must end with.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key hasSuffix:(nullable NSString *)suffix;
 
@@ -377,7 +377,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param queries The list of queries to or together.
 
- @returns An instance of `PFQuery` that is the `or` of the passed in queries.
+ @return An instance of `PFQuery` that is the `or` of the passed in queries.
  */
 + (instancetype)orQueryWithSubqueries:(NSArray PF_GENERIC(PFQuery *)*)queries;
 
@@ -389,7 +389,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param otherKey The key in objects in the returned by the sub query whose value should match.
  @param query The query to run.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key
               matchesKey:(NSString *)otherKey
@@ -403,7 +403,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param otherKey The key in objects in the returned by the sub query whose value should match.
  @param query The query to run.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key
          doesNotMatchKey:(NSString *)otherKey
@@ -417,7 +417,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key that the value is stored in
  @param query The query the value should match
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key matchesQuery:(PFQuery *)query;
 
@@ -429,7 +429,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param key The key that the value is stored in
  @param query The query the value should not match
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)whereKey:(NSString *)key doesNotMatchQuery:(PFQuery *)query;
 
@@ -442,7 +442,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param key The key to order by.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)orderByAscending:(NSString *)key;
 
@@ -460,7 +460,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param key The key to order by.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)orderByDescending:(NSString *)key;
 
@@ -480,7 +480,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param sortDescriptor The `NSSortDescriptor` to use to sort the results of the query.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)orderBySortDescriptor:(NSSortDescriptor *)sortDescriptor;
 
@@ -491,7 +491,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param sortDescriptors An array of `NSSortDescriptor` objects to use to sort the results of the query.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)orderBySortDescriptors:(nullable NSArray PF_GENERIC(NSSortDescriptor *)*)sortDescriptors;
 
@@ -505,7 +505,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param objectClass The class name for the object that is being requested.
  @param objectId The id of the object that is being requested.
 
- @returns The <PFObject> if found. Returns `nil` if the object isn't found, or if there was an error.
+ @return The <PFObject> if found. Returns `nil` if the object isn't found, or if there was an error.
  */
 + (nullable PFGenericObject)getObjectOfClass:(NSString *)objectClass
                                     objectId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
@@ -517,7 +517,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param objectId The id of the object that is being requested.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns The <PFObject> if found. Returns `nil` if the object isn't found, or if there was an `error`.
+ @return The <PFObject> if found. Returns `nil` if the object isn't found, or if there was an `error`.
  */
 + (nullable PFGenericObject)getObjectOfClass:(NSString *)objectClass
                                     objectId:(NSString *)objectId
@@ -531,7 +531,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param objectId The id of the object that is being requested.
 
- @returns The <PFObject> if found. Returns nil if the object isn't found, or if there was an error.
+ @return The <PFObject> if found. Returns nil if the object isn't found, or if there was an error.
  */
 - (nullable PFGenericObject)getObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
@@ -544,7 +544,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  @param objectId The id of the object that is being requested.
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns The <PFObject> if found. Returns nil if the object isn't found, or if there was an error.
+ @return The <PFObject> if found. Returns nil if the object isn't found, or if there was an error.
  */
 - (nullable PFGenericObject)getObjectWithId:(NSString *)objectId error:(NSError **)error;
 
@@ -556,7 +556,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param objectId The id of the object that is being requested.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(PFGenericObject) *)getObjectInBackgroundWithId:(NSString *)objectId;
 
@@ -597,7 +597,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param objectId The id of the object that is being requested.
 
- @returns The PFUser if found. Returns nil if the object isn't found, or if there was an error.
+ @return The PFUser if found. Returns nil if the object isn't found, or if there was an error.
  */
 + (nullable PFUser *)getUserObjectWithId:(NSString *)objectId PF_SWIFT_UNAVAILABLE;
 
@@ -621,7 +621,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Finds objects *synchronously* based on the constructed query.
 
- @returns Returns an array of <PFObject> objects that were found.
+ @return Returns an array of <PFObject> objects that were found.
  */
 - (nullable NSArray PF_GENERIC(PFGenericObject) *)findObjects PF_SWIFT_UNAVAILABLE;
 
@@ -630,14 +630,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns an array of <PFObject> objects that were found.
+ @return Returns an array of <PFObject> objects that were found.
  */
 - (nullable NSArray PF_GENERIC(PFGenericObject) *)findObjects:(NSError **)error;
 
 /**
  Finds objects *asynchronously* and sets the `NSArray` of <PFObject> objects as a result of the task.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSArray<PFGenericObject> *)*)findObjectsInBackground;
 
@@ -668,7 +668,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @warning This method mutates the query. It will reset the limit to `1`.
 
- @returns Returns a <PFObject>, or `nil` if none was found.
+ @return Returns a <PFObject>, or `nil` if none was found.
  */
 - (nullable PFGenericObject)getFirstObject PF_SWIFT_UNAVAILABLE;
 
@@ -679,7 +679,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns a <PFObject>, or `nil` if none was found.
+ @return Returns a <PFObject>, or `nil` if none was found.
  */
 - (nullable PFGenericObject)getFirstObject:(NSError **)error;
 
@@ -688,7 +688,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @warning This method mutates the query. It will reset the limit to `1`.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(PFGenericObject) *)getFirstObjectInBackground;
 
@@ -724,7 +724,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 /**
  Counts objects *synchronously* based on the constructed query.
 
- @returns Returns the number of <PFObject> objects that match the query, or `-1` if there is an error.
+ @return Returns the number of <PFObject> objects that match the query, or `-1` if there is an error.
  */
 - (NSInteger)countObjects PF_SWIFT_UNAVAILABLE;
 
@@ -733,14 +733,14 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param error Pointer to an `NSError` that will be set if necessary.
 
- @returns Returns the number of <PFObject> objects that match the query, or `-1` if there is an error.
+ @return Returns the number of <PFObject> objects that match the query, or `-1` if there is an error.
  */
 - (NSInteger)countObjects:(NSError **)error;
 
 /**
  Counts objects *asynchronously* and sets `NSNumber` with count as a result of the task.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)countObjectsInBackground;
 
@@ -833,7 +833,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @warning Requires Local Datastore to be enabled.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
 
  @see cachePolicy
  */
@@ -844,7 +844,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @warning Requires Local Datastore to be enabled.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
 
  @see PFObjectDefaultPin
  @see cachePolicy
@@ -858,7 +858,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @param name The pinned group.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
 
  @see PFObjectDefaultPin
  @see cachePolicy
@@ -872,7 +872,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 
  @warning Requires Local Datastore to be enabled.
 
- @returns The same instance of `PFQuery` as the receiver. This allows method chaining.
+ @return The same instance of `PFQuery` as the receiver. This allows method chaining.
  */
 - (instancetype)ignoreACLs;
 

--- a/Parse/PFQuery.m
+++ b/Parse/PFQuery.m
@@ -59,7 +59,7 @@ NSString *const PFQueryOptionKeyMaxDistance = @"$maxDistance";
 NSString *const PFQueryOptionKeyBox = @"$box";
 NSString *const PFQueryOptionKeyRegexOptions = @"$options";
 
-/*!
+/**
  Checks if an object can be used as value for query equality clauses.
  */
 static void PFQueryAssertValidEqualityClauseClass(id object) {
@@ -79,7 +79,7 @@ static void PFQueryAssertValidEqualityClauseClass(id object) {
     PFParameterAssert(NO, @"Cannot do a comparison query for type: %@", [object class]);
 }
 
-/*!
+/**
  Checks if an object can be used as value for query ordering clauses.
  */
 static void PFQueryAssertValidOrderingClauseClass(id object) {
@@ -559,7 +559,7 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
     }
 }
 
-/*!
+/**
  Creates a PFQuery with the constraints given by predicate.
  This method assumes the predicate has already been normalized.
  */
@@ -1054,7 +1054,7 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
 #pragma mark - Check Pinning Status
 ///--------------------------------------
 
-/*!
+/**
  If `enabled` is YES, raise an exception if OfflineStore is not enabled. If `enabled` is NO, raise
  an exception if OfflineStore is enabled.
  */

--- a/Parse/PFRelation.h
+++ b/Parse/PFRelation.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFRelation : NSObject
 
 /**
- @abstract The name of the class of the target child objects.
+ The name of the class of the target child objects.
  */
 @property (nullable, nonatomic, copy) NSString *targetClass;
 
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Returns a <PFQuery> object that can be used to get objects in this relation.
+ Returns a <PFQuery> object that can be used to get objects in this relation.
  */
 - (PFQuery *)query;
 
@@ -39,14 +39,14 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Adds a relation to the passed in object.
+ Adds a relation to the passed in object.
 
  @param object A <PFObject> object to add relation to.
  */
 - (void)addObject:(PFObject *)object;
 
 /**
- @abstract Removes a relation to the passed in object.
+ Removes a relation to the passed in object.
 
  @param object A <PFObject> object to add relation to.
  */

--- a/Parse/PFRelation.h
+++ b/Parse/PFRelation.h
@@ -14,13 +14,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  The `PFRelation` class that is used to access all of the children of a many-to-many relationship.
  Each instance of `PFRelation` is associated with a particular parent object and key.
  */
 @interface PFRelation : NSObject
 
-/*!
+/**
  @abstract The name of the class of the target child objects.
  */
 @property (nullable, nonatomic, copy) NSString *targetClass;
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Accessing Objects
 ///--------------------------------------
 
-/*!
+/**
  @abstract Returns a <PFQuery> object that can be used to get objects in this relation.
  */
 - (PFQuery *)query;
@@ -38,14 +38,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Modifying Relations
 ///--------------------------------------
 
-/*!
+/**
  @abstract Adds a relation to the passed in object.
 
  @param object A <PFObject> object to add relation to.
  */
 - (void)addObject:(PFObject *)object;
 
-/*!
+/**
  @abstract Removes a relation to the passed in object.
 
  @param object A <PFObject> object to add relation to.

--- a/Parse/PFRelation.h
+++ b/Parse/PFRelation.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- Returns a <PFQuery> object that can be used to get objects in this relation.
+ Returns a `PFQuery` object that can be used to get objects in this relation.
  */
 - (PFQuery *)query;
 
@@ -41,14 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Adds a relation to the passed in object.
 
- @param object A <PFObject> object to add relation to.
+ @param object A `PFObject` object to add relation to.
  */
 - (void)addObject:(PFObject *)object;
 
 /**
  Removes a relation to the passed in object.
 
- @param object A <PFObject> object to add relation to.
+ @param object A `PFObject` object to add relation to.
  */
 - (void)removeObject:(PFObject *)object;
 

--- a/Parse/PFRelation.m
+++ b/Parse/PFRelation.m
@@ -207,7 +207,7 @@ static NSString *const PFRelationKeyObjects = @"objects";
              };
 }
 
-/*!
+/**
  Returns true if and only if this object was ever known to be in the relation.
  This is used for offline caching.
  */

--- a/Parse/PFRole.h
+++ b/Parse/PFRole.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Constructs a new `PFRole` with the given name.
 
- @discussion If no default ACL has been specified, you must provide an ACL for the role.
+ If no default ACL has been specified, you must provide an ACL for the role.
 
  @param name The name of the Role to create.
  */
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Gets or sets the name for a role.
 
- @discussion This value must be set before the role has been saved to the server,
+ This value must be set before the role has been saved to the server,
  and cannot be set once the role has been saved.
 
  @warning A role's name can only contain alphanumeric characters, `_`, `-`, and spaces.
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Gets the <PFRelation> for the <PFUser> objects that are direct children of this role.
 
- @discussion These users are granted any privileges that this role has been granted
+ These users are granted any privileges that this role has been granted
  (e.g. read or write access through ACLs). You can add or remove users from
  the role through this relation.
  */
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Gets the <PFRelation> for the `PFRole` objects that are direct children of this role.
 
- @discussion These roles' users are granted any privileges that this role has been granted
+ These roles' users are granted any privileges that this role has been granted
  (e.g. read or write access through ACLs). You can add or remove child roles
  from this role through this relation.
  */

--- a/Parse/PFRole.h
+++ b/Parse/PFRole.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Constructs a new `PFRole` with the given name.
+ Constructs a new `PFRole` with the given name.
  If no default ACL has been specified, you must provide an ACL for the role.
 
  @param name The name of the Role to create.
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithName:(NSString *)name;
 
 /**
- @abstract Constructs a new `PFRole` with the given name.
+ Constructs a new `PFRole` with the given name.
 
  @param name The name of the Role to create.
  @param acl The ACL for this role. Roles must have an ACL.
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithName:(NSString *)name acl:(nullable PFACL *)acl;
 
 /**
- @abstract Constructs a new `PFRole` with the given name.
+ Constructs a new `PFRole` with the given name.
 
  @discussion If no default ACL has been specified, you must provide an ACL for the role.
 
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)roleWithName:(NSString *)name;
 
 /**
- @abstract Constructs a new `PFRole` with the given name.
+ Constructs a new `PFRole` with the given name.
 
  @param name The name of the Role to create.
  @param acl The ACL for this role. Roles must have an ACL.
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Gets or sets the name for a role.
+ Gets or sets the name for a role.
 
  @discussion This value must be set before the role has been saved to the server,
  and cannot be set once the role has been saved.
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *name;
 
 /**
- @abstract Gets the <PFRelation> for the <PFUser> objects that are direct children of this role.
+ Gets the <PFRelation> for the <PFUser> objects that are direct children of this role.
 
  @discussion These users are granted any privileges that this role has been granted
  (e.g. read or write access through ACLs). You can add or remove users from
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) PFRelation *users;
 
 /**
- @abstract Gets the <PFRelation> for the `PFRole` objects that are direct children of this role.
+ Gets the <PFRelation> for the `PFRole` objects that are direct children of this role.
 
  @discussion These roles' users are granted any privileges that this role has been granted
  (e.g. read or write access through ACLs). You can add or remove child roles

--- a/Parse/PFRole.h
+++ b/Parse/PFRole.h
@@ -16,8 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The `PFRole` class represents a Role on the Parse server.
- `PFRoles` represent groupings of <PFUser> objects for the purposes of granting permissions
- (e.g. specifying a <PFACL> for a <PFObject>).
+ `PFRoles` represent groupings of `PFUser` objects for the purposes of granting permissions
+ (e.g. specifying a `PFACL` for a `PFObject`).
  Roles are specified by their sets of child users and child roles,
  all of which are granted any permissions that the parent role has.
 
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *name;
 
 /**
- Gets the <PFRelation> for the <PFUser> objects that are direct children of this role.
+ Gets the `PFRelation` for the `PFUser` objects that are direct children of this role.
 
  These users are granted any privileges that this role has been granted
  (e.g. read or write access through ACLs). You can add or remove users from
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) PFRelation *users;
 
 /**
- Gets the <PFRelation> for the `PFRole` objects that are direct children of this role.
+ Gets the `PFRelation` for the `PFRole` objects that are direct children of this role.
 
  These roles' users are granted any privileges that this role has been granted
  (e.g. read or write access through ACLs). You can add or remove child roles

--- a/Parse/PFRole.h
+++ b/Parse/PFRole.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  The `PFRole` class represents a Role on the Parse server.
  `PFRoles` represent groupings of <PFUser> objects for the purposes of granting permissions
  (e.g. specifying a <PFACL> for a <PFObject>).
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Creating a New Role
 ///--------------------------------------
 
-/*!
+/**
  @abstract Constructs a new `PFRole` with the given name.
  If no default ACL has been specified, you must provide an ACL for the role.
 
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithName:(NSString *)name;
 
-/*!
+/**
  @abstract Constructs a new `PFRole` with the given name.
 
  @param name The name of the Role to create.
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithName:(NSString *)name acl:(nullable PFACL *)acl;
 
-/*!
+/**
  @abstract Constructs a new `PFRole` with the given name.
 
  @discussion If no default ACL has been specified, you must provide an ACL for the role.
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)roleWithName:(NSString *)name;
 
-/*!
+/**
  @abstract Constructs a new `PFRole` with the given name.
 
  @param name The name of the Role to create.
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Role-specific Properties
 ///--------------------------------------
 
-/*!
+/**
  @abstract Gets or sets the name for a role.
 
  @discussion This value must be set before the role has been saved to the server,
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy) NSString *name;
 
-/*!
+/**
  @abstract Gets the <PFRelation> for the <PFUser> objects that are direct children of this role.
 
  @discussion These users are granted any privileges that this role has been granted
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, readonly) PFRelation *users;
 
-/*!
+/**
  @abstract Gets the <PFRelation> for the `PFRole` objects that are direct children of this role.
 
  @discussion These roles' users are granted any privileges that this role has been granted

--- a/Parse/PFSession.h
+++ b/Parse/PFSession.h
@@ -22,8 +22,8 @@ typedef void(^PFSessionResultBlock)(PFSession *__nullable session, NSError *__nu
 
 /**
  `PFSession` is a local representation of a session.
- This class is a subclass of a <PFObject>,
- and retains the same functionality as any other subclass of <PFObject>.
+ This class is a subclass of a `PFObject`,
+ and retains the same functionality as any other subclass of `PFObject`.
  */
 @interface PFSession : PFObject<PFSubclassing>
 

--- a/Parse/PFSession.h
+++ b/Parse/PFSession.h
@@ -28,7 +28,7 @@ typedef void(^PFSessionResultBlock)(PFSession *__nullable session, NSError *__nu
 @interface PFSession : PFObject<PFSubclassing>
 
 /**
- @abstract The session token string for this session.
+ The session token string for this session.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *sessionToken;
 

--- a/Parse/PFSession.h
+++ b/Parse/PFSession.h
@@ -20,26 +20,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^PFSessionResultBlock)(PFSession *__nullable session, NSError *__nullable error);
 
-/*!
+/**
  `PFSession` is a local representation of a session.
  This class is a subclass of a <PFObject>,
  and retains the same functionality as any other subclass of <PFObject>.
  */
 @interface PFSession : PFObject<PFSubclassing>
 
-/*!
+/**
  @abstract The session token string for this session.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *sessionToken;
 
-/*!
+/**
  *Asynchronously* fetches a `PFSession` object related to the current user.
 
  @returns A task that is `completed` with an instance of `PFSession` class or is `faulted` if the operation fails.
  */
 + (BFTask PF_GENERIC(PFSession *)*)getCurrentSessionInBackground;
 
-/*!
+/**
  *Asynchronously* fetches a `PFSession` object related to the current user.
 
  @param block The block to execute when the operation completes.

--- a/Parse/PFSession.h
+++ b/Parse/PFSession.h
@@ -35,7 +35,7 @@ typedef void(^PFSessionResultBlock)(PFSession *__nullable session, NSError *__nu
 /**
  *Asynchronously* fetches a `PFSession` object related to the current user.
 
- @returns A task that is `completed` with an instance of `PFSession` class or is `faulted` if the operation fails.
+ @return A task that is `completed` with an instance of `PFSession` class or is `faulted` if the operation fails.
  */
 + (BFTask PF_GENERIC(PFSession *)*)getCurrentSessionInBackground;
 

--- a/Parse/PFSubclassing.h
+++ b/Parse/PFSubclassing.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  object of a registered subclass instead if one is known.
  A default implementation is provided by <PFObject> which should always be sufficient.
 
- @returns Returns the object that is instantiated.
+ @return Returns the object that is instantiated.
  */
 + (instancetype)object;
 
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param objectId The object id for the referenced object.
 
- @returns A new <PFObject> without data.
+ @return A new <PFObject> without data.
  */
 + (instancetype)objectWithoutDataWithObjectId:(nullable NSString *)objectId;
 
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param predicate The predicate to create conditions from.
 
- @returns An instance of <PFQuery>.
+ @return An instance of <PFQuery>.
 
  @see [PFQuery queryWithClassName:predicate:]
  */

--- a/Parse/PFSubclassing.h
+++ b/Parse/PFSubclassing.h
@@ -14,22 +14,22 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- If a subclass of <PFObject> conforms to `PFSubclassing` and calls <registerSubclass>,
+ If a subclass of `PFObject` conforms to `PFSubclassing` and calls `PFObject.+registerSubclass`,
  Parse framework will be able to use that class as the native class for a Parse cloud object.
 
- Classes conforming to this protocol should subclass <PFObject> and
+ Classes conforming to this protocol should subclass `PFObject` and
  include `PFObject+Subclass.h` in their implementation file.
- This ensures the methods in the Subclass category of <PFObject> are exposed in its subclasses only.
+ This ensures the methods in the Subclass category of `PFObject` are exposed in its subclasses only.
  */
 @protocol PFSubclassing
 
 /**
- Constructs an object of the most specific class known to implement <parseClassName>.
+ Constructs an object of the most specific class known to implement `+parseClassName`.
 
- This method takes care to help <PFObject> subclasses be subclassed themselves.
- For example, `[PFUser object]` returns a <PFUser> by default but will return an
+ This method takes care to help `PFObject` subclasses be subclassed themselves.
+ For example, `PFUser.+object` returns a `PFUser` by default but will return an
  object of a registered subclass instead if one is known.
- A default implementation is provided by <PFObject> which should always be sufficient.
+ A default implementation is provided by `PFObject` which should always be sufficient.
 
  @return Returns the object that is instantiated.
  */
@@ -38,13 +38,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
- Calling <PFObject.dataAvailable> on this object will return `NO`
- until <[PFObject fetchIfNeeded]> has been called. No network request will be made.
- A default implementation is provided by PFObject which should always be sufficient.
+ Calling `PFObject.dataAvailable` on this object will return `NO`
+ until `PFObject.-fetchIfNeeded` has been called. No network request will be made.
+ A default implementation is provided by `PFObject` which should always be sufficient.
 
  @param objectId The object id for the referenced object.
 
- @return A new <PFObject> without data.
+ @return A new `PFObject` without data.
  */
 + (instancetype)objectWithoutDataWithObjectId:(nullable NSString *)objectId;
 
@@ -56,27 +56,27 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Create a query which returns objects of this type.
 
- A default implementation is provided by <PFObject> which should always be sufficient.
+ A default implementation is provided by `PFObject` which should always be sufficient.
  */
 + (nullable PFQuery *)query;
 
 /**
  Returns a query for objects of this type with a given predicate.
 
- A default implementation is provided by <PFObject> which should always be sufficient.
+ A default implementation is provided by `PFObject` which should always be sufficient.
 
  @param predicate The predicate to create conditions from.
 
- @return An instance of <PFQuery>.
+ @return An instance of `PFQuery`.
 
  @see [PFQuery queryWithClassName:predicate:]
  */
 + (nullable PFQuery *)queryWithPredicate:(nullable NSPredicate *)predicate;
 
 /**
- Lets Parse know this class should be used to instantiate all objects with class type <parseClassName>.
+ Lets Parse know this class should be used to instantiate all objects with class type `parseClassName`.
 
- @warning This method must be called before <[Parse setApplicationId:clientKey:]>
+ @warning This method must be called before `Parse.+setApplicationId:clientKey:`.
  */
 + (void)registerSubclass;
 

--- a/Parse/PFSubclassing.h
+++ b/Parse/PFSubclassing.h
@@ -13,7 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  If a subclass of <PFObject> conforms to `PFSubclassing` and calls <registerSubclass>,
  Parse framework will be able to use that class as the native class for a Parse cloud object.
 
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol PFSubclassing
 
-/*!
+/**
  @abstract Constructs an object of the most specific class known to implement <parseClassName>.
 
  @discussion This method takes care to help <PFObject> subclasses be subclassed themselves.
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)object;
 
-/*!
+/**
  @abstract Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
  @discussion Calling <PFObject.dataAvailable> on this object will return `NO`
@@ -48,19 +48,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (instancetype)objectWithoutDataWithObjectId:(nullable NSString *)objectId;
 
-/*!
+/**
  @abstract The name of the class as seen in the REST API.
  */
 + (NSString *)parseClassName;
 
-/*!
+/**
  @abstract Create a query which returns objects of this type.
 
  @discussion A default implementation is provided by <PFObject> which should always be sufficient.
  */
 + (nullable PFQuery *)query;
 
-/*!
+/**
  @abstract Returns a query for objects of this type with a given predicate.
 
  @discussion A default implementation is provided by <PFObject> which should always be sufficient.
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable PFQuery *)queryWithPredicate:(nullable NSPredicate *)predicate;
 
-/*!
+/**
  @abstract Lets Parse know this class should be used to instantiate all objects with class type <parseClassName>.
 
  @warning This method must be called before <[Parse setApplicationId:clientKey:]>

--- a/Parse/PFSubclassing.h
+++ b/Parse/PFSubclassing.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol PFSubclassing
 
 /**
- @abstract Constructs an object of the most specific class known to implement <parseClassName>.
+ Constructs an object of the most specific class known to implement <parseClassName>.
 
  @discussion This method takes care to help <PFObject> subclasses be subclassed themselves.
  For example, `[PFUser object]` returns a <PFUser> by default but will return an
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)object;
 
 /**
- @abstract Creates a reference to an existing PFObject for use in creating associations between PFObjects.
+ Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
  @discussion Calling <PFObject.dataAvailable> on this object will return `NO`
  until <[PFObject fetchIfNeeded]> has been called. No network request will be made.
@@ -49,19 +49,19 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)objectWithoutDataWithObjectId:(nullable NSString *)objectId;
 
 /**
- @abstract The name of the class as seen in the REST API.
+ The name of the class as seen in the REST API.
  */
 + (NSString *)parseClassName;
 
 /**
- @abstract Create a query which returns objects of this type.
+ Create a query which returns objects of this type.
 
  @discussion A default implementation is provided by <PFObject> which should always be sufficient.
  */
 + (nullable PFQuery *)query;
 
 /**
- @abstract Returns a query for objects of this type with a given predicate.
+ Returns a query for objects of this type with a given predicate.
 
  @discussion A default implementation is provided by <PFObject> which should always be sufficient.
 
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable PFQuery *)queryWithPredicate:(nullable NSPredicate *)predicate;
 
 /**
- @abstract Lets Parse know this class should be used to instantiate all objects with class type <parseClassName>.
+ Lets Parse know this class should be used to instantiate all objects with class type <parseClassName>.
 
  @warning This method must be called before <[Parse setApplicationId:clientKey:]>
  */

--- a/Parse/PFSubclassing.h
+++ b/Parse/PFSubclassing.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Constructs an object of the most specific class known to implement <parseClassName>.
 
- @discussion This method takes care to help <PFObject> subclasses be subclassed themselves.
+ This method takes care to help <PFObject> subclasses be subclassed themselves.
  For example, `[PFUser object]` returns a <PFUser> by default but will return an
  object of a registered subclass instead if one is known.
  A default implementation is provided by <PFObject> which should always be sufficient.
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Creates a reference to an existing PFObject for use in creating associations between PFObjects.
 
- @discussion Calling <PFObject.dataAvailable> on this object will return `NO`
+ Calling <PFObject.dataAvailable> on this object will return `NO`
  until <[PFObject fetchIfNeeded]> has been called. No network request will be made.
  A default implementation is provided by PFObject which should always be sufficient.
 
@@ -56,14 +56,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Create a query which returns objects of this type.
 
- @discussion A default implementation is provided by <PFObject> which should always be sufficient.
+ A default implementation is provided by <PFObject> which should always be sufficient.
  */
 + (nullable PFQuery *)query;
 
 /**
  Returns a query for objects of this type with a given predicate.
 
- @discussion A default implementation is provided by <PFObject> which should always be sufficient.
+ A default implementation is provided by <PFObject> which should always be sufficient.
 
  @param predicate The predicate to create conditions from.
 

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -23,7 +23,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 @class PFQuery PF_GENERIC(PFGenericObject : PFObject *);
 @protocol PFUserAuthenticationDelegate;
 
-/*!
+/**
  The `PFUser` class is a local representation of a user persisted to the Parse Data.
  This class is a subclass of a <PFObject>, and retains the same functionality of a <PFObject>,
  but also extends it with various user specific methods, like authentication, signing up, and validation uniqueness.
@@ -38,28 +38,28 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /// @name Accessing the Current User
 ///--------------------------------------
 
-/*!
+/**
  @abstract Gets the currently logged in user from disk and returns an instance of it.
 
  @returns Returns a `PFUser` that is the currently logged in user. If there is none, returns `nil`.
  */
 + (nullable instancetype)currentUser;
 
-/*!
+/**
  @abstract The session token for the `PFUser`.
 
  @discussion This is set by the server upon successful authentication.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *sessionToken;
 
-/*!
+/**
  @abstract Whether the `PFUser` was just created from a request.
 
  @discussion This is only set after a Facebook or Twitter login.
  */
 @property (nonatomic, assign, readonly) BOOL isNew;
 
-/*!
+/**
  @abstract Whether the user is an authenticated object for the device.
 
  @discussion An authenticated `PFUser` is one that is obtained via a <signUp> or <logIn> method.
@@ -71,14 +71,14 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /// @name Creating a New User
 ///--------------------------------------
 
-/*!
+/**
  @abstract Creates a new `PFUser` object.
 
  @returns Returns a new `PFUser` object.
  */
 + (instancetype)user;
 
-/*!
+/**
  @abstract Enables automatic creation of anonymous users.
 
  @discussion After calling this method, <currentUser> will always have a value.
@@ -90,7 +90,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (void)enableAutomaticUser;
 
-/*!
+/**
  @abstract The username for the `PFUser`.
  */
 @property (nullable, nonatomic, strong) NSString *username;
@@ -103,12 +103,12 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 @property (nullable, nonatomic, strong) NSString *password;
 
-/*!
+/**
  @abstract The email for the `PFUser`.
  */
 @property (nullable, nonatomic, strong) NSString *email;
 
-/*!
+/**
  @abstract Signs up the user *synchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
@@ -119,7 +119,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 - (BOOL)signUp PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Signs up the user *synchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
@@ -132,7 +132,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 - (BOOL)signUp:(NSError **)error;
 
-/*!
+/**
  @abstract Signs up the user *asynchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
@@ -143,7 +143,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 - (BFTask PF_GENERIC(NSNumber *)*)signUpInBackground;
 
-/*!
+/**
  @abstract Signs up the user *asynchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
@@ -155,7 +155,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 - (void)signUpInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract Signs up the user *asynchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
@@ -174,7 +174,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /// @name Logging In
 ///--------------------------------------
 
-/*!
+/**
  @abstract Makes a *synchronous* request to login a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
@@ -189,7 +189,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (nullable instancetype)logInWithUsername:(NSString *)username
                                   password:(NSString *)password PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Makes a *synchronous* request to login a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
@@ -206,7 +206,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
                                   password:(NSString *)password
                                      error:(NSError **)error;
 
-/*!
+/**
  @abstract Makes an *asynchronous* request to login a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
@@ -220,7 +220,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (BFTask PF_GENERIC(__kindof PFUser *)*)logInWithUsernameInBackground:(NSString *)username
                                                               password:(NSString *)password;
 
-/*!
+/**
  @abstract Makes an *asynchronous* request to login a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
@@ -237,7 +237,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
                                target:(nullable id)target
                              selector:(nullable SEL)selector;
 
-/*!
+/**
  @abstract Makes an *asynchronous* request to log in a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
@@ -256,7 +256,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /// @name Becoming a User
 ///--------------------------------------
 
-/*!
+/**
  @abstract Makes a *synchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
@@ -269,7 +269,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (nullable instancetype)become:(NSString *)sessionToken PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract Makes a *synchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
@@ -283,7 +283,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (nullable instancetype)become:(NSString *)sessionToken error:(NSError **)error;
 
-/*!
+/**
  @abstract Makes an *asynchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
@@ -295,7 +295,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (BFTask PF_GENERIC(__kindof PFUser *)*)becomeInBackground:(NSString *)sessionToken;
 
-/*!
+/**
  @abstract Makes an *asynchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
@@ -307,7 +307,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (void)becomeInBackground:(NSString *)sessionToken block:(nullable PFUserResultBlock)block;
 
-/*!
+/**
  @abstract Makes an *asynchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
@@ -326,7 +326,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /// @name Revocable Session
 ///--------------------------------------
 
-/*!
+/**
  @abstract Enables revocable sessions and migrates the currentUser session token to use revocable session if needed.
 
  @discussion This method is required if you want to use <PFSession> APIs
@@ -338,7 +338,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (BFTask *)enableRevocableSessionInBackground;
 
-/*!
+/**
  @abstract Enables revocable sessions and upgrades the currentUser session token to use revocable session if needed.
 
  @discussion This method is required if you want to use <PFSession> APIs
@@ -353,12 +353,12 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /// @name Logging Out
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* logs out the currently logged in user on disk.
  */
 + (void)logOut;
 
-/*!
+/**
  @abstract *Asynchronously* logs out the currently logged in user.
 
  @discussion This will also remove the session from disk, log out of linked services
@@ -369,7 +369,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (BFTask *)logOutInBackground;
 
-/*!
+/**
  @abstract *Asynchronously* logs out the currently logged in user.
 
  @discussion This will also remove the session from disk, log out of linked services
@@ -384,7 +384,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /// @name Requesting a Password Reset
 ///--------------------------------------
 
-/*!
+/**
  @abstract *Synchronously* Send a password reset request for a specified email.
 
  @discussion If a user account exists with that email, an email will be sent to that address
@@ -396,7 +396,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (BOOL)requestPasswordResetForEmail:(NSString *)email PF_SWIFT_UNAVAILABLE;
 
-/*!
+/**
  @abstract *Synchronously* send a password reset request for a specified email and sets an error object.
 
  @discussion If a user account exists with that email, an email will be sent to that address
@@ -408,7 +408,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (BOOL)requestPasswordResetForEmail:(NSString *)email error:(NSError **)error;
 
-/*!
+/**
  @abstract Send a password reset request asynchronously for a specified email and sets an
  error object. If a user account exists with that email, an email will be sent to
  that address with instructions on how to reset their password.
@@ -417,7 +417,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (BFTask PF_GENERIC(NSNumber *)*)requestPasswordResetForEmailInBackground:(NSString *)email;
 
-/*!
+/**
  @abstract Send a password reset request *asynchronously* for a specified email.
 
  @discussion If a user account exists with that email, an email will be sent to that address
@@ -430,7 +430,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (void)requestPasswordResetForEmailInBackground:(NSString *)email
                                            block:(nullable PFBooleanResultBlock)block;
 
-/*!
+/**
  @abstract Send a password reset request *asynchronously* for a specified email and sets an error object.
 
  @discussion If a user account exists with that email, an email will be sent to that address
@@ -451,7 +451,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /// @name Third-party Authentication
 ///--------------------------------------
 
-/*!
+/**
  @abstract Registers a third party authentication delegate.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
@@ -462,7 +462,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 + (void)registerAuthenticationDelegate:(id<PFUserAuthenticationDelegate>)delegate forAuthType:(NSString *)authType;
 
-/*!
+/**
  @abstract Logs in a user with third party authentication credentials.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
@@ -476,7 +476,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (BFTask PF_GENERIC(PFUser *)*)logInWithAuthTypeInBackground:(NSString *)authType
                                                      authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;
 
-/*!
+/**
  @abstract Links this user to a third party authentication library.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
@@ -490,7 +490,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 - (BFTask PF_GENERIC(NSNumber *)*)linkWithAuthTypeInBackground:(NSString *)authType
                                                       authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;
 
-/*!
+/**
  @abstract Unlinks this user from a third party authentication library.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
@@ -502,7 +502,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 - (BFTask PF_GENERIC(NSNumber *)*)unlinkWithAuthTypeInBackground:(NSString *)authType;
 
-/*!
+/**
  @abstract Indicates whether this user is linked with a third party authentication library of a specific type.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -41,7 +41,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Gets the currently logged in user from disk and returns an instance of it.
 
- @returns Returns a `PFUser` that is the currently logged in user. If there is none, returns `nil`.
+ @return Returns a `PFUser` that is the currently logged in user. If there is none, returns `nil`.
  */
 + (nullable instancetype)currentUser;
 
@@ -74,7 +74,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Creates a new `PFUser` object.
 
- @returns Returns a new `PFUser` object.
+ @return Returns a new `PFUser` object.
  */
 + (instancetype)user;
 
@@ -115,7 +115,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @warning Make sure that password and username are set before calling this method.
 
- @returns Returns `YES` if the sign up was successful, otherwise `NO`.
+ @return Returns `YES` if the sign up was successful, otherwise `NO`.
  */
 - (BOOL)signUp PF_SWIFT_UNAVAILABLE;
 
@@ -128,7 +128,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @param error Error object to set on error.
 
- @returns Returns whether the sign up was successful.
+ @return Returns whether the sign up was successful.
  */
 - (BOOL)signUp:(NSError **)error;
 
@@ -139,7 +139,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @warning Make sure that password and username are set before calling this method.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)signUpInBackground;
 
@@ -183,7 +183,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @param username The username of the user.
  @param password The password of the user.
 
- @returns Returns an instance of the `PFUser` on success.
+ @return Returns an instance of the `PFUser` on success.
  If login failed for either wrong password or wrong username, returns `nil`.
  */
 + (nullable instancetype)logInWithUsername:(NSString *)username
@@ -199,7 +199,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @param password The password of the user.
  @param error The error object to set on error.
 
- @returns Returns an instance of the `PFUser` on success.
+ @return Returns an instance of the `PFUser` on success.
  If login failed for either wrong password or wrong username, returns `nil`.
  */
 + (nullable instancetype)logInWithUsername:(NSString *)username
@@ -215,7 +215,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @param username The username of the user.
  @param password The password of the user.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(__kindof PFUser *)*)logInWithUsernameInBackground:(NSString *)username
                                                               password:(NSString *)password;
@@ -264,7 +264,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @param sessionToken The session token for the user.
 
- @returns Returns an instance of the `PFUser` on success.
+ @return Returns an instance of the `PFUser` on success.
  If becoming a user fails due to incorrect token, it returns `nil`.
  */
 + (nullable instancetype)become:(NSString *)sessionToken PF_SWIFT_UNAVAILABLE;
@@ -278,7 +278,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @param sessionToken The session token for the user.
  @param error The error object to set on error.
 
- @returns Returns an instance of the `PFUser` on success.
+ @return Returns an instance of the `PFUser` on success.
  If becoming a user fails due to incorrect token, it returns `nil`.
  */
 + (nullable instancetype)become:(NSString *)sessionToken error:(NSError **)error;
@@ -291,7 +291,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @param sessionToken The session token for the user.
 
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(__kindof PFUser *)*)becomeInBackground:(NSString *)sessionToken;
 
@@ -333,7 +333,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  and your application's 'Require Revocable Session' setting is turned off on `http://parse.com` app settings.
  After returned `BFTask` completes - <PFSession> class and APIs will be available for use.
 
- @returns An instance of `BFTask` that is completed when revocable
+ @return An instance of `BFTask` that is completed when revocable
  sessions are enabled and currentUser token is migrated.
  */
 + (BFTask *)enableRevocableSessionInBackground;
@@ -365,7 +365,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  and all future calls to <currentUser> will return `nil`. This is preferrable to using <logOut>,
  unless your code is already running from a background thread.
 
- @returns An instance of `BFTask`, that is resolved with `nil` result when logging out completes.
+ @return An instance of `BFTask`, that is resolved with `nil` result when logging out completes.
  */
 + (BFTask *)logOutInBackground;
 
@@ -392,7 +392,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @param email Email of the account to send a reset password request.
 
- @returns Returns `YES` if the reset email request is successful. `NO` - if no account was found for the email address.
+ @return Returns `YES` if the reset email request is successful. `NO` - if no account was found for the email address.
  */
 + (BOOL)requestPasswordResetForEmail:(NSString *)email PF_SWIFT_UNAVAILABLE;
 
@@ -404,7 +404,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @param email Email of the account to send a reset password request.
  @param error Error object to set on error.
- @returns Returns `YES` if the reset email request is successful. `NO` - if no account was found for the email address.
+ @return Returns `YES` if the reset email request is successful. `NO` - if no account was found for the email address.
  */
 + (BOOL)requestPasswordResetForEmail:(NSString *)email error:(NSError **)error;
 
@@ -413,7 +413,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  error object. If a user account exists with that email, an email will be sent to
  that address with instructions on how to reset their password.
  @param email Email of the account to send a reset password request.
- @returns The task, that encapsulates the work being done.
+ @return The task, that encapsulates the work being done.
  */
 + (BFTask PF_GENERIC(NSNumber *)*)requestPasswordResetForEmailInBackground:(NSString *)email;
 
@@ -471,7 +471,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @param authType The name of the type of third party authentication source.
  @param authData The user credentials of the third party authentication source.
 
- @returns A `BFTask` that is resolved to `PFUser` when logging in completes.
+ @return A `BFTask` that is resolved to `PFUser` when logging in completes.
  */
 + (BFTask PF_GENERIC(PFUser *)*)logInWithAuthTypeInBackground:(NSString *)authType
                                                      authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;
@@ -485,7 +485,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @param authType The name of the type of third party authentication source.
  @param authData The user credentials of the third party authentication source.
 
- @returns A `BFTask` that is resolved to `@YES` if linking succeeds.
+ @return A `BFTask` that is resolved to `@YES` if linking succeeds.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)linkWithAuthTypeInBackground:(NSString *)authType
                                                       authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;
@@ -498,7 +498,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @param authType The name of the type of third party authentication source.
 
- @returns A `BFTask` that is resolved to `@YES` if unlinking succeeds.
+ @return A `BFTask` that is resolved to `@YES` if unlinking succeeds.
  */
 - (BFTask PF_GENERIC(NSNumber *)*)unlinkWithAuthTypeInBackground:(NSString *)authType;
 
@@ -510,7 +510,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @param authType The name of the type of third party authentication source.
 
- @returns `YES` if the user is linked with a provider, otherwise `NO`.
+ @return `YES` if the user is linked with a provider, otherwise `NO`.
  */
 - (BOOL)isLinkedWithAuthType:(NSString *)authType;
 

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -25,11 +25,11 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
 /**
  The `PFUser` class is a local representation of a user persisted to the Parse Data.
- This class is a subclass of a <PFObject>, and retains the same functionality of a <PFObject>,
+ This class is a subclass of a `PFObject`, and retains the same functionality of a `PFObject`,
  but also extends it with various user specific methods, like authentication, signing up, and validation uniqueness.
 
  Many APIs responsible for linking a `PFUser` with Facebook or Twitter have been deprecated in favor of dedicated
- utilities for each social network. See <PFFacebookUtils>, <PFTwitterUtils> and <PFAnonymousUtils> for more information.
+ utilities for each social network. See `PFFacebookUtils`, `PFTwitterUtils` and `PFAnonymousUtils` for more information.
  */
 
 @interface PFUser : PFObject <PFSubclassing>
@@ -62,7 +62,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Whether the user is an authenticated object for the device.
 
- An authenticated `PFUser` is one that is obtained via a <signUp> or <logIn> method.
+ An authenticated `PFUser` is one that is obtained via a `-signUp:` or `+logInWithUsername:password:` method.
  An authenticated object is required in order to save (with altered values) or delete it.
  */
 @property (nonatomic, assign, readonly, getter=isAuthenticated) BOOL authenticated;
@@ -81,11 +81,11 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Enables automatic creation of anonymous users.
 
- After calling this method, <currentUser> will always have a value.
+ After calling this method, `+currentUser` will always have a value.
  The user will only be created on the server once the user has been saved,
  or once an object with a relation to that user or an ACL that refers to the user has been saved.
 
- @warning <[PFObject saveEventually]> will not work on if an item being saved has a relation
+ @warning `PFObject.-saveEventually` will not work on if an item being saved has a relation
  to an automatic user that has never been saved.
  */
 + (void)enableAutomaticUser;
@@ -178,7 +178,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes a *synchronous* request to login a user with specified credentials.
 
  Returns an instance of the successfully logged in `PFUser`.
- This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
 
  @param username The username of the user.
  @param password The password of the user.
@@ -193,7 +193,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes a *synchronous* request to login a user with specified credentials.
 
  Returns an instance of the successfully logged in `PFUser`.
- This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
 
  @param username The username of the user.
  @param password The password of the user.
@@ -210,7 +210,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes an *asynchronous* request to login a user with specified credentials.
 
  Returns an instance of the successfully logged in `PFUser`.
- This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
 
  @param username The username of the user.
  @param password The password of the user.
@@ -224,7 +224,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes an *asynchronous* request to login a user with specified credentials.
 
  Returns an instance of the successfully logged in `PFUser`.
- This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
 
  @param username The username of the user.
  @param password The password of the user.
@@ -241,7 +241,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes an *asynchronous* request to log in a user with specified credentials.
 
  Returns an instance of the successfully logged in `PFUser`.
- This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
 
  @param username The username of the user.
  @param password The password of the user.
@@ -260,7 +260,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes a *synchronous* request to become a user with the given session token.
 
  Returns an instance of the successfully logged in `PFUser`.
- This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
 
  @param sessionToken The session token for the user.
 
@@ -273,7 +273,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes a *synchronous* request to become a user with the given session token.
 
  Returns an instance of the successfully logged in `PFUser`.
- This will also cache the user locally so that calls to <currentUser> will use the latest logged in user.
+ This will also cache the user locally so that calls to `+currentUser` will use the latest logged in user.
 
  @param sessionToken The session token for the user.
  @param error The error object to set on error.
@@ -287,7 +287,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes an *asynchronous* request to become a user with the given session token.
 
  Returns an instance of the successfully logged in `PFUser`.
- This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
 
  @param sessionToken The session token for the user.
 
@@ -299,7 +299,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes an *asynchronous* request to become a user with the given session token.
 
  Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
- so that calls to <currentUser> will use the latest logged in user.
+ so that calls to `+currentUser` will use the latest logged in user.
 
  @param sessionToken The session token for the user.
  @param block The block to execute.
@@ -311,7 +311,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  Makes an *asynchronous* request to become a user with the given session token.
 
  Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
- so that calls to <currentUser> will use the latest logged in user.
+ so that calls to `+currentUser` will use the latest logged in user.
 
  @param sessionToken The session token for the user.
  @param target Target object for the selector.
@@ -329,9 +329,9 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Enables revocable sessions and migrates the currentUser session token to use revocable session if needed.
 
- This method is required if you want to use <PFSession> APIs
+ This method is required if you want to use `PFSession` APIs
  and your application's 'Require Revocable Session' setting is turned off on `http://parse.com` app settings.
- After returned `BFTask` completes - <PFSession> class and APIs will be available for use.
+ After returned `BFTask` completes - `PFSession` class and APIs will be available for use.
 
  @return An instance of `BFTask` that is completed when revocable
  sessions are enabled and currentUser token is migrated.
@@ -341,9 +341,9 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Enables revocable sessions and upgrades the currentUser session token to use revocable session if needed.
 
- This method is required if you want to use <PFSession> APIs
+ This method is required if you want to use `PFSession` APIs
  and legacy sessions are enabled in your application settings on `http://parse.com/`.
- After returned `BFTask` completes - <PFSession> class and APIs will be available for use.
+ After returned `BFTask` completes - `PFSession` class and APIs will be available for use.
 
  @param block Block that will be called when revocable sessions are enabled and currentUser token is migrated.
  */
@@ -362,7 +362,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  *Asynchronously* logs out the currently logged in user.
 
  This will also remove the session from disk, log out of linked services
- and all future calls to <currentUser> will return `nil`. This is preferrable to using <logOut>,
+ and all future calls to `+currentUser` will return `nil`. This is preferrable to using `-logOut`,
  unless your code is already running from a background thread.
 
  @return An instance of `BFTask`, that is resolved with `nil` result when logging out completes.
@@ -373,7 +373,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  *Asynchronously* logs out the currently logged in user.
 
  This will also remove the session from disk, log out of linked services
- and all future calls to <currentUser> will return `nil`. This is preferrable to using <logOut>,
+ and all future calls to `+currentUser` will return `nil`. This is preferrable to using `-logOut`,
  unless your code is already running from a background thread.
 
  @param block A block that will be called when logging out completes or fails.

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -39,28 +39,28 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 ///--------------------------------------
 
 /**
- @abstract Gets the currently logged in user from disk and returns an instance of it.
+ Gets the currently logged in user from disk and returns an instance of it.
 
  @returns Returns a `PFUser` that is the currently logged in user. If there is none, returns `nil`.
  */
 + (nullable instancetype)currentUser;
 
 /**
- @abstract The session token for the `PFUser`.
+ The session token for the `PFUser`.
 
  @discussion This is set by the server upon successful authentication.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *sessionToken;
 
 /**
- @abstract Whether the `PFUser` was just created from a request.
+ Whether the `PFUser` was just created from a request.
 
  @discussion This is only set after a Facebook or Twitter login.
  */
 @property (nonatomic, assign, readonly) BOOL isNew;
 
 /**
- @abstract Whether the user is an authenticated object for the device.
+ Whether the user is an authenticated object for the device.
 
  @discussion An authenticated `PFUser` is one that is obtained via a <signUp> or <logIn> method.
  An authenticated object is required in order to save (with altered values) or delete it.
@@ -72,14 +72,14 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 ///--------------------------------------
 
 /**
- @abstract Creates a new `PFUser` object.
+ Creates a new `PFUser` object.
 
  @returns Returns a new `PFUser` object.
  */
 + (instancetype)user;
 
 /**
- @abstract Enables automatic creation of anonymous users.
+ Enables automatic creation of anonymous users.
 
  @discussion After calling this method, <currentUser> will always have a value.
  The user will only be created on the server once the user has been saved,
@@ -91,12 +91,12 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (void)enableAutomaticUser;
 
 /**
- @abstract The username for the `PFUser`.
+ The username for the `PFUser`.
  */
 @property (nullable, nonatomic, strong) NSString *username;
 
 /**!
- @abstract The password for the `PFUser`.
+ The password for the `PFUser`.
 
  @discussion This will not be filled in from the server with the password.
  It is only meant to be set.
@@ -104,12 +104,12 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 @property (nullable, nonatomic, strong) NSString *password;
 
 /**
- @abstract The email for the `PFUser`.
+ The email for the `PFUser`.
  */
 @property (nullable, nonatomic, strong) NSString *email;
 
 /**
- @abstract Signs up the user *synchronously*.
+ Signs up the user *synchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
 
@@ -120,7 +120,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 - (BOOL)signUp PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Signs up the user *synchronously*.
+ Signs up the user *synchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
 
@@ -133,7 +133,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 - (BOOL)signUp:(NSError **)error;
 
 /**
- @abstract Signs up the user *asynchronously*.
+ Signs up the user *asynchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
 
@@ -144,7 +144,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 - (BFTask PF_GENERIC(NSNumber *)*)signUpInBackground;
 
 /**
- @abstract Signs up the user *asynchronously*.
+ Signs up the user *asynchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
 
@@ -156,7 +156,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 - (void)signUpInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract Signs up the user *asynchronously*.
+ Signs up the user *asynchronously*.
 
  @discussion This will also enforce that the username isn't already taken.
 
@@ -175,7 +175,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 ///--------------------------------------
 
 /**
- @abstract Makes a *synchronous* request to login a user with specified credentials.
+ Makes a *synchronous* request to login a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
@@ -190,7 +190,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
                                   password:(NSString *)password PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Makes a *synchronous* request to login a user with specified credentials.
+ Makes a *synchronous* request to login a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
@@ -207,7 +207,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
                                      error:(NSError **)error;
 
 /**
- @abstract Makes an *asynchronous* request to login a user with specified credentials.
+ Makes an *asynchronous* request to login a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
@@ -221,7 +221,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
                                                               password:(NSString *)password;
 
 /**
- @abstract Makes an *asynchronous* request to login a user with specified credentials.
+ Makes an *asynchronous* request to login a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
@@ -238,7 +238,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
                              selector:(nullable SEL)selector;
 
 /**
- @abstract Makes an *asynchronous* request to log in a user with specified credentials.
+ Makes an *asynchronous* request to log in a user with specified credentials.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
@@ -257,7 +257,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 ///--------------------------------------
 
 /**
- @abstract Makes a *synchronous* request to become a user with the given session token.
+ Makes a *synchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
@@ -270,7 +270,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (nullable instancetype)become:(NSString *)sessionToken PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract Makes a *synchronous* request to become a user with the given session token.
+ Makes a *synchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
  This will also cache the user locally so that calls to <currentUser> will use the latest logged in user.
@@ -284,7 +284,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (nullable instancetype)become:(NSString *)sessionToken error:(NSError **)error;
 
 /**
- @abstract Makes an *asynchronous* request to become a user with the given session token.
+ Makes an *asynchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
@@ -296,7 +296,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (BFTask PF_GENERIC(__kindof PFUser *)*)becomeInBackground:(NSString *)sessionToken;
 
 /**
- @abstract Makes an *asynchronous* request to become a user with the given session token.
+ Makes an *asynchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
  so that calls to <currentUser> will use the latest logged in user.
@@ -308,7 +308,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (void)becomeInBackground:(NSString *)sessionToken block:(nullable PFUserResultBlock)block;
 
 /**
- @abstract Makes an *asynchronous* request to become a user with the given session token.
+ Makes an *asynchronous* request to become a user with the given session token.
 
  @discussion Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
  so that calls to <currentUser> will use the latest logged in user.
@@ -327,7 +327,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 ///--------------------------------------
 
 /**
- @abstract Enables revocable sessions and migrates the currentUser session token to use revocable session if needed.
+ Enables revocable sessions and migrates the currentUser session token to use revocable session if needed.
 
  @discussion This method is required if you want to use <PFSession> APIs
  and your application's 'Require Revocable Session' setting is turned off on `http://parse.com` app settings.
@@ -339,7 +339,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (BFTask *)enableRevocableSessionInBackground;
 
 /**
- @abstract Enables revocable sessions and upgrades the currentUser session token to use revocable session if needed.
+ Enables revocable sessions and upgrades the currentUser session token to use revocable session if needed.
 
  @discussion This method is required if you want to use <PFSession> APIs
  and legacy sessions are enabled in your application settings on `http://parse.com/`.
@@ -354,12 +354,12 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* logs out the currently logged in user on disk.
+ *Synchronously* logs out the currently logged in user on disk.
  */
 + (void)logOut;
 
 /**
- @abstract *Asynchronously* logs out the currently logged in user.
+ *Asynchronously* logs out the currently logged in user.
 
  @discussion This will also remove the session from disk, log out of linked services
  and all future calls to <currentUser> will return `nil`. This is preferrable to using <logOut>,
@@ -370,7 +370,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (BFTask *)logOutInBackground;
 
 /**
- @abstract *Asynchronously* logs out the currently logged in user.
+ *Asynchronously* logs out the currently logged in user.
 
  @discussion This will also remove the session from disk, log out of linked services
  and all future calls to <currentUser> will return `nil`. This is preferrable to using <logOut>,
@@ -385,7 +385,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 ///--------------------------------------
 
 /**
- @abstract *Synchronously* Send a password reset request for a specified email.
+ *Synchronously* Send a password reset request for a specified email.
 
  @discussion If a user account exists with that email, an email will be sent to that address
  with instructions on how to reset their password.
@@ -397,7 +397,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (BOOL)requestPasswordResetForEmail:(NSString *)email PF_SWIFT_UNAVAILABLE;
 
 /**
- @abstract *Synchronously* send a password reset request for a specified email and sets an error object.
+ *Synchronously* send a password reset request for a specified email and sets an error object.
 
  @discussion If a user account exists with that email, an email will be sent to that address
  with instructions on how to reset their password.
@@ -409,7 +409,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (BOOL)requestPasswordResetForEmail:(NSString *)email error:(NSError **)error;
 
 /**
- @abstract Send a password reset request asynchronously for a specified email and sets an
+ Send a password reset request asynchronously for a specified email and sets an
  error object. If a user account exists with that email, an email will be sent to
  that address with instructions on how to reset their password.
  @param email Email of the account to send a reset password request.
@@ -418,7 +418,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (BFTask PF_GENERIC(NSNumber *)*)requestPasswordResetForEmailInBackground:(NSString *)email;
 
 /**
- @abstract Send a password reset request *asynchronously* for a specified email.
+ Send a password reset request *asynchronously* for a specified email.
 
  @discussion If a user account exists with that email, an email will be sent to that address
  with instructions on how to reset their password.
@@ -431,7 +431,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
                                            block:(nullable PFBooleanResultBlock)block;
 
 /**
- @abstract Send a password reset request *asynchronously* for a specified email and sets an error object.
+ Send a password reset request *asynchronously* for a specified email and sets an error object.
 
  @discussion If a user account exists with that email, an email will be sent to that address
  with instructions on how to reset their password.
@@ -452,7 +452,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 ///--------------------------------------
 
 /**
- @abstract Registers a third party authentication delegate.
+ Registers a third party authentication delegate.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
  @see PFUserAuthenticationDelegate
@@ -463,7 +463,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (void)registerAuthenticationDelegate:(id<PFUserAuthenticationDelegate>)delegate forAuthType:(NSString *)authType;
 
 /**
- @abstract Logs in a user with third party authentication credentials.
+ Logs in a user with third party authentication credentials.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
  @see PFUserAuthenticationDelegate
@@ -477,7 +477,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
                                                      authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;
 
 /**
- @abstract Links this user to a third party authentication library.
+ Links this user to a third party authentication library.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
  @see PFUserAuthenticationDelegate
@@ -491,7 +491,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
                                                       authData:(NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;
 
 /**
- @abstract Unlinks this user from a third party authentication library.
+ Unlinks this user from a third party authentication library.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
  @see PFUserAuthenticationDelegate
@@ -503,7 +503,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 - (BFTask PF_GENERIC(NSNumber *)*)unlinkWithAuthTypeInBackground:(NSString *)authType;
 
 /**
- @abstract Indicates whether this user is linked with a third party authentication library of a specific type.
+ Indicates whether this user is linked with a third party authentication library of a specific type.
 
  @note This method shouldn't be invoked directly unless developing a third party authentication library.
  @see PFUserAuthenticationDelegate

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -48,21 +48,21 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  The session token for the `PFUser`.
 
- @discussion This is set by the server upon successful authentication.
+ This is set by the server upon successful authentication.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *sessionToken;
 
 /**
  Whether the `PFUser` was just created from a request.
 
- @discussion This is only set after a Facebook or Twitter login.
+ This is only set after a Facebook or Twitter login.
  */
 @property (nonatomic, assign, readonly) BOOL isNew;
 
 /**
  Whether the user is an authenticated object for the device.
 
- @discussion An authenticated `PFUser` is one that is obtained via a <signUp> or <logIn> method.
+ An authenticated `PFUser` is one that is obtained via a <signUp> or <logIn> method.
  An authenticated object is required in order to save (with altered values) or delete it.
  */
 @property (nonatomic, assign, readonly, getter=isAuthenticated) BOOL authenticated;
@@ -81,7 +81,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Enables automatic creation of anonymous users.
 
- @discussion After calling this method, <currentUser> will always have a value.
+ After calling this method, <currentUser> will always have a value.
  The user will only be created on the server once the user has been saved,
  or once an object with a relation to that user or an ACL that refers to the user has been saved.
 
@@ -98,7 +98,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**!
  The password for the `PFUser`.
 
- @discussion This will not be filled in from the server with the password.
+ This will not be filled in from the server with the password.
  It is only meant to be set.
  */
 @property (nullable, nonatomic, strong) NSString *password;
@@ -111,7 +111,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Signs up the user *synchronously*.
 
- @discussion This will also enforce that the username isn't already taken.
+ This will also enforce that the username isn't already taken.
 
  @warning Make sure that password and username are set before calling this method.
 
@@ -122,7 +122,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Signs up the user *synchronously*.
 
- @discussion This will also enforce that the username isn't already taken.
+ This will also enforce that the username isn't already taken.
 
  @warning Make sure that password and username are set before calling this method.
 
@@ -135,7 +135,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Signs up the user *asynchronously*.
 
- @discussion This will also enforce that the username isn't already taken.
+ This will also enforce that the username isn't already taken.
 
  @warning Make sure that password and username are set before calling this method.
 
@@ -146,7 +146,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Signs up the user *asynchronously*.
 
- @discussion This will also enforce that the username isn't already taken.
+ This will also enforce that the username isn't already taken.
 
  @warning Make sure that password and username are set before calling this method.
 
@@ -158,7 +158,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Signs up the user *asynchronously*.
 
- @discussion This will also enforce that the username isn't already taken.
+ This will also enforce that the username isn't already taken.
 
  @warning Make sure that password and username are set before calling this method.
 
@@ -177,7 +177,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes a *synchronous* request to login a user with specified credentials.
 
- @discussion Returns an instance of the successfully logged in `PFUser`.
+ Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
 
  @param username The username of the user.
@@ -192,7 +192,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes a *synchronous* request to login a user with specified credentials.
 
- @discussion Returns an instance of the successfully logged in `PFUser`.
+ Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
 
  @param username The username of the user.
@@ -209,7 +209,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes an *asynchronous* request to login a user with specified credentials.
 
- @discussion Returns an instance of the successfully logged in `PFUser`.
+ Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
 
  @param username The username of the user.
@@ -223,7 +223,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes an *asynchronous* request to login a user with specified credentials.
 
- @discussion Returns an instance of the successfully logged in `PFUser`.
+ Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
 
  @param username The username of the user.
@@ -240,7 +240,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes an *asynchronous* request to log in a user with specified credentials.
 
- @discussion Returns an instance of the successfully logged in `PFUser`.
+ Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
 
  @param username The username of the user.
@@ -259,7 +259,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes a *synchronous* request to become a user with the given session token.
 
- @discussion Returns an instance of the successfully logged in `PFUser`.
+ Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
 
  @param sessionToken The session token for the user.
@@ -272,7 +272,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes a *synchronous* request to become a user with the given session token.
 
- @discussion Returns an instance of the successfully logged in `PFUser`.
+ Returns an instance of the successfully logged in `PFUser`.
  This will also cache the user locally so that calls to <currentUser> will use the latest logged in user.
 
  @param sessionToken The session token for the user.
@@ -286,7 +286,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes an *asynchronous* request to become a user with the given session token.
 
- @discussion Returns an instance of the successfully logged in `PFUser`.
+ Returns an instance of the successfully logged in `PFUser`.
  This also caches the user locally so that calls to <currentUser> will use the latest logged in user.
 
  @param sessionToken The session token for the user.
@@ -298,7 +298,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes an *asynchronous* request to become a user with the given session token.
 
- @discussion Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
+ Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
  so that calls to <currentUser> will use the latest logged in user.
 
  @param sessionToken The session token for the user.
@@ -310,7 +310,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Makes an *asynchronous* request to become a user with the given session token.
 
- @discussion Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
+ Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
  so that calls to <currentUser> will use the latest logged in user.
 
  @param sessionToken The session token for the user.
@@ -329,7 +329,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Enables revocable sessions and migrates the currentUser session token to use revocable session if needed.
 
- @discussion This method is required if you want to use <PFSession> APIs
+ This method is required if you want to use <PFSession> APIs
  and your application's 'Require Revocable Session' setting is turned off on `http://parse.com` app settings.
  After returned `BFTask` completes - <PFSession> class and APIs will be available for use.
 
@@ -341,7 +341,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Enables revocable sessions and upgrades the currentUser session token to use revocable session if needed.
 
- @discussion This method is required if you want to use <PFSession> APIs
+ This method is required if you want to use <PFSession> APIs
  and legacy sessions are enabled in your application settings on `http://parse.com/`.
  After returned `BFTask` completes - <PFSession> class and APIs will be available for use.
 
@@ -361,7 +361,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  *Asynchronously* logs out the currently logged in user.
 
- @discussion This will also remove the session from disk, log out of linked services
+ This will also remove the session from disk, log out of linked services
  and all future calls to <currentUser> will return `nil`. This is preferrable to using <logOut>,
  unless your code is already running from a background thread.
 
@@ -372,7 +372,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  *Asynchronously* logs out the currently logged in user.
 
- @discussion This will also remove the session from disk, log out of linked services
+ This will also remove the session from disk, log out of linked services
  and all future calls to <currentUser> will return `nil`. This is preferrable to using <logOut>,
  unless your code is already running from a background thread.
 
@@ -387,7 +387,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  *Synchronously* Send a password reset request for a specified email.
 
- @discussion If a user account exists with that email, an email will be sent to that address
+ If a user account exists with that email, an email will be sent to that address
  with instructions on how to reset their password.
 
  @param email Email of the account to send a reset password request.
@@ -399,7 +399,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  *Synchronously* send a password reset request for a specified email and sets an error object.
 
- @discussion If a user account exists with that email, an email will be sent to that address
+ If a user account exists with that email, an email will be sent to that address
  with instructions on how to reset their password.
 
  @param email Email of the account to send a reset password request.
@@ -420,7 +420,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Send a password reset request *asynchronously* for a specified email.
 
- @discussion If a user account exists with that email, an email will be sent to that address
+ If a user account exists with that email, an email will be sent to that address
  with instructions on how to reset their password.
 
  @param email Email of the account to send a reset password request.
@@ -433,7 +433,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 /**
  Send a password reset request *asynchronously* for a specified email and sets an error object.
 
- @discussion If a user account exists with that email, an email will be sent to that address
+ If a user account exists with that email, an email will be sent to that address
  with instructions on how to reset their password.
 
  @param email Email of the account to send a reset password request.

--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -295,7 +295,7 @@ static BOOL revocableSessionEnabled_;
     }
 }
 
-/*!
+/**
  Copies special PFUser fields from another user.
  */
 - (PFObject *)mergeFromObject:(PFUser *)other {

--- a/Parse/PFUserAuthenticationDelegate.h
+++ b/Parse/PFUserAuthenticationDelegate.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param authData The auth data for the provider. This value may be `nil` when unlinking an account.
 
- @returns `YES` - if the `authData` was succesfully synchronized,
+ @return `YES` - if the `authData` was succesfully synchronized,
  or `NO` if user should not longer be associated because of bad `authData`.
  */
 - (BOOL)restoreAuthenticationWithAuthData:(nullable NSDictionary PF_GENERIC(NSString *, NSString *)*)authData;

--- a/Parse/PFUserAuthenticationDelegate.h
+++ b/Parse/PFUserAuthenticationDelegate.h
@@ -13,12 +13,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  Provides a general interface for delegation of third party authentication with <PFUser>s.
  */
 @protocol PFUserAuthenticationDelegate <NSObject>
 
-/*!
+/**
  @abstract Called when restoring third party authentication credentials that have been serialized,
  such as session keys, user id, etc.
 

--- a/Parse/PFUserAuthenticationDelegate.h
+++ b/Parse/PFUserAuthenticationDelegate.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol PFUserAuthenticationDelegate <NSObject>
 
 /**
- @abstract Called when restoring third party authentication credentials that have been serialized,
+ Called when restoring third party authentication credentials that have been serialized,
  such as session keys, user id, etc.
 
  @note This method will be executed on a background thread.

--- a/Parse/PFUserAuthenticationDelegate.h
+++ b/Parse/PFUserAuthenticationDelegate.h
@@ -14,7 +14,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Provides a general interface for delegation of third party authentication with <PFUser>s.
+ Provides a general interface for delegation of third party authentication with `PFUser`s.
  */
 @protocol PFUserAuthenticationDelegate <NSObject>
 

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -49,7 +49,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*!
+/**
  The `Parse` class contains static functions that handle global configuration for the Parse framework.
  */
 @interface Parse : NSObject
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Connecting to Parse
 ///--------------------------------------
 
-/*!
+/**
  @abstract Sets the applicationId and clientKey of your application.
 
  @param applicationId The application id of your Parse application.
@@ -66,12 +66,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)setApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey;
 
-/*!
+/**
  @abstract The current application id that was used to configure Parse framework.
  */
 + (NSString *)getApplicationId;
 
-/*!
+/**
  @abstract The current client key that was used to configure Parse framework.
  */
 + (NSString *)getClientKey;
@@ -80,13 +80,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Enabling Local Datastore
 ///--------------------------------------
 
-/*!
+/**
  @abstract Enable pinning in your application. This must be called before your application can use
  pinning. The recommended way is to call this method before `setApplicationId:clientKey:`.
  */
 + (void)enableLocalDatastore PF_TV_UNAVAILABLE;
 
-/*!
+/**
  @abstract Flag that indicates whether Local Datastore is enabled.
 
  @returns `YES` if Local Datastore is enabled, otherwise `NO`.
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Enabling Extensions Data Sharing
 ///--------------------------------------
 
-/*!
+/**
  @abstract Enables data sharing with an application group identifier.
 
  @discussion After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)enableDataSharingWithApplicationGroupIdentifier:(NSString *)groupIdentifier PF_EXTENSION_UNAVAILABLE("Use `enableDataSharingWithApplicationGroupIdentifier:containingApplication:`.") PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
-/*!
+/**
  @abstract Enables data sharing with an application group identifier.
 
  @discussion After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
@@ -124,14 +124,14 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)enableDataSharingWithApplicationGroupIdentifier:(NSString *)groupIdentifier
                                   containingApplication:(NSString *)bundleIdentifier PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
-/*!
+/**
  @abstract Application Group Identifier for Data Sharing
 
  @returns `NSString` value if data sharing is enabled, otherwise `nil`.
  */
 + (NSString *)applicationGroupIdentifierForDataSharing PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
-/*!
+/**
  @abstract Containing application bundle identifier.
 
  @returns `NSString` value if data sharing is enabled, otherwise `nil`.
@@ -144,7 +144,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Configuring UI Settings
 ///--------------------------------------
 
-/*!
+/**
  @abstract Set whether to show offline messages when using a Parse view or view controller related classes.
 
  @param enabled Whether a `UIAlertView` should be shown when the device is offline
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)offlineMessagesEnabled:(BOOL)enabled PARSE_DEPRECATED("This method is deprecated and has no effect.");
 
-/*!
+/**
  @abstract Set whether to show an error message when using a Parse view or view controller related classes
  and a Parse error was generated via a query.
 
@@ -170,7 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// @name Logging
 ///--------------------------------------
 
-/*!
+/**
  @abstract Sets the level of logging to display.
 
  @discussion By default:
@@ -182,7 +182,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)setLogLevel:(PFLogLevel)logLevel;
 
-/*!
+/**
  @abstract Log level that will be displayed.
 
  @discussion By default:

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -100,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Enables data sharing with an application group identifier.
 
- @discussion After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
+ After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
  are going to be available to every application/extension in a group that have the same Parse applicationId.
 
  @warning This method is required to be called before <setApplicationId:clientKey:>.
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Enables data sharing with an application group identifier.
 
- @discussion After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
+ After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
  are going to be available to every application/extension in a group that have the same Parse applicationId.
 
  @warning This method is required to be called before <setApplicationId:clientKey:>.
@@ -173,7 +173,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Sets the level of logging to display.
 
- @discussion By default:
+ By default:
  - If running inside an app that was downloaded from iOS App Store - it is set to <PFLogLevelNone>
  - All other cases - it is set to <PFLogLevelWarning>
 
@@ -185,7 +185,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Log level that will be displayed.
 
- @discussion By default:
+ By default:
  - If running inside an app that was downloaded from iOS App Store - it is set to <PFLogLevelNone>
  - All other cases - it is set to <PFLogLevelWarning>
 

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Sets the applicationId and clientKey of your application.
+ Sets the applicationId and clientKey of your application.
 
  @param applicationId The application id of your Parse application.
  @param clientKey The client key of your Parse application.
@@ -67,12 +67,12 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey;
 
 /**
- @abstract The current application id that was used to configure Parse framework.
+ The current application id that was used to configure Parse framework.
  */
 + (NSString *)getApplicationId;
 
 /**
- @abstract The current client key that was used to configure Parse framework.
+ The current client key that was used to configure Parse framework.
  */
 + (NSString *)getClientKey;
 
@@ -81,13 +81,13 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Enable pinning in your application. This must be called before your application can use
+ Enable pinning in your application. This must be called before your application can use
  pinning. The recommended way is to call this method before `setApplicationId:clientKey:`.
  */
 + (void)enableLocalDatastore PF_TV_UNAVAILABLE;
 
 /**
- @abstract Flag that indicates whether Local Datastore is enabled.
+ Flag that indicates whether Local Datastore is enabled.
 
  @returns `YES` if Local Datastore is enabled, otherwise `NO`.
  */
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Enables data sharing with an application group identifier.
+ Enables data sharing with an application group identifier.
 
  @discussion After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
  are going to be available to every application/extension in a group that have the same Parse applicationId.
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)enableDataSharingWithApplicationGroupIdentifier:(NSString *)groupIdentifier PF_EXTENSION_UNAVAILABLE("Use `enableDataSharingWithApplicationGroupIdentifier:containingApplication:`.") PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
 /**
- @abstract Enables data sharing with an application group identifier.
+ Enables data sharing with an application group identifier.
 
  @discussion After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
  are going to be available to every application/extension in a group that have the same Parse applicationId.
@@ -125,14 +125,14 @@ NS_ASSUME_NONNULL_BEGIN
                                   containingApplication:(NSString *)bundleIdentifier PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
 /**
- @abstract Application Group Identifier for Data Sharing
+ Application Group Identifier for Data Sharing
 
  @returns `NSString` value if data sharing is enabled, otherwise `nil`.
  */
 + (NSString *)applicationGroupIdentifierForDataSharing PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
 /**
- @abstract Containing application bundle identifier.
+ Containing application bundle identifier.
 
  @returns `NSString` value if data sharing is enabled, otherwise `nil`.
  */
@@ -145,7 +145,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Set whether to show offline messages when using a Parse view or view controller related classes.
+ Set whether to show offline messages when using a Parse view or view controller related classes.
 
  @param enabled Whether a `UIAlertView` should be shown when the device is offline
  and network access is required from a view or view controller.
@@ -155,7 +155,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)offlineMessagesEnabled:(BOOL)enabled PARSE_DEPRECATED("This method is deprecated and has no effect.");
 
 /**
- @abstract Set whether to show an error message when using a Parse view or view controller related classes
+ Set whether to show an error message when using a Parse view or view controller related classes
  and a Parse error was generated via a query.
 
  @param enabled Whether a `UIAlertView` should be shown when an error occurs.
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 /**
- @abstract Sets the level of logging to display.
+ Sets the level of logging to display.
 
  @discussion By default:
  - If running inside an app that was downloaded from iOS App Store - it is set to <PFLogLevelNone>
@@ -183,7 +183,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setLogLevel:(PFLogLevel)logLevel;
 
 /**
- @abstract Log level that will be displayed.
+ Log level that will be displayed.
 
  @discussion By default:
  - If running inside an app that was downloaded from iOS App Store - it is set to <PFLogLevelNone>

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Enable pinning in your application. This must be called before your application can use
- pinning. The recommended way is to call this method before `setApplicationId:clientKey:`.
+ pinning. The recommended way is to call this method before `+setApplicationId:clientKey:`.
  */
 + (void)enableLocalDatastore PF_TV_UNAVAILABLE;
 
@@ -100,10 +100,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Enables data sharing with an application group identifier.
 
- After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
+ After enabling - Local Datastore, `PFUser.+currentUser`, `PFInstallation.+currentInstallation` and all eventually commands
  are going to be available to every application/extension in a group that have the same Parse applicationId.
 
- @warning This method is required to be called before <setApplicationId:clientKey:>.
+ @warning This method is required to be called before `+setApplicationId:clientKey:`.
 
  @param groupIdentifier Application Group Identifier to share data with.
  */
@@ -112,10 +112,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Enables data sharing with an application group identifier.
 
- After enabling - Local Datastore, `currentUser`, `currentInstallation` and all eventually commands
+ After enabling - Local Datastore, `PFUser.+currentUser`, `PFInstallation.+currentInstallation` and all eventually commands
  are going to be available to every application/extension in a group that have the same Parse applicationId.
 
- @warning This method is required to be called before <setApplicationId:clientKey:>.
+ @warning This method is required to be called before `+setApplicationId:clientKey:`.
  This method can only be used by application extensions.
 
  @param groupIdentifier Application Group Identifier to share data with.
@@ -125,14 +125,14 @@ NS_ASSUME_NONNULL_BEGIN
                                   containingApplication:(NSString *)bundleIdentifier PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
 /**
- Application Group Identifier for Data Sharing
+ Application Group Identifier for Data Sharing.
 
  @return `NSString` value if data sharing is enabled, otherwise `nil`.
  */
 + (NSString *)applicationGroupIdentifierForDataSharing PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
 /**
- Containing application bundle identifier.
+ Containing application bundle identifier for Data Sharing.
 
  @return `NSString` value if data sharing is enabled, otherwise `nil`.
  */
@@ -174,8 +174,8 @@ NS_ASSUME_NONNULL_BEGIN
  Sets the level of logging to display.
 
  By default:
- - If running inside an app that was downloaded from iOS App Store - it is set to <PFLogLevelNone>
- - All other cases - it is set to <PFLogLevelWarning>
+ - If running inside an app that was downloaded from iOS App Store - it is set to `PFLogLevelNone`
+ - All other cases - it is set to `PFLogLevelWarning`
 
  @param logLevel Log level to set.
  @see PFLogLevel
@@ -186,10 +186,11 @@ NS_ASSUME_NONNULL_BEGIN
  Log level that will be displayed.
 
  By default:
- - If running inside an app that was downloaded from iOS App Store - it is set to <PFLogLevelNone>
- - All other cases - it is set to <PFLogLevelWarning>
 
- @return A <PFLogLevel> value.
+ - If running inside an app that was downloaded from iOS App Store - it is set to `PFLogLevelNone`
+ - All other cases - it is set to `PFLogLevelWarning`
+
+ @return A `PFLogLevel` value.
  @see PFLogLevel
  */
 + (PFLogLevel)logLevel;

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Flag that indicates whether Local Datastore is enabled.
 
- @returns `YES` if Local Datastore is enabled, otherwise `NO`.
+ @return `YES` if Local Datastore is enabled, otherwise `NO`.
  */
 + (BOOL)isLocalDatastoreEnabled PF_TV_UNAVAILABLE;
 
@@ -127,14 +127,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Application Group Identifier for Data Sharing
 
- @returns `NSString` value if data sharing is enabled, otherwise `nil`.
+ @return `NSString` value if data sharing is enabled, otherwise `nil`.
  */
 + (NSString *)applicationGroupIdentifierForDataSharing PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
 /**
  Containing application bundle identifier.
 
- @returns `NSString` value if data sharing is enabled, otherwise `nil`.
+ @return `NSString` value if data sharing is enabled, otherwise `nil`.
  */
 + (NSString *)containingApplicationBundleIdentifierForDataSharing PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
@@ -189,7 +189,7 @@ NS_ASSUME_NONNULL_BEGIN
  - If running inside an app that was downloaded from iOS App Store - it is set to <PFLogLevelNone>
  - All other cases - it is set to <PFLogLevelWarning>
 
- @returns A <PFLogLevel> value.
+ @return A <PFLogLevel> value.
  @see PFLogLevel
  */
 + (PFLogLevel)logLevel;

--- a/Tests/Other/Cache/TestCache.h
+++ b/Tests/Other/Cache/TestCache.h
@@ -9,7 +9,7 @@
 
 @import Foundation;
 
-/*!
+/**
  Because OCMock is not thread-safe, let's create our own class that implements NSCache.
  Note that we don't inherit from NSCache, so we still get 'strict mock' functionality. We cannot do expectations
  this way, however.

--- a/Tests/Unit/LocationManagerMobileTests.m
+++ b/Tests/Unit/LocationManagerMobileTests.m
@@ -15,7 +15,7 @@
 #import "PFLocationManager.h"
 #import "PFUnitTestCase.h"
 
-/*!
+/**
  We do this because OCMock does not allow you to stub -respondsToSelector:, so we force it to bend to our will using a
  protocol mock.
 


### PR DESCRIPTION
This change is required to power our new api ref generation.
- Replaced `/*!` with `/**`
- Removed `@abstract`, `@discussion` and converted `@returns` into `@return`
- Updated all cross references from `<[Class method]>` to `Class.+method` style
- Cleaned up and fixed few missing/wrong pieces of documentation.

The new style is as follows:
```objc
/**
 Short description of what the method does.

 Very long description that precisely describes on what we are doing with a cross reference link to `AnotherClass.+someRandomMethod`.

 @warning Some warning. // (optional)
 @note Some extra note. // (optional)

 @param argument This is a description of what is expected of this argument.

 @return Description of return value.
*/
- (BOOL)methodNameWithArgument:(id)argument;
```