### PR TITLE
Make ParseModuleCollection initialization not dispatch_async multiple times.

### DIFF
--- a/Parse/Internal/ParseModule.m
+++ b/Parse/Internal/ParseModule.m
@@ -81,11 +81,11 @@ typedef void (^ParseModuleEnumerationBlock)(id<ParseModule> module, BOOL *stop, 
 ///--------------------------------------
 
 - (void)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey {
-    [self enumerateModulesWithBlock:^(id<ParseModule> module, BOOL *stop, BOOL *remove) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self enumerateModulesWithBlock:^(id<ParseModule> module, BOOL *stop, BOOL *remove) {
             [module parseDidInitializeWithApplicationId:applicationId clientKey:clientKey];
-        });
-    }];
+        }];
+    });
 }
 
 ///--------------------------------------

--- a/Tests/Unit/ParseModuleUnitTests.m
+++ b/Tests/Unit/ParseModuleUnitTests.m
@@ -53,6 +53,10 @@
     }
 
     [collection parseDidInitializeWithApplicationId:nil clientKey:nil];
+
+    // Run a single runloop tick to trigger the parse initializaiton.
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate distantPast]];
+
     XCTAssertEqual([collection modulesCount], 0);
 }
 


### PR DESCRIPTION
By lifting the `dispatch_async` outside of the module collection enumeration, it allows for fewer local variable caputres, improving perfromance, as well as not requiring multiple flushes of the main dispatch queue to execute.