### PR TITLE
Improved and cleanup deployment for watchOS starter project.

### DIFF
--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter-Swift.xcodeproj/project.pbxproj
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter-Swift.xcodeproj/project.pbxproj
@@ -56,20 +56,6 @@
 			remoteGlobalIDString = 81411DD81BC3658C0004BE84;
 			remoteInfo = "ParseStarter Extension";
 		};
-		81411DF31BC3685A0004BE84 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 81BA813D1A49DA1800E65899 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 81993FC71B69AA940077D6B9;
-			remoteInfo = Bootstrap;
-		};
-		81993FCC1B69AAE40077D6B9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 81BA813D1A49DA1800E65899 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 81993FC71B69AA940077D6B9;
-			remoteInfo = Bootstrap;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -298,7 +284,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				81411DF41BC3685A0004BE84 /* PBXTargetDependency */,
 			);
 			name = "ParseStarter Extension";
 			productName = "ParseStarter Extension";
@@ -319,7 +304,6 @@
 			);
 			dependencies = (
 				068C15651BC8F15300820E44 /* PBXTargetDependency */,
-				81993FCD1B69AAE40077D6B9 /* PBXTargetDependency */,
 			);
 			name = "ParseStarter-Swift";
 			productName = ParseStarterProject;
@@ -460,16 +444,6 @@
 			isa = PBXTargetDependency;
 			target = 81411DD81BC3658C0004BE84 /* ParseStarter Extension */;
 			targetProxy = 81411DDB1BC3658D0004BE84 /* PBXContainerItemProxy */;
-		};
-		81411DF41BC3685A0004BE84 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 81993FC71B69AA940077D6B9 /* Bootstrap */;
-			targetProxy = 81411DF31BC3685A0004BE84 /* PBXContainerItemProxy */;
-		};
-		81993FCD1B69AAE40077D6B9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 81993FC71B69AA940077D6B9 /* Bootstrap */;
-			targetProxy = 81993FCC1B69AAE40077D6B9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter-Swift.xcodeproj/project.pbxproj
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter-Swift.xcodeproj/project.pbxproj
@@ -27,19 +27,18 @@
 		81411DDF1BC3658D0004BE84 /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81411DDE1BC3658D0004BE84 /* InterfaceController.swift */; };
 		81411DE11BC3658D0004BE84 /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81411DE01BC3658D0004BE84 /* ExtensionDelegate.swift */; };
 		81411DE71BC3658D0004BE84 /* ParseStarter.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 81411DCD1BC3658C0004BE84 /* ParseStarter.app */; };
-		81411DF21BC3660D0004BE84 /* Parse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81411DF11BC3660D0004BE84 /* Parse.framework */; };
-		81411DF91BC368880004BE84 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81411DF61BC368800004BE84 /* Bolts.framework */; settings = {ASSET_TAGS = (); }; };
-		81411DFA1BC3688F0004BE84 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81411DF81BC368800004BE84 /* Bolts.framework */; settings = {ASSET_TAGS = (); }; };
-		81411E011BC368D30004BE84 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 81411E001BC368D30004BE84 /* libsqlite3.tbd */; };
 		814C3ACA1B69877600E307BB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 814C3AC61B69877600E307BB /* Main.storyboard */; };
 		814C3ACB1B69877600E307BB /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 814C3AC81B69877600E307BB /* Images.xcassets */; };
+		81ADCB9B1C1C111200A2971F /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 81ADCB9A1C1C111200A2971F /* libsqlite3.tbd */; };
+		81ADCB9C1C1C111800A2971F /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 81ADCB9A1C1C111200A2971F /* libsqlite3.tbd */; };
+		81ADCBA31C1C120D00A2971F /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81ADCB9E1C1C120700A2971F /* Bolts.framework */; };
+		81ADCBA41C1C120D00A2971F /* Parse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81ADCB9F1C1C120700A2971F /* Parse.framework */; };
+		81ADCBA51C1C121200A2971F /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81ADCBA11C1C120700A2971F /* Bolts.framework */; };
+		81ADCBA61C1C121200A2971F /* Parse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81ADCBA21C1C120700A2971F /* Parse.framework */; };
 		81BA814B1A49DA1800E65899 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BA814A1A49DA1800E65899 /* AppDelegate.swift */; };
 		81BA814D1A49DA1800E65899 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BA814C1A49DA1800E65899 /* ViewController.swift */; };
