### PR TITLE
Remove useless and crazy imports in PFConstants.

### DIFF
--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionFileDownloadTaskDelegate.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionFileDownloadTaskDelegate.m
@@ -59,7 +59,7 @@
         return;
     }
 
-    int progress = (int)(self.downloadedBytes / (CGFloat)self.response.expectedContentLength * 100);
+    int progress = (int)(self.downloadedBytes / (double)self.response.expectedContentLength * 100);
     _progressBlock(progress);
 }
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionUploadTaskDelegate.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionUploadTaskDelegate.m
@@ -45,7 +45,7 @@
    didSendBodyData:(int64_t)bytesSent
     totalBytesSent:(int64_t)totalBytesSent
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
-    int progress = (int)round(totalBytesSent / (CGFloat)totalBytesExpectedToSend * 100);
+    int progress = (int)round(totalBytesSent / (double)totalBytesExpectedToSend * 100);
     dispatch_async(dispatch_get_main_queue(), ^{
         if (_progressBlock) {
             _progressBlock(progress);

--- a/Parse/PFAnalytics.m
+++ b/Parse/PFAnalytics.m
@@ -10,6 +10,10 @@
 #import "PFAnalytics.h"
 #import "PFAnalytics_Private.h"
 
+#if PF_TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+#endif
+
 #import "BFTask+Private.h"
 #import "PFAnalyticsController.h"
 #import "PFAssert.h"

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -29,12 +29,6 @@ extern NSInteger const PARSE_API_VERSION;
 
 extern NSString *const __nonnull kPFDeviceType;
 
-#if PARSE_IOS_ONLY
-#import <UIKit/UIKit.h>
-#else
-#import <Cocoa/Cocoa.h>
-#endif
-
 ///--------------------------------------
 /// @name Server
 ///--------------------------------------


### PR DESCRIPTION
These imports are quite bad - removing them.
Since in all public APIs - we always import a framework if it's required for any of the types in the header - no public impact.