### PR TITLE
Convert DefaultACLController to instance on CoreManager.

### DIFF
--- a/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
+++ b/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
@@ -11,6 +11,8 @@
 
 #import <Parse/PFConstants.h>
 
+#import "PFCoreDataProvider.h"
+
 @class BFTask PF_GENERIC(__covariant BFGenericType);
 @class PFACL;
 
@@ -18,13 +20,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PFDefaultACLController : NSObject
 
+@property (nonatomic, weak, readonly) id<PFCurrentUserControllerProvider> dataSource;
+
 ///--------------------------------------
 /// @name Init
 ///--------------------------------------
 
-// TODO: (nlutsenko, richardross) Make it not terrible aka don't have singletons
-+ (instancetype)defaultController;
-+ (void)clearDefaultController;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
++ (instancetype)controllerWithDataSource:(id<PFCurrentUserControllerProvider>)dataSource;
 
 ///--------------------------------------
 /// @name Default ACL

--- a/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.m
+++ b/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.m
@@ -13,9 +13,7 @@
 
 #import "PFACLPrivate.h"
 #import "PFAsyncTaskQueue.h"
-#import "PFCoreManager.h"
 #import "PFCurrentUserController.h"
-#import "Parse_Private.h"
 
 @implementation PFDefaultACLController {
     PFAsyncTaskQueue *_taskQueue;
@@ -27,30 +25,22 @@
     PFACL *_defaultACLWithCurrentUser;
 }
 
-static PFDefaultACLController *defaultController_;
-
 ///--------------------------------------
 #pragma mark - Init
 ///--------------------------------------
 
-+ (instancetype)defaultController {
-    if (!defaultController_) {
-        defaultController_ = [[self alloc] init];
-    }
-    return defaultController_;
-}
-
-+ (void)clearDefaultController {
-    defaultController_ = nil;
-}
-
-- (instancetype)init {
+- (instancetype)initWithDataSource:(id<PFCurrentUserControllerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;
 
     _taskQueue = [[PFAsyncTaskQueue alloc] init];
+    _dataSource = dataSource;
 
     return self;
+}
+
++ (instancetype)controllerWithDataSource:(id<PFCurrentUserControllerProvider>)dataSource {
+    return [[self alloc] initWithDataSource:dataSource];
 }
 
 ///--------------------------------------
@@ -63,7 +53,7 @@ static PFDefaultACLController *defaultController_;
             return _defaultACL;
         }
 
-        PFCurrentUserController *currentUserController = [Parse _currentManager].coreManager.currentUserController;
+        PFCurrentUserController *currentUserController = self.dataSource.currentUserController;
         return [[currentUserController getCurrentObjectAsync] continueWithBlock:^id(BFTask *task) {
             PFUser *currentUser = task.result;
             if (!currentUser) {

--- a/Parse/Internal/PFCoreDataProvider.h
+++ b/Parse/Internal/PFCoreDataProvider.h
@@ -13,6 +13,18 @@
 NS_ASSUME_NONNULL_BEGIN
 
 ///--------------------------------------
+/// @name Default ACL
+///--------------------------------------
+
+@class PFDefaultACLController;
+
+@protocol PFDefaultACLControllerProvider <NSObject>
+
+@property (nonatomic, strong, readonly) PFDefaultACLController *defaultACLController;
+
+@end
+
+///--------------------------------------
 /// @name Object
 ///--------------------------------------
 

--- a/Parse/Internal/PFCoreManager.h
+++ b/Parse/Internal/PFCoreManager.h
@@ -40,6 +40,7 @@ PFPersistenceControllerProvider>
 
 @interface PFCoreManager : NSObject
 <PFLocationManagerProvider,
+PFDefaultACLControllerProvider,
 PFObjectControllerProvider,
 PFObjectBatchController,
 PFObjectFilePersistenceControllerProvider,

--- a/Parse/Internal/PFCoreManager.m
+++ b/Parse/Internal/PFCoreManager.m
@@ -14,6 +14,7 @@
 #import "PFCloudCodeController.h"
 #import "PFConfigController.h"
 #import "PFCurrentUserController.h"
+#import "PFDefaultACLController.h"
 #import "PFFileController.h"
 #import "PFLocationManager.h"
 #import "PFMacros.h"
@@ -45,6 +46,7 @@
 @implementation PFCoreManager
 
 @synthesize locationManager = _locationManager;
+@synthesize defaultACLController = _defaultACLController;
 
 @synthesize queryController = _queryController;
 @synthesize fileController = _fileController;
@@ -104,6 +106,21 @@
         manager = _locationManager;
     });
     return manager;
+}
+
+///--------------------------------------
+#pragma mark - DefaultACLController
+///--------------------------------------
+
+- (PFDefaultACLController *)defaultACLController {
+    __block PFDefaultACLController *controller = nil;
+    dispatch_sync(_controllerAccessQueue, ^{
+        if (!_defaultACLController) {
+            _defaultACLController = [PFDefaultACLController controllerWithDataSource:self];
+        }
+        controller = _defaultACLController;
+    });
+    return controller;
 }
 
 ///--------------------------------------