-		81BA81711A49DB6800E65899 /* Parse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81BA816C1A49DB6800E65899 /* Parse.framework */; };
-		81BA81771A49E0D500E65899 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 81BA81761A49E0D500E65899 /* libsqlite3.dylib */; };
 		81BA81791A49E0DB00E65899 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81BA81781A49E0DB00E65899 /* AudioToolbox.framework */; };
 		81BA817B1A49E0E500E65899 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81BA817A1A49E0E500E65899 /* SystemConfiguration.framework */; };
-		81BA817F1A49E0F000E65899 /* libstdc++.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 81BA817E1A49E0F000E65899 /* libstdc++.6.dylib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,24 +106,19 @@
 		81411DDE1BC3658D0004BE84 /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
 		81411DE01BC3658D0004BE84 /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
 		81411DE41BC3658D0004BE84 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		81411DF11BC3660D0004BE84 /* Parse.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Parse.framework; sourceTree = "<group>"; };
-		81411DF61BC368800004BE84 /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Bolts.framework; sourceTree = "<group>"; };
-		81411DF81BC368800004BE84 /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Bolts.framework; sourceTree = "<group>"; };
-		81411E001BC368D30004BE84 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS2.0.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
 		814C3AC71B69877600E307BB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		814C3AC81B69877600E307BB /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		814C3AC91B69877600E307BB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		81ADCB9A1C1C111200A2971F /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
+		81ADCB9E1C1C120700A2971F /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Bolts.framework; sourceTree = "<group>"; };
+		81ADCB9F1C1C120700A2971F /* Parse.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Parse.framework; sourceTree = "<group>"; };
+		81ADCBA11C1C120700A2971F /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Bolts.framework; sourceTree = "<group>"; };
+		81ADCBA21C1C120700A2971F /* Parse.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Parse.framework; sourceTree = "<group>"; };
 		81BA81451A49DA1800E65899 /* ParseStarter-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ParseStarter-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81BA814A1A49DA1800E65899 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		81BA814C1A49DA1800E65899 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		81BA816C1A49DB6800E65899 /* Parse.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Parse.framework; sourceTree = "<group>"; };
-		81BA816D1A49DB6800E65899 /* ParseCrashReporting.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ParseCrashReporting.framework; sourceTree = "<group>"; };
-		81BA816E1A49DB6800E65899 /* ParseFacebookUtils.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ParseFacebookUtils.framework; sourceTree = "<group>"; };
-		81BA81761A49E0D500E65899 /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
 		81BA81781A49E0DB00E65899 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		81BA817A1A49E0E500E65899 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
-		81BA817E1A49E0F000E65899 /* libstdc++.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.6.dylib"; path = "usr/lib/libstdc++.6.dylib"; sourceTree = SDKROOT; };
-		81BA81801A49E10C00E65899 /* ParseUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ParseUI.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,9 +126,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				81411E011BC368D30004BE84 /* libsqlite3.tbd in Frameworks */,
-				81411DF21BC3660D0004BE84 /* Parse.framework in Frameworks */,
-				81411DFA1BC3688F0004BE84 /* Bolts.framework in Frameworks */,
+				81ADCB9C1C1C111800A2971F /* libsqlite3.tbd in Frameworks */,
+				81ADCBA61C1C121200A2971F /* Parse.framework in Frameworks */,
+				81ADCBA51C1C121200A2971F /* Bolts.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -142,12 +136,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				81BA817F1A49E0F000E65899 /* libstdc++.6.dylib in Frameworks */,
+				81ADCB9B1C1C111200A2971F /* libsqlite3.tbd in Frameworks */,
 				81BA817B1A49E0E500E65899 /* SystemConfiguration.framework in Frameworks */,
 				81BA81791A49E0DB00E65899 /* AudioToolbox.framework in Frameworks */,
