### PR TITLE
Inject parse api server url instead of referencing a global constant.

### DIFF
--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, readonly) NSString *applicationId;
 @property (nonatomic, copy, readonly) NSString *clientKey;
+@property (nonatomic, strong, readonly) NSURL *serverURL;
 
 @property (nonatomic, assign) NSTimeInterval initialRetryDelay;
 
@@ -42,10 +43,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                      applicationId:(NSString *)applicationId
-                         clientKey:(NSString *)clientKey;
+                         clientKey:(NSString *)clientKey
+                         serverURL:(NSURL *)serverURL;
 + (instancetype)commandRunnerWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                               applicationId:(NSString *)applicationId
-                                  clientKey:(NSString *)clientKey;
+                                  clientKey:(NSString *)clientKey
+                                  serverURL:(NSURL *)serverURL;
 
 ///--------------------------------------
 /// @name Data Commands

--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
@@ -19,14 +19,14 @@
 @interface PFCommandURLRequestConstructor : NSObject
 
 @property (nonatomic, weak, readonly) id<PFInstallationIdentifierStoreProvider> dataSource;
+@property (nonatomic, strong, readonly) NSURL *serverURL;
 
 ///--------------------------------------
 /// @name Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource NS_DESIGNATED_INITIALIZER;
-+ (instancetype)constructorWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource;
++ (instancetype)constructorWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource serverURL:(NSURL *)serverURL;
 
 ///--------------------------------------
 /// @name Data

--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
@@ -31,17 +31,18 @@
     PFNotDesignatedInitializer();
 }
 