--- a/Parse/PFACL.m
+++ b/Parse/PFACL.m
@@ -21,6 +21,8 @@
 #import "PFRole.h"
 #import "PFUser.h"
 #import "PFUserPrivate.h"
+#import "Parse_Private.h"
+#import "PFCoreManager.h"
 
 static NSString *const PFACLPublicKey_ = @"*";
 static NSString *const PFACLUnresolvedKey_ = @"*unresolved";
@@ -69,12 +71,15 @@ static NSString *const PFACLCodingDataKey_ = @"ACL";
 }
 
 + (PFACL *)defaultACL {
-    return [[[PFDefaultACLController defaultController] getDefaultACLAsync] waitForResult:NULL
-                                                                    withMainThreadWarning:NO];
+    PFDefaultACLController *controller = [Parse _currentManager].coreManager.defaultACLController;
+    return [[controller getDefaultACLAsync] waitForResult:NULL withMainThreadWarning:NO];
 }
 
 + (void)setDefaultACL:(PFACL *)acl withAccessForCurrentUser:(BOOL)currentUserAccess {
-    [[PFDefaultACLController defaultController] setDefaultACLAsync:acl withCurrentUserAccess:currentUserAccess];
+    PFDefaultACLController *controller = [Parse _currentManager].coreManager.defaultACLController;
+    // TODO: (nlutsenko) Remove this in favor of assert on `_currentManager`.
+    PFConsistencyAssert(controller, @"Can't set default ACL before Parse is initialized.");
+    [controller setDefaultACLAsync:acl withCurrentUserAccess:currentUserAccess];
 }
 
 - (void)setShared:(BOOL)newShared {

--- a/Tests/Unit/DefaultACLControllerTests.m
+++ b/Tests/Unit/DefaultACLControllerTests.m
@@ -21,18 +21,18 @@
 
 @interface DefaultACLControllerTests : PFUnitTestCase
 
+@property (nonatomic, strong, readonly) id<PFCurrentUserControllerProvider> mockedDataSource;
+
 @end
 
 @implementation DefaultACLControllerTests
 
 ///--------------------------------------
-#pragma mark - XCTestCase
+#pragma mark - Helpers
 ///--------------------------------------
 
-- (void)tearDown {
-    [PFDefaultACLController clearDefaultController];
-
-    [super tearDown];
+- (id<PFCurrentUserControllerProvider>)mockedDataSource {
+    return PFStrictProtocolMock(@protocol(PFCurrentUserControllerProvider));
 }
 
 ///--------------------------------------
@@ -40,18 +40,10 @@
 ///--------------------------------------
 
 - (void)testConstructors {
-    XCTAssertNotNil([[PFDefaultACLController alloc] init]);
-}
-
-- (void)testSingleton {
-    PFDefaultACLController *oldController = [PFDefaultACLController defaultController];
-    XCTAssertNotNil(oldController);
-
-    [PFDefaultACLController clearDefaultController];
-    PFDefaultACLController *newController = [PFDefaultACLController defaultController];
-    XCTAssertNotNil(newController);
-
-    XCTAssertNotEqual(oldController, newController);
+    id dataSource = self.mockedDataSource;
+    PFDefaultACLController *controller = [PFDefaultACLController controllerWithDataSource:dataSource];
+    XCTAssertNotNil(controller);
+    XCTAssertEqual((id)controller.dataSource, dataSource);
 }
 
 - (void)testSetDefaultACL {
@@ -60,7 +52,7 @@
     OCMExpect([mockedACL createUnsharedCopy]).andReturnWeak(mockedACL);
     OCMExpect([mockedACL setShared:YES]);
 
-    PFDefaultACLController *aclController = [[PFDefaultACLController alloc] init];
+    PFDefaultACLController *aclController = [PFDefaultACLController controllerWithDataSource:self.mockedDataSource];
 
     XCTestExpectation *expecatation = [self currentSelectorTestExpectation];
     [[aclController setDefaultACLAsync:mockedACL withCurrentUserAccess:NO] continueWithBlock:^id(BFTask *task) {
@@ -88,7 +80,7 @@
 
     [OCMStub([mockedCurrentUserController getCurrentObjectAsync]) andReturn:[BFTask taskWithResult:nil]];
 
-    PFDefaultACLController *aclController = [[PFDefaultACLController alloc] init];
+    PFDefaultACLController *aclController = [PFDefaultACLController controllerWithDataSource:self.mockedDataSource];
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[[aclController setDefaultACLAsync:mockedACL withCurrentUserAccess:YES] continueWithBlock:^id(BFTask *task) {
@@ -118,7 +110,7 @@
     PFUser *user = [PFUser user];
     [OCMStub([mockedCurrentUserController getCurrentObjectAsync]) andReturn:[BFTask taskWithResult:user]];
 
-    PFDefaultACLController *aclController = [[PFDefaultACLController alloc] init];
+    PFDefaultACLController *aclController = [PFDefaultACLController controllerWithDataSource:self.mockedDataSource];
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[[[aclController setDefaultACLAsync:mockedACL withCurrentUserAccess:YES] continueWithBlock:^id(BFTask *task) {


### PR DESCRIPTION
This also adds assert on setting the default ACL without initializing Parse.