-				81411DF91BC368880004BE84 /* Bolts.framework in Frameworks */,
-				81BA81771A49E0D500E65899 /* libsqlite3.dylib in Frameworks */,
-				81BA81711A49DB6800E65899 /* Parse.framework in Frameworks */,
+				81ADCBA31C1C120D00A2971F /* Bolts.framework in Frameworks */,
+				81ADCBA41C1C120D00A2971F /* Parse.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,24 +185,6 @@
 			name = Resources;
 			sourceTree = "<group>";
 		};
-		81411DF51BC368800004BE84 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				81411DF61BC368800004BE84 /* Bolts.framework */,
-			);
-			name = iOS;
-			path = Vendor/iOS;
-			sourceTree = "<group>";
-		};
-		81411DF71BC368800004BE84 /* watchOS */ = {
-			isa = PBXGroup;
-			children = (
-				81411DF81BC368800004BE84 /* Bolts.framework */,
-			);
-			name = watchOS;
-			path = Vendor/watchOS;
-			sourceTree = "<group>";
-		};
 		814C3AC51B69877600E307BB /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -218,6 +193,26 @@
 			);
 			name = Resources;
 			path = ../Resources;
+			sourceTree = "<group>";
+		};
+		81ADCB9D1C1C120700A2971F /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				81ADCB9E1C1C120700A2971F /* Bolts.framework */,
+				81ADCB9F1C1C120700A2971F /* Parse.framework */,
+			);
+			name = iOS;
+			path = Frameworks/iOS;
+			sourceTree = "<group>";
+		};
+		81ADCBA01C1C120700A2971F /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				81ADCBA11C1C120700A2971F /* Bolts.framework */,
+				81ADCBA21C1C120700A2971F /* Parse.framework */,
+			);
+			name = watchOS;
+			path = Frameworks/watchOS;
 			sourceTree = "<group>";
 		};
 		81BA813C1A49DA1800E65899 = {
@@ -255,14 +250,8 @@
 		81BA816A1A49DB5600E65899 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				81411E001BC368D30004BE84 /* libsqlite3.tbd */,
-				81411DF51BC368800004BE84 /* iOS */,
-				81411DF71BC368800004BE84 /* watchOS */,
-				81411DF11BC3660D0004BE84 /* Parse.framework */,
-				81BA816C1A49DB6800E65899 /* Parse.framework */,
-				81BA816D1A49DB6800E65899 /* ParseCrashReporting.framework */,
-				81BA816E1A49DB6800E65899 /* ParseFacebookUtils.framework */,
-				81BA81801A49E10C00E65899 /* ParseUI.framework */,
+				81ADCB9D1C1C120700A2971F /* iOS */,
+				81ADCBA01C1C120700A2971F /* watchOS */,
 				81BA81751A49E0C500E65899 /* System Frameworks */,
 			);
 			name = Frameworks;
@@ -271,10 +260,9 @@
 		81BA81751A49E0C500E65899 /* System Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				81BA817E1A49E0F000E65899 /* libstdc++.6.dylib */,
+				81ADCB9A1C1C111200A2971F /* libsqlite3.tbd */,
 				81BA817A1A49E0E500E65899 /* SystemConfiguration.framework */,
 				81BA81781A49E0DB00E65899 /* AudioToolbox.framework */,
-				81BA81761A49E0D500E65899 /* libsqlite3.dylib */,
 			);
 			name = "System Frameworks";
 			sourceTree = "<group>";
@@ -423,7 +411,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ ! -d \"Vendor/iOS/Bolts.framework\" ]]; then\n  mkdir -p Vendor/iOS\n  cp -R ../../../Vendor/Bolts-ObjC/build/ios/Bolts.framework ./Vendor/iOS\nfi\n\nif [[ ! -d \"Vendor/watchOS/Bolts.framework\" ]]; then\n  mkdir -p Vendor/watchOS\n  cp -R ../../../Vendor/Bolts-ObjC/build/watchOS/Bolts.framework ./Vendor/watchOS\nfi\n";
+			shellScript = "if [[ ! -d \"Frameworks/iOS/Bolts.framework\" ]]; then\n  mkdir -p Frameworks/iOS\n  cp -R ../../../Vendor/Bolts-ObjC/build/ios/Bolts.framework ./Frameworks/iOS\nfi\n\nif [[ ! -d \"Frameworks/watchOS/Bolts.framework\" ]]; then\n  mkdir -p Frameworks/watchOS\n  cp -R ../../../Vendor/Bolts-ObjC/build/watchOS/Bolts.framework ./Frameworks/watchOS\nfi\n";
 		};
 		81CC85E11A49F6D40076DE19 /* Upload Symbol Files */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -514,7 +502,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(BUILT_PRODUCTS_DIR)",
 					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/Vendor/watchOS",
