### PR TITLE
Use "CFBundleShortVersionString" to get app version

### DIFF
--- a/Parse/PFInstallation.m
+++ b/Parse/PFInstallation.m
@@ -278,7 +278,7 @@ static NSSet *protectedKeys;
 - (void)_updateVersionInfoFromDevice {
     NSDictionary *appInfo = [NSBundle mainBundle].infoDictionary;
     NSString *appName = appInfo[(__bridge NSString *)kCFBundleNameKey];
-    NSString *appVersion = appInfo[(__bridge NSString *)kCFBundleVersionKey];
+    NSString *appVersion = appInfo[@"CFBundleShortVersionString"];
     NSString *appIdentifier = appInfo[(__bridge NSString *)kCFBundleIdentifierKey];
     // It's possible that the app was created without an info.plist and we just
     // cannot get the data we need.


### PR DESCRIPTION
The `PFInstallation` class is currently using the key `kCFBundleVersionKey` to get the app version number. Using this key retrieves the value for the "Bundle Version" key in the application's `Info.plist` file, which represents the build number as specified in General tab of the main target:

![screen shot 2015-12-08 at 11 47 21 am](https://cloud.githubusercontent.com/assets/879038/11661810/b261f93a-9da1-11e5-9cce-2ca905984865.png)

Using the key "CFBundleShortVersionString" will retrieve the value for the "Bundle versions string, short" in the `Info.plist` file, which represents the version number as specified in the General tab of the main target:

![screen shot 2015-12-08 at 11 51 46 am](https://cloud.githubusercontent.com/assets/879038/11661897/1f2a34f6-9da2-11e5-9210-bbd653112265.png)

This PR updates the `PFInstallation` class to use the key "CFBundleShortVersionString" instead of `kCFBundleVersionKey` when getting the app version.