### PR TITLE
Fix usage of PFObject.setValuesForKeysWithDictionary: with 'NSNull' keys.

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -2293,6 +2293,14 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     self[key] = value;
 }
 
+- (void)setValuesForKeysWithDictionary:(NSDictionary PF_GENERIC(NSString *,id)*)keyedValues {
+    // This is overwritten to make sure we don't use `nil` instead of `NSNull` (the default NSObject implementation).
+    // Remove this if we 100% conform to KVC.
+    [keyedValues enumerateKeysAndObjectsUsingBlock:^(NSString *key, id obj, BOOL *stop) {
+        [self setValue:obj forKey:key];
+    }];
+}
+
 ///--------------------------------------
 #pragma mark - Misc
 ///--------------------------------------

--- a/Tests/Unit/ObjectUnitTests.m
+++ b/Tests/Unit/ObjectUnitTests.m
@@ -184,6 +184,27 @@
     XCTAssertEqualObjects([object valueForKey:@"yarr"], @"yolo");
 }
 
+- (void)testKeyValueCodingFromDictionary {
+    NSString *string = @"foo";
+    NSNumber *number = @0.75;
+    NSDate *date = [NSDate date];
+    NSData *data = [@"foo" dataUsingEncoding:NSUTF8StringEncoding];
+    NSNull *null = [NSNull null];
+    NSDictionary *dictionary = @{ @"string" : string,
+                                  @"number" : number,
+                                  @"date" : date,
+                                  @"data" : data,
+                                  @"null" : null };
+
+    PFObject *object = [PFObject objectWithClassName:@"Test"];
+    [object setValuesForKeysWithDictionary:dictionary];
+    XCTAssertEqualObjects(string, object[@"string"]);
+    XCTAssertEqualObjects(number, object[@"number"]);
+    XCTAssertEqualObjects(date, object[@"date"]);
+    XCTAssertEqualObjects(null, object[@"null"]);
+    XCTAssertEqualObjects(data, object[@"data"]);
+}
+
 #pragma mark Fetch
 
 - (void)testFetchObjectWithoutObjectIdError {


### PR DESCRIPTION
The default implementation invokes setValue:forKey: for each key-value pair, substituting `nil` for `NSNull` values in keyedValues.
Overwrite and invoke everything directly, without substituing `nil` for `NSNull`.
Fixes #667.