+					"$(PROJECT_DIR)/Frameworks/watchOS",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "ParseStarter Extension/Info.plist";
@@ -536,7 +524,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(BUILT_PRODUCTS_DIR)",
 					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/Vendor/watchOS",
+					"$(PROJECT_DIR)/Frameworks/watchOS",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "ParseStarter Extension/Info.plist";
@@ -690,7 +678,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/Vendor/iOS",
+					"$(PROJECT_DIR)/Frameworks/iOS",
 				);
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -707,7 +695,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/Vendor/iOS",
+					"$(PROJECT_DIR)/Frameworks/iOS",
 				);
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter-Swift.xcodeproj/xcshareddata/xcschemes/ParseWatchStarter-iOS.xcscheme
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter-Swift.xcodeproj/xcshareddata/xcschemes/ParseWatchStarter-iOS.xcscheme
@@ -14,6 +14,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "81993FC71B69AA940077D6B9"
+               BuildableName = "Bootstrap"
+               BlueprintName = "Bootstrap"
+               ReferencedContainer = "container:ParseStarter-Swift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "81C3821B19CCA89E0066284A"
                BuildableName = "Parse.framework"
                BlueprintName = "Parse-iOS"

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter-Swift.xcodeproj/xcshareddata/xcschemes/ParseWatchStarter-watchOS.xcscheme
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter-Swift.xcodeproj/xcshareddata/xcschemes/ParseWatchStarter-watchOS.xcscheme
@@ -14,6 +14,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "81993FC71B69AA940077D6B9"
+               BuildableName = "Bootstrap"
+               BlueprintName = "Bootstrap"
+               ReferencedContainer = "container:ParseStarter-Swift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "81C3821B19CCA89E0066284A"
                BuildableName = "Parse.framework"
                BlueprintName = "Parse-iOS"

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
@@ -49,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let defaultACL = PFACL();
 
         // If you would like all objects to be private by default, remove this line.
-        defaultACL.setPublicReadAccess(true)
+        defaultACL.publicReadAccess = true
 
         PFACL.setDefaultACL(defaultACL, withAccessForCurrentUser:true)
 

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/Resources/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -59,6 +59,11 @@
       "idiom" : "ipad",
       "size" : "76x76",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/Rakefile
+++ b/Rakefile
@@ -222,7 +222,19 @@ namespace :package do
       File.join(script_folder, 'ParseStarterProject', 'watchOS', 'ParseStarterProject-Swift')
     ]
     watchos_framework_archive = File.join(release_folder, package_watchos_name)
-    make_starter_package(release_folder, watchos_starters, watchos_framework_archive, package_starter_watchos_name)
+    watchos_starters.each do |project_path|
+      `git clean -xfd #{project_path}`
+      `mkdir -p #{project_path}/Frameworks/iOS && mkdir -p #{project_path}/Frameworks/watchOS`
+      `cd #{project_path}/Frameworks/iOS && unzip -o #{ios_framework_archive}`
+      `cd #{project_path}/Frameworks/watchOS && unzip -o #{watchos_framework_archive}`
+      xcodeproj_path = Dir.glob(File.join(project_path, '*.xcodeproj'))[0]
+      prepare_xcodeproj(xcodeproj_path)
+    end
+    make_package(release_folder, watchos_starters, package_starter_watchos_name)
+    watchos_starters.each do |project_path|
+      `git clean -xfd #{project_path}`
+      `git checkout #{project_path}`
+    end
   end
 
   def make_package(target_path, items, archive_name)

--- a/Rakefile
+++ b/Rakefile
@@ -277,7 +277,9 @@ namespace :package do
       if target.name == 'Bootstrap'
         target.remove_from_project
       else
-        target.dependencies.each(&:remove_from_project)
+        target.dependencies.each do |dependency|
+          dependency.remove_from_project if dependency.display_name == 'Bootstrap'
+        end
       end
     end
     project.save


### PR DESCRIPTION
Required for #179.
- Improves deployment by moving the Bootstrap script to scheme instead of target dependency.
- Updated Rakefile packaging for watchOS starter to pull both iOS and watchOS frameworks.
- Updated PFACL API usage in watchOS starter.

Tested with `rake package:starters` multiple times - it produces the proper ones now.