### PR TITLE
Fixed construction of urls with path that ends with forward slash.

### DIFF
--- a/Parse/Internal/HTTPRequest/PFURLConstructor.m
+++ b/Parse/Internal/HTTPRequest/PFURLConstructor.m
@@ -24,6 +24,12 @@
     if (path.length != 0) {
         NSString *fullPath = (components.path.length ? components.path : @"/");
         fullPath = [fullPath stringByAppendingPathComponent:path];
+        // If the last character in the provided path is a `/` -> `stringByAppendingPathComponent:` will remove it.
+        // so we need to append it manually to make sure we contruct with the requested behavior.
+        if ([path characterAtIndex:path.length - 1] == '/' &&
+            [fullPath characterAtIndex:fullPath.length - 1] != '/') {
+            fullPath = [fullPath stringByAppendingString:@"/"];
+        }
         components.path = fullPath;
     }
     if (query) {

--- a/Tests/Unit/URLConstructorTests.m
+++ b/Tests/Unit/URLConstructorTests.m
@@ -61,6 +61,18 @@
                                                              path:@"/100500/yolo"
                                                             query:nil].absoluteString,
                           @"https://yolo.com/abc/xyz/100500/yolo");
+    XCTAssertEqualObjects([PFURLConstructor URLFromAbsoluteString:@"https://yolo.com/"
+                                                             path:@"/yolo/"
+                                                            query:nil].absoluteString,
+                          @"https://yolo.com/yolo/");
+    XCTAssertEqualObjects([PFURLConstructor URLFromAbsoluteString:@"https://yolo.com/"
+                                                             path:@"a/yolo/"
+                                                            query:nil].absoluteString,
+                          @"https://yolo.com/a/yolo/");
+    XCTAssertEqualObjects([PFURLConstructor URLFromAbsoluteString:@"https://yolo.com/"
+                                                             path:@"/a/yolo/"
+                                                            query:nil].absoluteString,
+                          @"https://yolo.com/a/yolo/");
 }
 
 @end


### PR DESCRIPTION
We rely on this when requesting file saves - which will fail with a different error if there is a forward slash in the end (filename is invalid, instead of resource not found).