-- (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource {
+- (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource serverURL:(NSURL *)serverURL {
     self = [super init];
     if (!self) return nil;
 
     _dataSource = dataSource;
+    _serverURL = serverURL;
 
     return self;
 }
 
-+ (instancetype)constructorWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource {
-    return [[self alloc] initWithDataSource:dataSource];
++ (instancetype)constructorWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource serverURL:(NSURL *)serverURL {
+    return [[self alloc] initWithDataSource:dataSource serverURL:serverURL];
 }
 
 ///--------------------------------------
@@ -50,8 +51,8 @@
 
 - (BFTask PF_GENERIC(NSURLRequest *)*)getDataURLRequestAsyncForCommand:(PFRESTCommand *)command {
     return (BFTask *)[[self _getURLRequestHeadersAsyncForCommand:command] continueWithSuccessBlock:^id(BFTask PF_GENERIC(NSDictionary *)*task) {
-        NSURL *url = [PFURLConstructor URLFromAbsoluteString:[PFInternalUtils parseServerURLString]
-                                                        path:[NSString stringWithFormat:@"/1/%@", command.httpPath]
+        NSURL *url = [PFURLConstructor URLFromAbsoluteString:self.serverURL.absoluteString
+                                                        path:command.httpPath
                                                        query:nil];
         NSDictionary *headers = task.result;
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.h
@@ -16,15 +16,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFURLSessionCommandRunner : NSObject <PFCommandRunning>
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
-                     retryAttempts:(NSUInteger)retryAttempts
-                     applicationId:(NSString *)applicationId
-                         clientKey:(NSString *)clientKey;
 
 + (instancetype)commandRunnerWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                               retryAttempts:(NSUInteger)retryAttempts
                               applicationId:(NSString *)applicationId
-                                  clientKey:(NSString *)clientKey;
+                                  clientKey:(NSString *)clientKey
+                                  serverURL:(NSURL *)serverURL;
 
 @end
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -41,6 +41,7 @@
 
 @synthesize applicationId = _applicationId;
 @synthesize clientKey = _clientKey;
+@synthesize serverURL = _serverURL;
 @synthesize initialRetryDelay = _initialRetryDelay;
 
 ///--------------------------------------
@@ -53,23 +54,26 @@
 
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                      applicationId:(NSString *)applicationId
-                         clientKey:(NSString *)clientKey {
+                         clientKey:(NSString *)clientKey
+                         serverURL:(nonnull NSURL *)serverURL {
     return [self initWithDataSource:dataSource
                       retryAttempts:PFCommandRunningDefaultMaxAttemptsCount
                       applicationId:applicationId
-                          clientKey:clientKey];
+                          clientKey:clientKey
+                          serverURL:serverURL];
 
 }
 
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                      retryAttempts:(NSUInteger)retryAttempts
                      applicationId:(NSString *)applicationId
-                         clientKey:(NSString *)clientKey {
+                         clientKey:(NSString *)clientKey
+                         serverURL:(NSURL *)serverURL {
     NSURLSessionConfiguration *configuration = [[self class] _urlSessionConfigurationForApplicationId:applicationId
                                                                                             clientKey:clientKey];
 
     PFURLSession *session = [PFURLSession sessionWithConfiguration:configuration delegate:self];
-    PFCommandURLRequestConstructor *constructor = [PFCommandURLRequestConstructor constructorWithDataSource:dataSource];
+    PFCommandURLRequestConstructor *constructor = [PFCommandURLRequestConstructor constructorWithDataSource:dataSource serverURL:serverURL];
     self = [self initWithDataSource:dataSource
                             session:session
                  requestConstructor:constructor
@@ -79,6 +83,7 @@
     _retryAttempts = retryAttempts;
     _applicationId = [applicationId copy];
     _clientKey = [clientKey copy];
+    _serverURL = serverURL;
 
     return self;
 }
@@ -102,18 +107,21 @@
 
 + (instancetype)commandRunnerWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                               applicationId:(NSString *)applicationId
-                                  clientKey:(NSString *)clientKey {
-    return [[self alloc] initWithDataSource:dataSource applicationId:applicationId clientKey:clientKey];
+                                  clientKey:(NSString *)clientKey
+                                  serverURL:(nonnull NSURL *)serverURL {
+    return [[self alloc] initWithDataSource:dataSource applicationId:applicationId clientKey:clientKey serverURL:serverURL];
 }
 
 + (instancetype)commandRunnerWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                               retryAttempts:(NSUInteger)retryAttempts
                               applicationId:(NSString *)applicationId
-                                  clientKey:(NSString *)clientKey {
+                                  clientKey:(NSString *)clientKey
+                                  serverURL:(nonnull NSURL *)serverURL {
     return [[self alloc] initWithDataSource:dataSource
                               retryAttempts:retryAttempts
                               applicationId:applicationId
-                                  clientKey:clientKey];
+                                  clientKey:clientKey
+                                  serverURL:serverURL];
 }
 
 ///--------------------------------------

--- a/Parse/Internal/PFInternalUtils.m
+++ b/Parse/Internal/PFInternalUtils.m
@@ -33,6 +33,7 @@
 #import "PFJSONSerialization.h"
 #import "PFMultiProcessFileLockController.h"
 #import "PFHash.h"
+#import "Parse_Private.h"
 
 #if TARGET_OS_IOS
 #import "PFProduct.h"
@@ -44,7 +45,7 @@ static NSString *parseServer_;
 
 + (void)initialize {
     if (self == [PFInternalUtils class]) {
-        [self setParseServer:kPFParseServer];
+        [self setParseServer:_ParseDefaultServerURLString];
     }
 }
 

--- a/Parse/Internal/PFReachability.m
+++ b/Parse/Internal/PFReachability.m
@@ -16,6 +16,7 @@
 #import "PFLogging.h"
 #import "PFMacros.h"
 #import "PFWeakValue.h"
+#import "Parse_Private.h"
 
 @interface PFReachability () {
     dispatch_queue_t _synchronizationQueue;
@@ -102,9 +103,7 @@ static void _reachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReac
     static PFReachability *reachability;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSString *serverUrlAsString = [NSString stringWithFormat:@"%@/%ld", kPFParseServer, (long)PARSE_API_VERSION];
-        NSURL *serverUrl = [NSURL URLWithString:serverUrlAsString];
-        reachability = [[self alloc] initWithURL:serverUrl];
+        reachability = [[self alloc] initWithURL:[Parse _currentManager].serverURL];
     });
     return reachability;
 }

--- a/Parse/Internal/ParseManager.h
+++ b/Parse/Internal/ParseManager.h
@@ -34,6 +34,7 @@ PFKeyValueCacheProvider,
 PFInstallationIdentifierStoreProvider>
 
 @property (nonatomic, copy, readonly) ParseClientConfiguration *configuration;
+@property (nonatomic, strong, readonly) NSURL *serverURL;
 
 @property (nonatomic, strong, readonly) PFCoreManager *coreManager;
 
@@ -56,11 +57,12 @@ PFInstallationIdentifierStoreProvider>
 /**
  Initializes an instance of ParseManager class.
 
- @param configuration                   Configuration of parse app.
+ @param configuration Configuration of parse app.
+ @param url           Parse API Server URL.
 
  @return `ParseManager` instance.
  */
-- (instancetype)initWithConfiguration:(ParseClientConfiguration *)configuration;
+- (instancetype)initWithConfiguration:(ParseClientConfiguration *)configuration serverURL:(NSURL *)url NS_DESIGNATED_INITIALIZER;
 
 /**
  Begins all necessary operations for this manager to become active.

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -90,7 +90,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
     PFNotDesignatedInitializer();
 }
 
-- (instancetype)initWithConfiguration:(ParseClientConfiguration *)configuration {
+- (instancetype)initWithConfiguration:(ParseClientConfiguration *)configuration serverURL:(NSURL *)url {
     self = [super init];
     if (!self) return nil;
 
@@ -109,6 +109,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
     _preloadQueue = dispatch_queue_create("com.parse.preload", DISPATCH_QUEUE_SERIAL);
 
     _configuration = [configuration copy];
+    _serverURL = url;
 
     return self;
 }

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -316,7 +316,8 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
             _commandRunner = [PFURLSessionCommandRunner commandRunnerWithDataSource:self
                                                                       retryAttempts:self.configuration.networkRetryAttempts
                                                                       applicationId:self.configuration.applicationId
-                                                                          clientKey:self.configuration.clientKey];
+                                                                          clientKey:self.configuration.clientKey
+                                                                          serverURL:self.serverURL];
         }
         runner = _commandRunner;
     });

--- a/Parse/Internal/Parse_Private.h
+++ b/Parse/Internal/Parse_Private.h
@@ -13,6 +13,8 @@
 
 #import "ParseManager.h"
 
+extern NSString *const _ParseDefaultServerURLString;
+
 @class PFEventuallyQueue;
 
 @interface Parse ()

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -30,12 +30,6 @@ extern NSInteger const PARSE_API_VERSION;
 extern NSString *const __nonnull kPFDeviceType;
 
 ///--------------------------------------
-/// @name Server
-///--------------------------------------
-
-extern NSString *const __nonnull kPFParseServer;
-
-///--------------------------------------
 /// @name Cache Policies
 ///--------------------------------------
 

--- a/Parse/PFConstants.m
+++ b/Parse/PFConstants.m
@@ -17,8 +17,6 @@ NSString *const kPFDeviceType                = @"ios";
 NSString *const kPFDeviceType                = @"osx";
 #endif
 
-NSString *const kPFParseServer               = @"https://api.parse.com";
-
 NSString *const PFParseErrorDomain = @"Parse";
 
 ///--------------------------------------

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -25,12 +25,15 @@
 #import "PFKeychainStore.h"
 #import "PFLogging.h"
 #import "PFObjectSubclassingController.h"
+#import "Parse_Private.h"
 
 #if !TARGET_OS_WATCH && !TARGET_OS_TV
 #import "PFInstallationPrivate.h"
 #endif
 
 #import "PFCategoryLoader.h"
+
+NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
 
 @implementation Parse
 
@@ -73,7 +76,8 @@ static ParseClientConfiguration *currentParseConfiguration_;
                         configuration.containingApplicationBundleIdentifier != nil,
                         @"'containingApplicationBundleIdentifier' must be non-nil in extension environment");
 
-    ParseManager *manager = [[ParseManager alloc] initWithConfiguration:configuration];
+    ParseManager *manager = [[ParseManager alloc] initWithConfiguration:configuration
+                                                              serverURL:[NSURL URLWithString:[PFInternalUtils parseServerURLString]]];
     [manager startManaging];
 
     currentParseManager_ = manager;

--- a/Tests/Unit/CommandURLRequestConstructorTests.m
+++ b/Tests/Unit/CommandURLRequestConstructorTests.m
@@ -16,6 +16,7 @@
 #import "PFInstallationIdentifierStore.h"
 #import "PFRESTCommand.h"
 #import "PFTestCase.h"
+#import "Parse_Private.h"
 
 @interface CommandURLRequestConstructorTests : PFTestCase
 
@@ -41,18 +42,18 @@
 
 - (void)testConstructors {
     id providerMock = [self mockedInstallationidentifierStoreProviderWithInstallationIdentifier:nil];
-    PFCommandURLRequestConstructor *constructor = [[PFCommandURLRequestConstructor alloc] initWithDataSource:providerMock];
-    XCTAssertNotNil(constructor);
-    XCTAssertEqual((id)constructor.dataSource, providerMock);
+    NSURL *url = [NSURL URLWithString:@"https://parse.com/123"];
 
-    constructor = [PFCommandURLRequestConstructor constructorWithDataSource:providerMock];
+    PFCommandURLRequestConstructor *constructor = [PFCommandURLRequestConstructor constructorWithDataSource:providerMock serverURL:url];
     XCTAssertNotNil(constructor);
     XCTAssertEqual((id)constructor.dataSource, providerMock);
+    XCTAssertEqual(constructor.serverURL, url);
 }
 
 - (void)testDataURLRequest {
     id providerMock = [self mockedInstallationidentifierStoreProviderWithInstallationIdentifier:@"installationId"];
-    PFCommandURLRequestConstructor *constructor = [[PFCommandURLRequestConstructor alloc] initWithDataSource:providerMock];
+    NSURL *url = [NSURL URLWithString:@"https://parse.com/123"];
+    PFCommandURLRequestConstructor *constructor = [PFCommandURLRequestConstructor constructorWithDataSource:providerMock serverURL:url];
 
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                                      httpMethod:PFHTTPRequestMethodPOST
@@ -61,7 +62,7 @@
     command.additionalRequestHeaders = @{ @"CustomHeader" : @"CustomValue" };
 
     NSURLRequest *request = [[constructor getDataURLRequestAsyncForCommand:command] waitForResult:nil];
-    XCTAssertTrue([[request.URL absoluteString] containsString:@"/1/yolo"]);
+    XCTAssertTrue([[request.URL absoluteString] containsString:@"/123/yolo"]);
     XCTAssertEqualObjects(request.allHTTPHeaderFields, (@{ PFCommandHeaderNameInstallationId : @"installationId",
                                                            PFCommandHeaderNameSessionToken : @"yarr",
                                                            PFHTTPRequestHeaderNameContentType : @"application/json; charset=utf-8",
@@ -72,7 +73,8 @@
 
 - (void)testDataURLRequestMethodOverride {
     id providerMock = [self mockedInstallationidentifierStoreProviderWithInstallationIdentifier:@"installationId"];
-    PFCommandURLRequestConstructor *constructor = [[PFCommandURLRequestConstructor alloc] initWithDataSource:providerMock];
+    NSURL *url = [NSURL URLWithString:@"https://parse.com/123"];
+    PFCommandURLRequestConstructor *constructor = [PFCommandURLRequestConstructor constructorWithDataSource:providerMock serverURL:url];
 
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                                      httpMethod:PFHTTPRequestMethodGET
@@ -105,7 +107,8 @@
 
 - (void)testDataURLRequestBodyEncoding {
     id providerMock = [self mockedInstallationidentifierStoreProviderWithInstallationIdentifier:@"installationId"];
-    PFCommandURLRequestConstructor *constructor = [[PFCommandURLRequestConstructor alloc] initWithDataSource:providerMock];
+    NSURL *url = [NSURL URLWithString:@"https://parse.com/123"];
+    PFCommandURLRequestConstructor *constructor = [PFCommandURLRequestConstructor constructorWithDataSource:providerMock serverURL:url];
 
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                                      httpMethod:PFHTTPRequestMethodPOST
@@ -119,7 +122,8 @@
 
 - (void)testFileUploadURLRequest {
     id providerMock = [self mockedInstallationidentifierStoreProviderWithInstallationIdentifier:@"installationId"];
-    PFCommandURLRequestConstructor *constructor = [[PFCommandURLRequestConstructor alloc] initWithDataSource:providerMock];
+    NSURL *url = [NSURL URLWithString:@"https://parse.com/123"];
+    PFCommandURLRequestConstructor *constructor = [PFCommandURLRequestConstructor constructorWithDataSource:providerMock serverURL:url];
 
     PFRESTCommand *command = [PFRESTCommand commandWithHTTPPath:@"yolo"
                                                      httpMethod:PFHTTPRequestMethodPOST

--- a/Tests/Unit/CommandUnitTests.m
+++ b/Tests/Unit/CommandUnitTests.m
@@ -54,7 +54,8 @@
     NSError *error = nil;
     PFURLSessionCommandRunner *commandRunner = [PFURLSessionCommandRunner commandRunnerWithDataSource:[Parse _currentManager]
                                                                                         applicationId:[Parse getApplicationId]
-                                                                                            clientKey:[Parse getClientKey]];
+                                                                                            clientKey:[Parse getClientKey]
+                                                                                            serverURL:[NSURL URLWithString:_ParseDefaultServerURLString]];
     [[commandRunner runCommandAsync:command
                         withOptions:PFCommandRunningOptionRetryIfFailed] waitForResult:&error];
 
@@ -83,7 +84,8 @@
     NSError *error = nil;
     PFURLSessionCommandRunner *commandRunner = [PFURLSessionCommandRunner commandRunnerWithDataSource:[Parse _currentManager]
                                                                                         applicationId:[Parse getApplicationId]
-                                                                                            clientKey:[Parse getClientKey]];
+                                                                                            clientKey:[Parse getClientKey]
+                                                                                            serverURL:[NSURL URLWithString:_ParseDefaultServerURLString]];
     commandRunner.initialRetryDelay = DBL_MIN;
     [[commandRunner runCommandAsync:command
                         withOptions:PFCommandRunningOptionRetryIfFailed] waitForResult:&error];

--- a/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -28,24 +28,29 @@
 
 - (void)testConstructors {
     id mockedDataSource = PFStrictProtocolMock(@protocol(PFInstallationIdentifierStoreProvider));
+    NSURL *url = [NSURL URLWithString:@"https://parse.com/123"];
 
     PFURLSessionCommandRunner *commandRunner = [[PFURLSessionCommandRunner alloc] initWithDataSource:mockedDataSource
                                                                                        applicationId:@"appId"
-                                                                                           clientKey:@"clientKey"];
+                                                                                           clientKey:@"clientKey"
+                                                                                           serverURL:url];
     XCTAssertNotNil(commandRunner);
     XCTAssertEqual(mockedDataSource, (id)commandRunner.dataSource);
     XCTAssertEqualObjects(@"appId", commandRunner.applicationId);
     XCTAssertEqualObjects(@"clientKey", commandRunner.clientKey);
     XCTAssertEqual(commandRunner.initialRetryDelay, PFCommandRunningDefaultRetryDelay);
+    XCTAssertEqual(commandRunner.serverURL, url);
 
     commandRunner = [PFURLSessionCommandRunner commandRunnerWithDataSource:mockedDataSource
                                                              applicationId:@"appId"
-                                                                 clientKey:@"clientKey"];
+                                                                 clientKey:@"clientKey"
+                                                                 serverURL:url];
     XCTAssertNotNil(commandRunner);
     XCTAssertEqual(mockedDataSource, (id)commandRunner.dataSource);
     XCTAssertEqualObjects(@"appId", commandRunner.applicationId);
     XCTAssertEqualObjects(@"clientKey", commandRunner.clientKey);
     XCTAssertEqual(commandRunner.initialRetryDelay, PFCommandRunningDefaultRetryDelay);
+    XCTAssertEqual(commandRunner.serverURL, url);
 
     PFAssertThrowsInconsistencyException([PFURLSessionCommandRunner new]);
 }


### PR DESCRIPTION
This also adds moves the `/1` logic to the constant itself, instead of hard-coding it on URLRequest creation time. 
Depends on #664 