### PR TITLE
Deprecate target:selector: asynchronous methods in all public classes.

### DIFF
--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -1337,6 +1337,14 @@
 		81CA29D91C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29DA1C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29DB1C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E11C28EB2000C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E21C28EB2200C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E31C28EB2300C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E41C28EB2400C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E61C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; };
+		81CA29E71C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; };
+		81CA29E81C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; };
+		81CA29E91C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; };
 		81CB7F6F1B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F701B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F711B166FE500DC601D /* PFObjectState.m in Sources */ = {isa = PBXBuildFile; fileRef = 81CB7F6E1B166FE500DC601D /* PFObjectState.m */; };
@@ -2119,6 +2127,7 @@
 		81C9CA0519FECF5F00D514C5 /* PFRESTFileCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFRESTFileCommand.m; sourceTree = "<group>"; };
 		81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFAnonymousUtils+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFCloud+Deprecated.h"; sourceTree = "<group>"; };
+		81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFFile+Deprecated.h"; sourceTree = "<group>"; };
 		81CB7F6D1B166FE500DC601D /* PFObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFObjectState.h; sourceTree = "<group>"; };
 		81CB7F6E1B166FE500DC601D /* PFObjectState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFObjectState.m; sourceTree = "<group>"; };
 		81CB7F731B166FF500DC601D /* PFMutableObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMutableObjectState.h; sourceTree = "<group>"; };
@@ -2352,6 +2361,7 @@
 				0925ABEB13D791770095FEFA /* PFConstants.h */,
 				0925ABEC13D791770095FEFA /* PFConstants.m */,
 				81DEF07D199C42A300D86A21 /* PFFile.h */,
+				81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */,
 				81DEF07E199C42A300D86A21 /* PFFile.m */,
 				09B119F614880776002B5594 /* PFGeoPoint.h */,
 				09B119F714880776002B5594 /* PFGeoPoint.m */,
@@ -3911,6 +3921,7 @@
 				810155BC1BB3832700D7C7BD /* ParseModule.h in Headers */,
 				810155BD1BB3832700D7C7BD /* PFAssert.h in Headers */,
 				810155BE1BB3832700D7C7BD /* PFUserState.h in Headers */,
+				81CA29E11C28EB2000C4F34A /* PFFile+Deprecated.h in Headers */,
 				810155BF1BB3832700D7C7BD /* PFDecoder.h in Headers */,
 				810155C01BB3832700D7C7BD /* PFGeoPointPrivate.h in Headers */,
 				810155C11BB3832700D7C7BD /* PFURLSessionFileDownloadTaskDelegate.h in Headers */,
@@ -4145,6 +4156,7 @@
 				815F23981BD04D150054659F /* PFURLSession_Private.h in Headers */,
 				815F23991BD04D150054659F /* PFRESTCommand_Private.h in Headers */,
 				815F239A1BD04D150054659F /* PFObjectState.h in Headers */,
+				81CA29E21C28EB2200C4F34A /* PFFile+Deprecated.h in Headers */,
 				815F239B1BD04D150054659F /* PFHTTPRequest.h in Headers */,
 				815F239C1BD04D150054659F /* PFRESTCommand.h in Headers */,
 				815F239D1BD04D150054659F /* PFCloud.h in Headers */,
@@ -4351,6 +4363,7 @@
 				815EE8F519F976D50076FE5D /* PFRESTCommand.h in Headers */,
 				818AAA7319D36B1C00FC1B3C /* PFCloud.h in Headers */,
 				81A715A41B423A4100A504FC /* PFObjectUtilities.h in Headers */,
+				81CA29E41C28EB2400C4F34A /* PFFile+Deprecated.h in Headers */,
 				81CA29CF1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */,
 				81C76EE81B4B201E0031C2FD /* PFObjectConstants.h in Headers */,
 				81CB7F751B166FF500DC601D /* PFMutableObjectState.h in Headers */,
@@ -4642,6 +4655,7 @@
 				814B64121A769EF500213055 /* PFLogger.h in Headers */,
 				8124C8AD1B27D5D600758E00 /* PFSessionUtilities.h in Headers */,
 				814881561B795CAC008763BF /* PFPropertyInfo_Runtime.h in Headers */,
+				81CA29E31C28EB2300C4F34A /* PFFile+Deprecated.h in Headers */,
 				81BCB4C91B744626006659CB /* PFURLSessionDataTaskDelegate_Private.h in Headers */,
 				8166FB9C1B4F2F08003841A2 /* PFUserConstants.h in Headers */,
 				81C76EE91B4B201E0031C2FD /* PFObjectConstants.h in Headers */,

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -1329,6 +1329,10 @@
 		81C9CA0719FECF5F00D514C5 /* PFRESTFileCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C9CA0419FECF5F00D514C5 /* PFRESTFileCommand.h */; };
 		81C9CA0819FECF5F00D514C5 /* PFRESTFileCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C9CA0519FECF5F00D514C5 /* PFRESTFileCommand.m */; };
 		81C9CA0919FECF5F00D514C5 /* PFRESTFileCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C9CA0519FECF5F00D514C5 /* PFRESTFileCommand.m */; };
+		81CA29CF1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29D01C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29D11C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29D21C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CB7F6F1B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F701B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F711B166FE500DC601D /* PFObjectState.m in Sources */ = {isa = PBXBuildFile; fileRef = 81CB7F6E1B166FE500DC601D /* PFObjectState.m */; };
@@ -2109,6 +2113,7 @@
 		81C9C9F619FEA89200D514C5 /* PFRESTPushCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFRESTPushCommand.m; sourceTree = "<group>"; };
 		81C9CA0419FECF5F00D514C5 /* PFRESTFileCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFRESTFileCommand.h; sourceTree = "<group>"; };
 		81C9CA0519FECF5F00D514C5 /* PFRESTFileCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFRESTFileCommand.m; sourceTree = "<group>"; };
+		81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFAnonymousUtils+Deprecated.h"; sourceTree = "<group>"; };
 		81CB7F6D1B166FE500DC601D /* PFObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFObjectState.h; sourceTree = "<group>"; };
 		81CB7F6E1B166FE500DC601D /* PFObjectState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFObjectState.m; sourceTree = "<group>"; };
 		81CB7F731B166FF500DC601D /* PFMutableObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMutableObjectState.h; sourceTree = "<group>"; };
@@ -2332,6 +2337,7 @@
 				9739513816B9D28E0010B884 /* PFAnalytics.h */,
 				9739513916B9D28E0010B884 /* PFAnalytics.m */,
 				638CBBB415191435004F54E4 /* PFAnonymousUtils.h */,
+				81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */,
 				638CBBB515191435004F54E4 /* PFAnonymousUtils.m */,
 				805D3D9F15E31241007E8D10 /* PFCloud.h */,
 				805D3DA015E31241007E8D10 /* PFCloud.m */,
@@ -4023,6 +4029,7 @@
 				810156461BB3832700D7C7BD /* PFPropertyInfo_Runtime.h in Headers */,
 				818ADC791BE1A8BA00C8006C /* PFFilePersistenceGroup.h in Headers */,
 				810156481BB3832700D7C7BD /* PFURLSessionDataTaskDelegate.h in Headers */,
+				81CA29D21C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */,
 				810156491BB3832700D7C7BD /* PFDateFormatter.h in Headers */,
 				8101564A1BB3832700D7C7BD /* PFCloudCodeController.h in Headers */,
 				8101564B1BB3832700D7C7BD /* PFMultiProcessFileLockController.h in Headers */,
@@ -4185,6 +4192,7 @@
 				815F23CF1BD04D150054659F /* PFRESTQueryCommand.h in Headers */,
 				815F23D01BD04D150054659F /* PFACLState_Private.h in Headers */,
 				815F23D11BD04D150054659F /* PFObject.h in Headers */,
+				81CA29D11C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */,
 				815F23D31BD04D150054659F /* PFSQLiteDatabase.h in Headers */,
 				815F23D41BD04D150054659F /* PFProductsRequestHandler.h in Headers */,
 				815F23D51BD04D150054659F /* PFProduct+Private.h in Headers */,
@@ -4335,6 +4343,7 @@
 				815EE8F519F976D50076FE5D /* PFRESTCommand.h in Headers */,
 				818AAA7319D36B1C00FC1B3C /* PFCloud.h in Headers */,
 				81A715A41B423A4100A504FC /* PFObjectUtilities.h in Headers */,
+				81CA29CF1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */,
 				81C76EE81B4B201E0031C2FD /* PFObjectConstants.h in Headers */,
 				81CB7F751B166FF500DC601D /* PFMutableObjectState.h in Headers */,
 				81C1EE491AE1EF960031C438 /* PFWeakValue.h in Headers */,
@@ -4589,6 +4598,7 @@
 				81F0E89019E6F83E00812A88 /* PFACL.h in Headers */,
 				814881461B795C63008763BF /* PFKeyValueCache.h in Headers */,
 				81EB595F1AF46434001EA1FC /* PFFileController.h in Headers */,
+				81CA29D01C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */,
 				815EE94219FA88FB0076FE5D /* PFHTTPURLRequestConstructor.h in Headers */,
 				81F0E89419E6F83E00812A88 /* PFConstants.h in Headers */,
 				8143E65E1AFC1BA5008C4E06 /* PFOfflineQueryController.h in Headers */,

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -1347,6 +1347,10 @@
 		81CA29EC1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29ED1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29EE1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29F01C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29F11C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29F21C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29F31C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CB7F6F1B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F701B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F711B166FE500DC601D /* PFObjectState.m in Sources */ = {isa = PBXBuildFile; fileRef = 81CB7F6E1B166FE500DC601D /* PFObjectState.m */; };
@@ -2132,6 +2136,7 @@
 		81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFFile+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFPush+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFQuery+Deprecated.h"; sourceTree = "<group>"; };
+		81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFUser+Deprecated.h"; sourceTree = "<group>"; };
 		81CB7F6D1B166FE500DC601D /* PFObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFObjectState.h; sourceTree = "<group>"; };
 		81CB7F6E1B166FE500DC601D /* PFObjectState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFObjectState.m; sourceTree = "<group>"; };
 		81CB7F731B166FF500DC601D /* PFMutableObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMutableObjectState.h; sourceTree = "<group>"; };
@@ -2390,6 +2395,7 @@
 				812145751AA4A4C1000B23F5 /* PFSession.h */,
 				812145761AA4A4C1000B23F5 /* PFSession.m */,
 				0925ABF513D791770095FEFA /* PFUser.h */,
+				81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */,
 				0925ABF613D791770095FEFA /* PFUser.m */,
 				811083F11BA2580100FC7F65 /* PFUserAuthenticationDelegate.h */,
 				E9BBE98E16D18E5800CD7B52 /* PFObject+Subclass.h */,
@@ -4053,6 +4059,7 @@
 				810156451BB3832700D7C7BD /* PFObjectLocalIdStore.h in Headers */,
 				810156461BB3832700D7C7BD /* PFPropertyInfo_Runtime.h in Headers */,
 				818ADC791BE1A8BA00C8006C /* PFFilePersistenceGroup.h in Headers */,
+				81CA29F31C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */,
 				810156481BB3832700D7C7BD /* PFURLSessionDataTaskDelegate.h in Headers */,
 				81CA29D21C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */,
 				810156491BB3832700D7C7BD /* PFDateFormatter.h in Headers */,
@@ -4272,6 +4279,7 @@
 				815F24071BD04D150054659F /* PFQueryState_Private.h in Headers */,
 				815F24081BD04D150054659F /* PFObjectSubclassingController.h in Headers */,
 				815F24091BD04D150054659F /* PFOfflineQueryController.h in Headers */,
+				81CA29F21C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */,
 				815F240A1BD04D150054659F /* PFUser.h in Headers */,
 				815F240B1BD04D150054659F /* PFSQLiteDatabase_Private.h in Headers */,
 				F5B64D8D1BFA646C0038F3CB /* ParseClientConfiguration.h in Headers */,
@@ -4380,6 +4388,7 @@
 				81C1EE491AE1EF960031C438 /* PFWeakValue.h in Headers */,
 				8166FCB41B503886003841A2 /* PFOfflineStore.h in Headers */,
 				81329E8E1AE1E8840071EE3E /* PFReachability.h in Headers */,
+				81CA29F01C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */,
 				81C7F4AC1AF42BD9007B5418 /* PFMutableQueryState.h in Headers */,
 				F5B0B3131B44A05100F3EBC4 /* PFPaymentTransactionObserver_Private.h in Headers */,
 				81CB7F991B17970400DC601D /* PFPushState_Private.h in Headers */,
@@ -4679,6 +4688,7 @@
 				8166FC7A1B50376D003841A2 /* PFObjectControlling.h in Headers */,
 				8196D58E1B0BD23B000465A1 /* PFCoreManager.h in Headers */,
 				81C7F48C1AF4110B007B5418 /* PFQueryUtilities.h in Headers */,
+				81CA29F11C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */,
 				8166FC981B50381B003841A2 /* PFQueryPrivate.h in Headers */,
 				8196D5621B0AB661000465A1 /* PFAnalyticsUtilities.h in Headers */,
 				F5556A191B66F47900410837 /* PFURLSession_Private.h in Headers */,

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -1333,6 +1333,10 @@
 		81CA29D01C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29D11C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29D21C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29D81C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29D91C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29DA1C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29DB1C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CB7F6F1B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F701B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F711B166FE500DC601D /* PFObjectState.m in Sources */ = {isa = PBXBuildFile; fileRef = 81CB7F6E1B166FE500DC601D /* PFObjectState.m */; };
@@ -2114,6 +2118,7 @@
 		81C9CA0419FECF5F00D514C5 /* PFRESTFileCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFRESTFileCommand.h; sourceTree = "<group>"; };
 		81C9CA0519FECF5F00D514C5 /* PFRESTFileCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFRESTFileCommand.m; sourceTree = "<group>"; };
 		81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFAnonymousUtils+Deprecated.h"; sourceTree = "<group>"; };
+		81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFCloud+Deprecated.h"; sourceTree = "<group>"; };
 		81CB7F6D1B166FE500DC601D /* PFObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFObjectState.h; sourceTree = "<group>"; };
 		81CB7F6E1B166FE500DC601D /* PFObjectState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFObjectState.m; sourceTree = "<group>"; };
 		81CB7F731B166FF500DC601D /* PFMutableObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMutableObjectState.h; sourceTree = "<group>"; };
@@ -2340,6 +2345,7 @@
 				81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */,
 				638CBBB515191435004F54E4 /* PFAnonymousUtils.m */,
 				805D3D9F15E31241007E8D10 /* PFCloud.h */,
+				81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */,
 				805D3DA015E31241007E8D10 /* PFCloud.m */,
 				81EB6632198A7FA600851598 /* PFConfig.h */,
 				81EB6633198A7FA600851598 /* PFConfig.m */,
@@ -3966,6 +3972,7 @@
 				810155FF1BB3832700D7C7BD /* PFConstants.h in Headers */,
 				810156001BB3832700D7C7BD /* PFSQLiteDatabaseResult.h in Headers */,
 				810156011BB3832700D7C7BD /* PFAnalytics_Private.h in Headers */,
+				81CA29DB1C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */,
 				810156021BB3832700D7C7BD /* PFConfigController.h in Headers */,
 				810156031BB3832700D7C7BD /* PFRelationState.h in Headers */,
 				810156041BB3832700D7C7BD /* PFFileState_Private.h in Headers */,
@@ -4175,6 +4182,7 @@
 				815F23BD1BD04D150054659F /* PFObjectSubclassInfo.h in Headers */,
 				815F23BE1BD04D150054659F /* PFAnalyticsController.h in Headers */,
 				815F23BF1BD04D150054659F /* PFErrorUtilities.h in Headers */,
+				81CA29DA1C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */,
 				815F23C01BD04D150054659F /* PFRelation.h in Headers */,
 				815F23C11BD04D150054659F /* PFAnonymousUtils_Private.h in Headers */,
 				815F23C21BD04D150054659F /* PFPin.h in Headers */,
@@ -4405,6 +4413,7 @@
 				818ADC7E1BE1A8BA00C8006C /* PFPersistenceGroup.h in Headers */,
 				8166FC941B503809003841A2 /* PFPushPrivate.h in Headers */,
 				8124C89F1B27BF0900758E00 /* PFSessionController.h in Headers */,
+				81CA29D81C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */,
 				818AAA7F19D36B1C00FC1B3C /* PFRole.h in Headers */,
 				81CB7F941B1795CF00DC601D /* PFMutablePushState.h in Headers */,
 				8166FCE81B504083003841A2 /* PFPushManager.h in Headers */,
@@ -4600,6 +4609,7 @@
 				81EB595F1AF46434001EA1FC /* PFFileController.h in Headers */,
 				81CA29D01C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h in Headers */,
 				815EE94219FA88FB0076FE5D /* PFHTTPURLRequestConstructor.h in Headers */,
+				81CA29D91C28E15900C4F34A /* PFCloud+Deprecated.h in Headers */,
 				81F0E89419E6F83E00812A88 /* PFConstants.h in Headers */,
 				8143E65E1AFC1BA5008C4E06 /* PFOfflineQueryController.h in Headers */,
 				81CB7F7B1B16710D00DC601D /* PFObjectState_Private.h in Headers */,

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -1341,10 +1341,8 @@
 		81CA29E21C28EB2200C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29E31C28EB2300C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29E41C28EB2400C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81CA29E61C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; };
-		81CA29E71C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; };
-		81CA29E81C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; };
-		81CA29E91C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; };
+		81CA29E61C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29E71C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CB7F6F1B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F701B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F711B166FE500DC601D /* PFObjectState.m in Sources */ = {isa = PBXBuildFile; fileRef = 81CB7F6E1B166FE500DC601D /* PFObjectState.m */; };
@@ -2128,6 +2126,7 @@
 		81CA29CE1C28DF8F00C4F34A /* PFAnonymousUtils+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFAnonymousUtils+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFCloud+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFFile+Deprecated.h"; sourceTree = "<group>"; };
+		81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFPush+Deprecated.h"; sourceTree = "<group>"; };
 		81CB7F6D1B166FE500DC601D /* PFObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFObjectState.h; sourceTree = "<group>"; };
 		81CB7F6E1B166FE500DC601D /* PFObjectState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFObjectState.m; sourceTree = "<group>"; };
 		81CB7F731B166FF500DC601D /* PFMutableObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMutableObjectState.h; sourceTree = "<group>"; };
@@ -2374,6 +2373,7 @@
 				49FDE2EC158C138F00126F64 /* PFPurchase.h */,
 				49FDE2ED158C138F00126F64 /* PFPurchase.m */,
 				0925ABF113D791770095FEFA /* PFPush.h */,
+				81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */,
 				0925ABF213D791770095FEFA /* PFPush.m */,
 				0925ABF313D791770095FEFA /* PFQuery.h */,
 				0925ABF413D791770095FEFA /* PFQuery.m */,
@@ -4323,6 +4323,7 @@
 				8166FCCC1B5038B7003841A2 /* PFPaymentTransactionObserver.h in Headers */,
 				8166FB9B1B4F2F08003841A2 /* PFUserConstants.h in Headers */,
 				8166FC871B503794003841A2 /* PFInstallationIdentifierStore_Private.h in Headers */,
+				81CA29E61C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */,
 				F5B0B30A1B449F1D00F3EBC4 /* PFTaskQueue.h in Headers */,
 				F5B0B30C1B449F1D00F3EBC4 /* PFLocationManager.h in Headers */,
 				8166FCD91B503914003841A2 /* PFUserAuthenticationController.h in Headers */,
@@ -4520,6 +4521,7 @@
 				F5B0B31F1B44A33100F3EBC4 /* PFPinningEventuallyQueue.h in Headers */,
 				8166FC881B503794003841A2 /* PFInstallationIdentifierStore_Private.h in Headers */,
 				814881651B795CD4008763BF /* PFMultiProcessFileLockController.h in Headers */,
+				81CA29E71C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */,
 				F5B0B3221B44A33100F3EBC4 /* ParseInternal.h in Headers */,
 				81CD66551B4DA5A70042FC0B /* PFCurrentInstallationController.h in Headers */,
 				F5B0B3231B44A33100F3EBC4 /* ParseModule.h in Headers */,

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -1351,6 +1351,10 @@
 		81CA29F11C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29F21C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29F31C28ECFD00C4F34A /* PFUser+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29F51C28ED2300C4F34A /* PFObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29F41C28ED2300C4F34A /* PFObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29F61C28ED2300C4F34A /* PFObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29F41C28ED2300C4F34A /* PFObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29F71C28ED2300C4F34A /* PFObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29F41C28ED2300C4F34A /* PFObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29F81C28ED2300C4F34A /* PFObject+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29F41C28ED2300C4F34A /* PFObject+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CB7F6F1B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F701B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F711B166FE500DC601D /* PFObjectState.m in Sources */ = {isa = PBXBuildFile; fileRef = 81CB7F6E1B166FE500DC601D /* PFObjectState.m */; };
@@ -2137,6 +2141,7 @@
 		81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFPush+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFQuery+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFUser+Deprecated.h"; sourceTree = "<group>"; };
+		81CA29F41C28ED2300C4F34A /* PFObject+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFObject+Deprecated.h"; sourceTree = "<group>"; };
 		81CB7F6D1B166FE500DC601D /* PFObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFObjectState.h; sourceTree = "<group>"; };
 		81CB7F6E1B166FE500DC601D /* PFObjectState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFObjectState.m; sourceTree = "<group>"; };
 		81CB7F731B166FF500DC601D /* PFMutableObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMutableObjectState.h; sourceTree = "<group>"; };
@@ -2377,6 +2382,8 @@
 				44B78E11157D21B000A5E97F /* PFInstallation.h */,
 				44B78E12157D21B000A5E97F /* PFInstallation.m */,
 				0925ABED13D791770095FEFA /* PFObject.h */,
+				E9BBE98E16D18E5800CD7B52 /* PFObject+Subclass.h */,
+				81CA29F41C28ED2300C4F34A /* PFObject+Deprecated.h */,
 				0925ABEE13D791770095FEFA /* PFObject.m */,
 				499E425515B6409000A2C28E /* PFProduct.h */,
 				499E425615B6409000A2C28E /* PFProduct.m */,
@@ -2398,7 +2405,6 @@
 				81CA29EF1C28ECFD00C4F34A /* PFUser+Deprecated.h */,
 				0925ABF613D791770095FEFA /* PFUser.m */,
 				811083F11BA2580100FC7F65 /* PFUserAuthenticationDelegate.h */,
-				E9BBE98E16D18E5800CD7B52 /* PFObject+Subclass.h */,
 				E9E81E8316EEF93E001D034F /* PFSubclassing.h */,
 				81DEF089199D555800D86A21 /* PFNetworkActivityIndicatorManager.h */,
 				81DEF08A199D555800D86A21 /* PFNetworkActivityIndicatorManager.m */,
@@ -3977,6 +3983,7 @@
 				810155EB1BB3832700D7C7BD /* PFURLSessionDataTaskDelegate_Private.h in Headers */,
 				810155EC1BB3832700D7C7BD /* PFURLSession_Private.h in Headers */,
 				810155ED1BB3832700D7C7BD /* PFRESTCommand_Private.h in Headers */,
+				81CA29F81C28ED2300C4F34A /* PFObject+Deprecated.h in Headers */,
 				810155EE1BB3832700D7C7BD /* PFObjectState.h in Headers */,
 				810155EF1BB3832700D7C7BD /* PFHTTPRequest.h in Headers */,
 				810155F01BB3832700D7C7BD /* PFRESTCommand.h in Headers */,
@@ -4232,6 +4239,7 @@
 				815F23D41BD04D150054659F /* PFProductsRequestHandler.h in Headers */,
 				815F23D51BD04D150054659F /* PFProduct+Private.h in Headers */,
 				815F23D61BD04D150054659F /* PFKeyValueCache.h in Headers */,
+				81CA29F71C28ED2300C4F34A /* PFObject+Deprecated.h in Headers */,
 				815F23D81BD04D150054659F /* PFSessionController.h in Headers */,
 				815F23D91BD04D150054659F /* PFRole.h in Headers */,
 				815F23DC1BD04D150054659F /* PFSession.h in Headers */,
@@ -4312,6 +4320,7 @@
 				81C9CA0619FECF5F00D514C5 /* PFRESTFileCommand.h in Headers */,
 				81CB7F7A1B16710D00DC601D /* PFObjectState_Private.h in Headers */,
 				81BB6E211B0E7A1A00465C38 /* PFBase64Encoder.h in Headers */,
+				81CA29F51C28ED2300C4F34A /* PFObject+Deprecated.h in Headers */,
 				818AAA6F19D36B1C00FC1B3C /* Parse.h in Headers */,
 				819A4B081A67330200D01241 /* PFHash.h in Headers */,
 				91DF24991A0B0FF200CFC7D4 /* PFEventuallyQueue_Private.h in Headers */,
@@ -4626,6 +4635,7 @@
 				815619011A1F79AC0076504A /* PFDateFormatter.h in Headers */,
 				811214741B3E1CF10052741B /* PFObjectBatchController.h in Headers */,
 				818ADC771BE1A8BA00C8006C /* PFFilePersistenceGroup.h in Headers */,
+				81CA29F61C28ED2300C4F34A /* PFObject+Deprecated.h in Headers */,
 				8148814A1B795C63008763BF /* PFKeyValueCache_Private.h in Headers */,
 				81D843CA1B012FBA007CEBCB /* PFCloudCodeController.h in Headers */,
 				81068EBC1ADE462500A34D13 /* Parse_Private.h in Headers */,

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -1343,6 +1343,10 @@
 		81CA29E41C28EB2400C4F34A /* PFFile+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29E61C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CA29E71C28EC3B00C4F34A /* PFPush+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29EB1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29EC1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29ED1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81CA29EE1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81CB7F6F1B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F701B166FE500DC601D /* PFObjectState.h in Headers */ = {isa = PBXBuildFile; fileRef = 81CB7F6D1B166FE500DC601D /* PFObjectState.h */; };
 		81CB7F711B166FE500DC601D /* PFObjectState.m in Sources */ = {isa = PBXBuildFile; fileRef = 81CB7F6E1B166FE500DC601D /* PFObjectState.m */; };
@@ -2127,6 +2131,7 @@
 		81CA29D71C28E15900C4F34A /* PFCloud+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFCloud+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29DC1C28EA7400C4F34A /* PFFile+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFFile+Deprecated.h"; sourceTree = "<group>"; };
 		81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFPush+Deprecated.h"; sourceTree = "<group>"; };
+		81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PFQuery+Deprecated.h"; sourceTree = "<group>"; };
 		81CB7F6D1B166FE500DC601D /* PFObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFObjectState.h; sourceTree = "<group>"; };
 		81CB7F6E1B166FE500DC601D /* PFObjectState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFObjectState.m; sourceTree = "<group>"; };
 		81CB7F731B166FF500DC601D /* PFMutableObjectState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFMutableObjectState.h; sourceTree = "<group>"; };
@@ -2376,6 +2381,7 @@
 				81CA29E51C28EC3B00C4F34A /* PFPush+Deprecated.h */,
 				0925ABF213D791770095FEFA /* PFPush.m */,
 				0925ABF313D791770095FEFA /* PFQuery.h */,
+				81CA29EA1C28ECA300C4F34A /* PFQuery+Deprecated.h */,
 				0925ABF413D791770095FEFA /* PFQuery.m */,
 				8083B859155DAB1B0023EEFA /* PFRelation.h */,
 				8083B85A155DAB1B0023EEFA /* PFRelation.m */,
@@ -3980,6 +3986,7 @@
 				810155FC1BB3832700D7C7BD /* PFSessionUtilities.h in Headers */,
 				810155FD1BB3832700D7C7BD /* PFGeoPoint.h in Headers */,
 				810155FE1BB3832700D7C7BD /* PFLogger.h in Headers */,
+				81CA29EE1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */,
 				810155FF1BB3832700D7C7BD /* PFConstants.h in Headers */,
 				810156001BB3832700D7C7BD /* PFSQLiteDatabaseResult.h in Headers */,
 				810156011BB3832700D7C7BD /* PFAnalytics_Private.h in Headers */,
@@ -4128,6 +4135,7 @@
 				815F237B1BD04D150054659F /* PFUserFileCodingLogic.h in Headers */,
 				815F237C1BD04D150054659F /* PFAsyncTaskQueue.h in Headers */,
 				815F237D1BD04D150054659F /* PFBaseState.h in Headers */,
+				81CA29ED1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */,
 				815F237E1BD04D150054659F /* PFPaymentTransactionObserver_Private.h in Headers */,
 				815F237F1BD04D150054659F /* PFOfflineObjectController.h in Headers */,
 				815F23801BD04D150054659F /* PFPropertyInfo_Private.h in Headers */,
@@ -4344,6 +4352,7 @@
 				F5B0B2EB1B449EEF00F3EBC4 /* PFAlertView.h in Headers */,
 				8119C9971A76E28F0085B516 /* PFNetworkCommand.h in Headers */,
 				8166FCB01B503886003841A2 /* PFOfflineQueryLogic.h in Headers */,
+				81CA29EB1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */,
 				81951F161ACB90DA00E142EB /* PFJSONSerialization.h in Headers */,
 				81068EBB1ADE462500A34D13 /* Parse_Private.h in Headers */,
 				81A2458D1B1E99C6006A6953 /* PFFieldOperation.h in Headers */,
@@ -4550,6 +4559,7 @@
 				F5B0B3471B44A33200F3EBC4 /* PFPushState_Private.h in Headers */,
 				812B63011B5F30D3009CEAA9 /* PFObjectFileCoder.h in Headers */,
 				811083F31BA2580100FC7F65 /* PFUserAuthenticationDelegate.h in Headers */,
+				81CA29EC1C28ECA300C4F34A /* PFQuery+Deprecated.h in Headers */,
 				F5B0B3481B44A33200F3EBC4 /* PFMutablePushState.h in Headers */,
 				F5B0B3491B44A33200F3EBC4 /* PFPushController.h in Headers */,
 				F5B0B34A1B44A33200F3EBC4 /* PFPushChannelsController.h in Headers */,

--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -103,7 +103,6 @@
 - (instancetype)refresh;
 - (instancetype)refresh:(NSError **)error;
 - (void)refreshInBackgroundWithBlock:(PFObjectResultBlock)block;
-- (void)refreshInBackgroundWithTarget:(id)target selector:(SEL)selector;
 
 #endif
 

--- a/Parse/PFAnonymousUtils+Deprecated.h
+++ b/Parse/PFAnonymousUtils+Deprecated.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Parse/PFAnonymousUtils.h>
+#import <Parse/PFConstants.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PFAnonymousUtils (Deprecated)
+
+///--------------------------------------
+/// @name Creating an Anonymous User
+///--------------------------------------
+
+/**
+ Creates an anonymous user asynchronously and invokes a selector on a target.
+
+ @param target Target object for the selector.
+ @param selector The selector that will be called when the asynchronous request is complete.
+ It should have the following signature: `(void)callbackWithUser:(PFUser *)user error:(NSError *)error`.
+
+ @deprecated Please use `PFAnonymousUtils.+logInWithBlock:` instead.
+ */
++ (void)logInWithTarget:(nullable id)target
+               selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFAnonymousUtils.+logInWithBlock:` instead.");
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/PFAnonymousUtils.h
+++ b/Parse/PFAnonymousUtils.h
@@ -48,21 +48,12 @@ NS_ASSUME_NONNULL_BEGIN
 + (BFTask PF_GENERIC(PFUser *)*)logInInBackground;
 
 /**
- Creates an anonymous user.
+ Creates an anonymous user asynchronously and performs a provided block.
 
  @param block The block to execute when anonymous user creation is complete.
  It should have the following argument signature: `^(PFUser *user, NSError *error)`.
  */
 + (void)logInWithBlock:(nullable PFUserResultBlock)block;
-
-/*
- Creates an anonymous user.
-
- @param target Target object for the selector.
- @param selector The selector that will be called when the asynchronous request is complete.
- It should have the following signature: `(void)callbackWithUser:(PFUser *)user error:(NSError *)error`.
- */
-+ (void)logInWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
 ///--------------------------------------
 /// @name Determining Whether a User is Anonymous

--- a/Parse/PFAnonymousUtils.m
+++ b/Parse/PFAnonymousUtils.m
@@ -30,12 +30,6 @@
     [[self logInInBackground] thenCallBackOnMainThreadAsync:block];
 }
 
-+ (void)logInWithTarget:(id)target selector:(SEL)selector {
-    [self logInWithBlock:^(PFUser *user, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:user object:error];
-    }];
-}
-
 ///--------------------------------------
 #pragma mark - Link
 ///--------------------------------------
@@ -86,6 +80,16 @@ static PFAnonymousAuthenticationProvider *authenticationProvider_;
 + (PFUser *)_lazyLogIn {
     PFAnonymousAuthenticationProvider *provider = [self _authenticationProvider];
     return [PFUser logInLazyUserWithAuthType:PFAnonymousUserAuthenticationType authData:provider.authData];
+}
+
+@end
+
+@implementation PFAnonymousUtils (Deprecated)
+
++ (void)logInWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self logInWithBlock:^(PFUser *user, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:user object:error];
+    }];
 }
 
 @end

--- a/Parse/PFCloud+Deprecated.h
+++ b/Parse/PFCloud+Deprecated.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Parse/PFCloud.h>
+#import <Parse/PFConstants.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PFCloud (Deprecated)
+
+/**
+ Calls the given cloud function *asynchronously* with the parameters provided
+ and then executes the given selector when it is done.
+
+ @param function The function name to call.
+ @param parameters The parameters to send to the function.
+ @param target The object to call the selector on.
+ @param selector The selector to call when the function call finished.
+ It should have the following signature: `(void)callbackWithResult:(id)result error:(NSError *)error`.
+ Result will be `nil` if error is set and vice versa.
+
+ @deprecated Please use `PFCloud.+callFunctionInBackground:withParameters:` instead.
+ */
++ (void)callFunctionInBackground:(NSString *)function
+                  withParameters:(nullable NSDictionary *)parameters
+                          target:(nullable id)target
+                        selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFCloud.+callFunctionInBackground:withParameters:` instead.");
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/PFCloud.h
+++ b/Parse/PFCloud.h
@@ -69,22 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
                   withParameters:(nullable NSDictionary *)parameters
                            block:(nullable PFIdResultBlock)block;
 
-/*
- Calls the given cloud function *asynchronously* with the parameters provided
- and then executes the given selector when it is done.
-
- @param function The function name to call.
- @param parameters The parameters to send to the function.
- @param target The object to call the selector on.
- @param selector The selector to call when the function call finished.
- It should have the following signature: `(void)callbackWithResult:(id)result error:(NSError *)error`.
- Result will be `nil` if error is set and vice versa.
- */
-+ (void)callFunctionInBackground:(NSString *)function
-                  withParameters:(nullable NSDictionary *)parameters
-                          target:(nullable id)target
-                        selector:(nullable SEL)selector;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Parse/PFCloud.m
+++ b/Parse/PFCloud.m
@@ -42,17 +42,25 @@
 
 + (void)callFunctionInBackground:(NSString *)function
                   withParameters:(NSDictionary *)parameters
-                          target:(id)target
-                        selector:(SEL)selector {
+                           block:(PFIdResultBlock)block {
+    [[self callFunctionInBackground:function withParameters:parameters] thenCallBackOnMainThreadAsync:block];
+}
+
+@end
+
+///--------------------------------------
+#pragma mark - Deprecated
+///--------------------------------------
+
+@implementation PFCloud (Deprecated)
+
++ (void)callFunctionInBackground:(NSString *)function
+                  withParameters:(nullable NSDictionary *)parameters
+                          target:(nullable id)target
+                        selector:(nullable SEL)selector {
     [self callFunctionInBackground:function withParameters:parameters block:^(id results, NSError *error) {
         [PFInternalUtils safePerformSelector:selector withTarget:target object:results object:error];
     }];
-}
-
-+ (void)callFunctionInBackground:(NSString *)function
-                  withParameters:(NSDictionary *)parameters
-                           block:(PFIdResultBlock)block {
-    [[self callFunctionInBackground:function withParameters:parameters] thenCallBackOnMainThreadAsync:block];
 }
 
 @end

--- a/Parse/PFFile+Deprecated.h
+++ b/Parse/PFFile+Deprecated.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Parse/PFConstants.h>
+#import <Parse/PFFile.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PFFile (Deprecated)
+
+///--------------------------------------
+/// @name Saving Files
+///--------------------------------------
+
+/**
+ Saves the file *asynchronously* and invokes the given selector on a target.
+
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFFile.-saveInBackgroundWithBlock:` instead.
+ */
+- (void)saveInBackgroundWithTarget:(nullable id)target
+                          selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFFile.-saveInBackgroundWithBlock:` instead.");
+
+///--------------------------------------
+/// @name Getting Files
+///--------------------------------------
+
+/**
+ *Asynchronously* gets the data from cache if available or fetches its contents from the network.
+
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSData *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+
+ @deprecated Please use `PFFile.-getDataInBackgroundWithBlock:` instead.
+ */
+- (void)getDataInBackgroundWithTarget:(nullable id)target
+                             selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFFile.-getDataInBackgroundWithBlock:` instead.");
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -202,17 +202,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)saveInBackgroundWithBlock:(nullable PFBooleanResultBlock)block
                     progressBlock:(nullable PFProgressBlock)progressBlock;
 
-/*
- Saves the file *asynchronously* and calls the given callback.
-
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-- (void)saveInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
-
 ///--------------------------------------
 /// @name Getting Data from Parse
 ///--------------------------------------
@@ -371,16 +360,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)getDataStreamInBackgroundWithBlock:(nullable PFDataStreamResultBlock)resultBlock
                              progressBlock:(nullable PFProgressBlock)progressBlock;
-
-/*
- *Asynchronously* gets the data from cache if available or fetches its contents from the network.
-
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSData *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- */
-- (void)getDataInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
 /**
  *Asynchronously* gets the file path for file from cache if available or fetches its contents from the network.

--- a/Parse/PFFile.m
+++ b/Parse/PFFile.m
@@ -176,12 +176,6 @@ static const unsigned long long PFFileMaxFileSize = 10 * 1024 * 1024; // 10 MB
     [[self _uploadAsyncWithProgressBlock:progressBlock] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
 
-- (void)saveInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
-}
-
 #pragma mark Downloading
 
 - (NSData *)getData {
@@ -240,12 +234,6 @@ static const unsigned long long PFFileMaxFileSize = 10 * 1024 * 1024; // 10 MB
 - (void)getDataStreamInBackgroundWithBlock:(PFDataStreamResultBlock)resultBlock
                              progressBlock:(PFProgressBlock)progressBlock {
     [[self _getDataStreamAsyncWithProgressBlock:progressBlock] thenCallBackOnMainThreadAsync:resultBlock];
-}
-
-- (void)getDataInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self getDataInBackgroundWithBlock:^(NSData *data, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:data object:error];
-    }];
 }
 
 - (BFTask PF_GENERIC(NSString *)*)getFilePathInBackground {
@@ -545,6 +533,26 @@ static const unsigned long long PFFileMaxFileSize = 10 * 1024 * 1024; // 10 MB
 
 + (PFFileController *)fileController {
     return [Parse _currentManager].coreManager.fileController;
+}
+
+@end
+
+///--------------------------------------
+#pragma mark - Deprecated
+///--------------------------------------
+
+@implementation PFFile (Deprecated)
+
+- (void)saveInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
+}
+
+- (void)getDataInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self getDataInBackgroundWithBlock:^(NSData *data, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:data object:error];
+    }];
 }
 
 @end

--- a/Parse/PFObject+Deprecated.h
+++ b/Parse/PFObject+Deprecated.h
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Parse/PFConstants.h>
+#import <Parse/PFObject.h>
+
+@interface PFObject (Deprecated)
+
+///--------------------------------------
+/// @name Saving Objects
+///--------------------------------------
+
+/**
+ Saves the `PFObject` asynchronously and calls the given callback.
+
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFObject.-saveInBackgroundWithBlock:` instead.
+ */
+- (void)saveInBackgroundWithTarget:(nullable id)target
+                          selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.-saveInBackgroundWithBlock:` instead.");
+
+///--------------------------------------
+/// @name Saving Many Objects
+///--------------------------------------
+
+/**
+ Saves a collection of objects all at once *asynchronously* and calls a callback when done.
+
+ @param objects The array of objects to save.
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)number error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFObject.+saveAllInBackground:block:` instead.
+ */
++ (void)saveAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
+                     target:(nullable id)target
+                   selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.+saveAllInBackground:block:` instead.");
+
+///--------------------------------------
+/// @name Getting an Object
+///--------------------------------------
+
+/**
+ *Asynchronously* refreshes the `PFObject` and calls the given callback.
+
+ @param target The target on which the selector will be called.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(PFObject *)refreshedObject error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `refreshedObject` will be the `PFObject` with the refreshed data.
+
+ @deprecated Please use `PFObject.-fetchInBackgroundWithBlock:` instead.
+ */
+- (void)refreshInBackgroundWithTarget:(nullable id)target
+                             selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.-fetchInBackgroundWithBlock:` instead.");
+
+/**
+ Fetches the `PFObject *asynchronously* and calls the given callback.
+
+ @param target The target on which the selector will be called.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(PFObject *)refreshedObject error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `refreshedObject` will be the `PFObject` with the refreshed data.
+
+ @deprecated Please use `PFObject.-fetchInBackgroundWithBlock:` instead.
+ */
+- (void)fetchInBackgroundWithTarget:(nullable id)target
+                           selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.-fetchInBackgroundWithBlock:` instead.");
+
+/**
+ Fetches the PFObject's data asynchronously if `dataAvailable` is `NO`, then calls the callback.
+
+ @param target The target on which the selector will be called.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(PFObject *)fetchedObject error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `refreshedObject` will be the `PFObject` with the refreshed data.
+
+ @deprecated Please use `PFObject.-fetchIfNeededInBackgroundWithBlock:` instead.
+ */
+- (void)fetchIfNeededInBackgroundWithTarget:(nullable id)target
+                                   selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.-fetchIfNeededInBackgroundWithBlock:` instead.");
+
+///--------------------------------------
+/// @name Getting Many Objects
+///--------------------------------------
+
+/**
+ Fetches all of the `PFObject` objects with the current data from the server *asynchronously*
+ and calls the given callback.
+
+ @param objects The list of objects to fetch.
+ @param target The target on which the selector will be called.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSArray *)fetchedObjects error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `fetchedObjects` will the array of `PFObject` objects that were fetched.
+
+ @deprecated Please use `PFObject.+fetchAllInBackground:block:` instead.
+ */
++ (void)fetchAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
+                      target:(nullable id)target
+                    selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.+fetchAllInBackground:block:` instead.");
+
+/**
+ Fetches all of the PFObjects with the current data from the server *asynchronously*
+ and calls the given callback.
+
+ @param objects The list of objects to fetch.
+ @param target The target on which the selector will be called.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSArray *)fetchedObjects error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `fetchedObjects` will the array of `PFObject` objects that were fetched.
+
+ @deprecated Please use `PFObject.+fetchAllIfNeededInBackground:block:` instead.
+ */
++ (void)fetchAllIfNeededInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
+                              target:(nullable id)target
+                            selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.+fetchAllIfNeededInBackground:block:` instead.");
+
+///--------------------------------------
+/// @name Deleting an Object
+///--------------------------------------
+
+/**
+ Deletes the `PFObject` *asynchronously* and calls the given callback.
+
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFObject.-deleteInBackgroundWithBlock:` instead.
+ */
+- (void)deleteInBackgroundWithTarget:(nullable id)target
+                            selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.-deleteInBackgroundWithBlock:` instead.");
+
+///--------------------------------------
+/// @name Deleting Many Objects
+///--------------------------------------
+
+/**
+ Deletes a collection of objects all at once *asynchronously* and calls a callback when done.
+
+ @param objects The array of objects to delete.
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)number error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFObject.+deleteAllInBackground:block:` instead.
+ */
++ (void)deleteAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
+                       target:(nullable id)target
+                     selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.+deleteAllInBackground:block:` instead.");
+
+@end

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -317,17 +317,6 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)saveInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
-/*
- Saves the `PFObject` asynchronously and calls the given callback.
-
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-- (void)saveInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
-
 /**
  Saves this object to the server at some unspecified time in the future,
  even if Parse is currently inaccessible.
@@ -408,20 +397,6 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (void)saveAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
                       block:(nullable PFBooleanResultBlock)block;
 
-/*
- Saves a collection of objects all at once *asynchronously* and calls a callback when done.
-
- @param objects The array of objects to save.
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)number error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-+ (void)saveAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
-                     target:(nullable id)target
-                   selector:(nullable SEL)selector;
-
 ///--------------------------------------
 /// @name Deleting Many Objects
 ///--------------------------------------
@@ -462,20 +437,6 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (void)deleteAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
                         block:(nullable PFBooleanResultBlock)block;
 
-/*
- Deletes a collection of objects all at once *asynchronously* and calls a callback when done.
-
- @param objects The array of objects to delete.
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)number error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-+ (void)deleteAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
-                       target:(nullable id)target
-                     selector:(nullable SEL)selector;
-
 ///--------------------------------------
 /// @name Getting an Object
 ///--------------------------------------
@@ -514,20 +475,6 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  @deprecated Please use `-fetchInBackgroundWithBlock:` instead.
  */
 - (void)refreshInBackgroundWithBlock:(nullable PFObjectResultBlock)block PARSE_DEPRECATED("Please use `-fetchInBackgroundWithBlock:` instead.");
-
-/*
- *Asynchronously* refreshes the `PFObject` and calls the given callback.
-
- @param target The target on which the selector will be called.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(PFObject *)refreshedObject error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `refreshedObject` will be the `PFObject` with the refreshed data.
-
- @deprecated Please use `fetchInBackgroundWithTarget:selector:` instead.
- */
-- (void)refreshInBackgroundWithTarget:(nullable id)target
-                             selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `fetchInBackgroundWithTarget:selector:` instead.");
 
 #endif
 
@@ -569,17 +516,6 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 - (void)fetchInBackgroundWithBlock:(nullable PFObjectResultBlock)block;
 
-/*
- Fetches the `PFObject *asynchronously* and calls the given callback.
-
- @param target The target on which the selector will be called.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(PFObject *)refreshedObject error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `refreshedObject` will be the `PFObject` with the refreshed data.
- */
-- (void)fetchInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
-
 /**
  Fetches the `PFObject` data *asynchronously* if `dataAvailable` is `NO`,
  then sets it as a result for the task.
@@ -595,17 +531,6 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  It should have the following argument signature: `^(PFObject *object, NSError *error)`.
  */
 - (void)fetchIfNeededInBackgroundWithBlock:(nullable PFObjectResultBlock)block;
-
-/*
- Fetches the PFObject's data asynchronously if `dataAvailable` is `NO`, then calls the callback.
-
- @param target The target on which the selector will be called.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(PFObject *)fetchedObject error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `refreshedObject` will be the `PFObject` with the refreshed data.
- */
-- (void)fetchIfNeededInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
 ///--------------------------------------
 /// @name Getting Many Objects
@@ -664,21 +589,6 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (void)fetchAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
                        block:(nullable PFArrayResultBlock)block;
 
-/*
- Fetches all of the `PFObject` objects with the current data from the server *asynchronously*
- and calls the given callback.
-
- @param objects The list of objects to fetch.
- @param target The target on which the selector will be called.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSArray *)fetchedObjects error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `fetchedObjects` will the array of `PFObject` objects that were fetched.
- */
-+ (void)fetchAllInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
-                      target:(nullable id)target
-                    selector:(nullable SEL)selector;
-
 /**
  Fetches all of the `PFObject` objects with the current data from the server *asynchronously*.
 
@@ -698,21 +608,6 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 + (void)fetchAllIfNeededInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
                                block:(nullable PFArrayResultBlock)block;
-
-/*
- Fetches all of the PFObjects with the current data from the server *asynchronously*
- and calls the given callback.
-
- @param objects The list of objects to fetch.
- @param target The target on which the selector will be called.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSArray *)fetchedObjects error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `fetchedObjects` will the array of `PFObject` objects that were fetched.
- */
-+ (void)fetchAllIfNeededInBackground:(nullable NSArray PF_GENERIC(PFObject *)*)objects
-                              target:(nullable id)target
-                            selector:(nullable SEL)selector;
 
 ///--------------------------------------
 /// @name Fetching From Local Datastore
@@ -786,18 +681,6 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  It should have the following argument signature: `^(BOOL succeeded, NSError *error)`.
  */
 - (void)deleteInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
-
-/*
- Deletes the `PFObject` *asynchronously* and calls the given callback.
-
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-- (void)deleteInBackgroundWithTarget:(nullable id)target
-                            selector:(nullable SEL)selector;
 
 /**
  Deletes this object from the server at some unspecified time in the future,

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -1873,12 +1873,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }];
 }
 
-- (void)deleteInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self deleteInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
-}
-
 - (void)deleteInBackgroundWithBlock:(PFBooleanResultBlock)block {
     [[self deleteInBackground] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
@@ -1898,12 +1892,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 - (BFTask *)saveInBackground {
     return [self.taskQueue enqueue:^BFTask *(BFTask *toAwait) {
         return [self saveAsync:toAwait];
-    }];
-}
-
-- (void)saveInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
     }];
 }
 
@@ -1987,10 +1975,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     return [self fetch:error];
 }
 
-- (void)refreshInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self fetchInBackgroundWithTarget:target selector:selector];
-}
-
 - (void)refreshInBackgroundWithBlock:(PFObjectResultBlock)block {
     [self fetchInBackgroundWithBlock:block];
 }
@@ -2018,12 +2002,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     [[self fetchInBackground] thenCallBackOnMainThreadAsync:block];
 }
 
-- (void)fetchInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self fetchInBackgroundWithBlock:^(PFObject *object, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:object object:error];
-    }];
-}
-
 - (instancetype)fetchIfNeeded {
     return [self fetchIfNeeded:nil];
 }
@@ -2041,12 +2019,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 - (void)fetchIfNeededInBackgroundWithBlock:(PFObjectResultBlock)block {
     [[self fetchIfNeededInBackground] thenCallBackOnMainThreadAsync:block];
-}
-
-- (void)fetchIfNeededInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self fetchIfNeededInBackgroundWithBlock:^(PFObject *object, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:object object:error];
-    }];
 }
 
 ///--------------------------------------
@@ -2087,12 +2059,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }] continueWithSuccessResult:fetchObjects];
 }
 
-+ (void)fetchAllInBackground:(NSArray *)objects target:(id)target selector:(SEL)selector {
-    [self fetchAllInBackground:objects block:^(NSArray *objects, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:objects object:error];
-    }];
-}
-
 + (void)fetchAllInBackground:(NSArray *)objects block:(PFArrayResultBlock)block {
     [[self fetchAllInBackground:objects] thenCallBackOnMainThreadAsync:block];
 }
@@ -2111,12 +2077,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
             }];
         } forObjects:uniqueObjects];
     }] continueWithSuccessResult:fetchObjects];
-}
-
-+ (void)fetchAllIfNeededInBackground:(NSArray *)objects target:(id)target selector:(SEL)selector {
-    [self fetchAllIfNeededInBackground:objects block:^(NSArray *objects, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:objects object:error];
-    }];
 }
 
 + (void)fetchAllIfNeededInBackground:(NSArray *)objects block:(PFArrayResultBlock)block {
@@ -2359,12 +2319,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }];
 }
 
-+ (void)saveAllInBackground:(NSArray *)objects target:(id)target selector:(SEL)selector {
-    [PFObject saveAllInBackground:objects block:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
-}
-
 + (void)saveAllInBackground:(NSArray *)objects block:(PFBooleanResultBlock)block {
     [[PFObject saveAllInBackground:objects] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
@@ -2405,12 +2359,6 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
             } forObjects:uniqueObjects];
         }];
     }] continueWithSuccessResult:@YES];
-}
-
-+ (void)deleteAllInBackground:(NSArray *)objects target:(id)target selector:(SEL)selector {
-    [PFObject deleteAllInBackground:objects block:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
 }
 
 + (void)deleteAllInBackground:(NSArray *)objects block:(PFBooleanResultBlock)block {
@@ -2678,6 +2626,78 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
 + (PFObjectSubclassingController *)subclassingController {
     return [PFObjectSubclassingController defaultController];
+}
+
+@end
+
+///--------------------------------------
+#pragma mark - Deprecated
+///--------------------------------------
+
+@implementation PFObject (Deprecated)
+
+#pragma mark Saving Objects
+
+- (void)saveInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
+}
+
+#pragma mark Saving Many Objects
+
++ (void)saveAllInBackground:(NSArray PF_GENERIC(PFObject *)*)objects target:(nullable id)target selector:(nullable SEL)selector {
+    [self saveAllInBackground:objects block:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
+}
+
+#pragma mark Getting an Object
+
+- (void)refreshInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self fetchInBackgroundWithTarget:target selector:selector];
+}
+
+- (void)fetchInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self fetchInBackgroundWithBlock:^(PFObject *object, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:object object:error];
+    }];
+}
+
+- (void)fetchIfNeededInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self fetchIfNeededInBackgroundWithBlock:^(PFObject *object, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:object object:error];
+    }];
+}
+
+#pragma mark Getting Many Objects
+
++ (void)fetchAllInBackground:(NSArray PF_GENERIC(PFObject *)*)objects target:(nullable id)target selector:(nullable SEL)selector {
+    [self fetchAllInBackground:objects block:^(NSArray *objects, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:objects object:error];
+    }];
+}
+
++ (void)fetchAllIfNeededInBackground:(NSArray PF_GENERIC(PFObject *)*)objects target:(nullable id)target selector:(nullable SEL)selector {
+    [self fetchAllIfNeededInBackground:objects block:^(NSArray *objects, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:objects object:error];
+    }];
+}
+
+#pragma mark Deleting an Object
+
+- (void)deleteInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self deleteInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
+}
+
+#pragma mark Deleting Many Objects
+
++ (void)deleteAllInBackground:(NSArray PF_GENERIC(PFObject *)*)objects target:(nullable id)target selector:(nullable SEL)selector {
+    [self deleteAllInBackground:objects block:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
 }
 
 @end

--- a/Parse/PFPush+Deprecated.h
+++ b/Parse/PFPush+Deprecated.h
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Parse/PFConstants.h>
+#import <Parse/PFPush.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PFPush (Deprecated)
+
+///--------------------------------------
+/// @name Sending Push Notifications
+///--------------------------------------
+
+/**
+ *Asynchronously* send a push message to a channel.
+
+ @param channel The channel to send to. The channel name must start with
+ a letter and contain only letters, numbers, dashes, and underscores.
+ @param message The message to send.
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFPush.+sendPushMessageToChannelInBackground:withMessage:block:` instead.
+ */
++ (void)sendPushMessageToChannelInBackground:(NSString *)channel
+                                 withMessage:(NSString *)message
+                                      target:(nullable id)target
+                                    selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFPush.+sendPushMessageToChannelInBackground:withMessage:block:` instead.");
+
+/**
+ *Asynchronously* send this push message and calls the given callback.
+
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFPush.-sendPushInBackgroundWithTarget:selector:` instead.
+ */
+- (void)sendPushInBackgroundWithTarget:(nullable id)target
+                              selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFPush.-sendPushInBackgroundWithTarget:selector:` instead.");
+
+/**
+ *Asynchronously* send a push message with arbitrary data to a channel.
+
+ See the guide for information about the dictionary structure.
+
+ @param channel The channel to send to. The channel name must start with
+ a letter and contain only letters, numbers, dashes, and underscores.
+ @param data The data to send.
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFPush.+sendPushDataToChannelInBackground:withData:block:` instead.
+ */
++ (void)sendPushDataToChannelInBackground:(NSString *)channel
+                                 withData:(NSDictionary *)data
+                                   target:(nullable id)target
+                                 selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFPush.+sendPushDataToChannelInBackground:withData:block:` instead.");
+
+///--------------------------------------
+/// @name Managing Channel Subscriptions
+///--------------------------------------
+
+/**
+ *Asynchronously* get all the channels that this device is subscribed to.
+
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSSet *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+
+ @deprecated Please use `PFPush.+getSubscribedChannelsInBackgroundWithBlock:` instead.
+ */
++ (void)getSubscribedChannelsInBackgroundWithTarget:(id)target
+                                           selector:(SEL)selector PARSE_DEPRECATED("Please use `PFPush.+getSubscribedChannelsInBackgroundWithBlock:` instead.");
+
+/**
+ *Asynchronously* subscribes the device to a channel of push notifications and calls the given callback.
+
+ @param channel The channel to subscribe to. The channel name must start with
+ a letter and contain only letters, numbers, dashes, and underscores.
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFPush.+subscribeToChannelInBackground:block:` instead.
+ */
++ (void)subscribeToChannelInBackground:(NSString *)channel
+                                target:(nullable id)target
+                              selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFPush.+subscribeToChannelInBackground:block:` instead.");
+
+/**
+ *Asynchronously* unsubscribes the device from a channel of push notifications and calls the given callback.
+
+ @param channel The channel to unsubscribe from.
+ @param target The object to call selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFPush.+unsubscribeFromChannelInBackground:block:` instead.
+ */
++ (void)unsubscribeFromChannelInBackground:(NSString *)channel
+                                    target:(nullable id)target
+                                  selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFPush.+unsubscribeFromChannelInBackground:block:` instead.");
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  The preferred way of modifying or retrieving channel subscriptions is to use
  the `PFInstallation` class, instead of the class methods in `PFPush`.
  */
-PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
+PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject<NSCopying>
 
 ///--------------------------------------
 /// @name Creating a Push Notification
@@ -186,23 +186,6 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
                                  withMessage:(NSString *)message
                                        block:(nullable PFBooleanResultBlock)block;
 
-/*
- *Asynchronously* send a push message to a channel.
-
- @param channel The channel to send to. The channel name must start with
- a letter and contain only letters, numbers, dashes, and underscores.
- @param message The message to send.
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-+ (void)sendPushMessageToChannelInBackground:(NSString *)channel
-                                 withMessage:(NSString *)message
-                                      target:(__nullable id)target
-                                    selector:(__nullable SEL)selector;
-
 /**
  Send a push message to a query.
 
@@ -263,17 +246,6 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 - (void)sendPushInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
-/*
- *Asynchronously* send this push message and calls the given callback.
-
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-- (void)sendPushInBackgroundWithTarget:(__nullable id)target selector:(__nullable SEL)selector;
-
 /**
  *Synchronously* send a push message with arbitrary data to a channel.
 
@@ -318,25 +290,6 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (void)sendPushDataToChannelInBackground:(NSString *)channel
                                  withData:(NSDictionary *)data
                                     block:(nullable PFBooleanResultBlock)block;
-
-/*
- *Asynchronously* send a push message with arbitrary data to a channel.
-
- See the guide for information about the dictionary structure.
-
- @param channel The channel to send to. The channel name must start with
- a letter and contain only letters, numbers, dashes, and underscores.
- @param data The data to send.
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-+ (void)sendPushDataToChannelInBackground:(NSString *)channel
-                                 withData:(NSDictionary *)data
-                                   target:(__nullable id)target
-                                 selector:(__nullable SEL)selector;
 
 /**
  *Synchronously* send a push message with arbitrary data to a query.
@@ -438,16 +391,6 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 + (void)getSubscribedChannelsInBackgroundWithBlock:(PFSetResultBlock)block;
 
-/*
- *Asynchronously* get all the channels that this device is subscribed to.
-
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSSet *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- */
-+ (void)getSubscribedChannelsInBackgroundWithTarget:(id)target selector:(SEL)selector;
-
 /**
  *Synchrnously* subscribes the device to a channel of push notifications.
 
@@ -480,21 +423,6 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
 + (void)subscribeToChannelInBackground:(NSString *)channel
                                  block:(nullable PFBooleanResultBlock)block;
 
-/*
- *Asynchronously* subscribes the device to a channel of push notifications and calls the given callback.
-
- @param channel The channel to subscribe to. The channel name must start with
- a letter and contain only letters, numbers, dashes, and underscores.
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-+ (void)subscribeToChannelInBackground:(NSString *)channel
-                                target:(nullable id)target
-                              selector:(nullable SEL)selector;
-
 /**
  *Synchronously* unsubscribes the device to a channel of push notifications.
 
@@ -523,20 +451,6 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject <NSCopying>
  */
 + (void)unsubscribeFromChannelInBackground:(NSString *)channel
                                      block:(nullable PFBooleanResultBlock)block;
-
-/*
- *Asynchronously* unsubscribes the device from a channel of push notifications and calls the given callback.
-
- @param channel The channel to unsubscribe from.
- @param target The object to call selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-+ (void)unsubscribeFromChannelInBackground:(NSString *)channel
-                                    target:(nullable id)target
-                                  selector:(nullable SEL)selector;
 
 @end
 

--- a/Parse/PFPush.m
+++ b/Parse/PFPush.m
@@ -148,12 +148,6 @@ static Class _pushInternalUtilClass = nil;
     }];
 }
 
-- (void)sendPushInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self sendPushInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
-}
-
 - (void)sendPushInBackgroundWithBlock:(PFBooleanResultBlock)block {
     [[self sendPushInBackground] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
@@ -227,15 +221,6 @@ static Class _pushInternalUtilClass = nil;
                                     withMessage:message] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
 
-+ (void)sendPushMessageToChannelInBackground:(NSString *)channel
-                                 withMessage:(NSString *)message
-                                      target:(id)target
-                                    selector:(SEL)selector {
-    [self sendPushMessageToChannelInBackground:channel withMessage:message block:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
-}
-
 + (BOOL)sendPushDataToChannel:(NSString *)channel
                      withData:(NSDictionary *)data
                         error:(NSError **)error {
@@ -253,15 +238,6 @@ static Class _pushInternalUtilClass = nil;
                                  withData:(NSDictionary *)data
                                     block:(PFBooleanResultBlock)block {
     [[self sendPushDataToChannelInBackground:channel withData:data] thenCallBackOnMainThreadWithBoolValueAsync:block];
-}
-
-+ (void)sendPushDataToChannelInBackground:(NSString *)channel
-                                 withData:(NSDictionary *)data
-                                   target:(id)target
-                                 selector:(SEL)selector {
-    [self sendPushDataToChannelInBackground:channel withData:data block:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
 }
 
 #pragma mark To Query
@@ -336,12 +312,6 @@ static Class _pushInternalUtilClass = nil;
     [[self getSubscribedChannelsInBackground] thenCallBackOnMainThreadAsync:block];
 }
 
-+ (void)getSubscribedChannelsInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self getSubscribedChannelsInBackgroundWithBlock:^(NSSet *channels, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:channels object:error];
-    }];
-}
-
 #pragma mark Subscribe
 
 + (BOOL)subscribeToChannel:(NSString *)channel error:(NSError **)error {
@@ -356,12 +326,6 @@ static Class _pushInternalUtilClass = nil;
     [[self subscribeToChannelInBackground:channel] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
 
-+ (void)subscribeToChannelInBackground:(NSString *)channel target:(id)target selector:(SEL)selector {
-    [self subscribeToChannelInBackground:channel block:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
-}
-
 #pragma mark Unsubscribe
 
 + (BOOL)unsubscribeFromChannel:(NSString *)channel error:(NSError **)error {
@@ -374,12 +338,6 @@ static Class _pushInternalUtilClass = nil;
 
 + (void)unsubscribeFromChannelInBackground:(NSString *)channel block:(PFBooleanResultBlock)block {
     [[self unsubscribeFromChannelInBackground:channel] thenCallBackOnMainThreadWithBoolValueAsync:block];
-}
-
-+ (void)unsubscribeFromChannelInBackground:(NSString *)channel target:(id)target selector:(SEL)selector {
-    [self unsubscribeFromChannelInBackground:channel block:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
 }
 
 ///--------------------------------------
@@ -466,6 +424,60 @@ static Class _pushInternalUtilClass = nil;
 
 + (PFPushChannelsController *)channelsController {
     return [Parse _currentManager].pushManager.channelsController;
+}
+
+@end
+
+///--------------------------------------
+#pragma mark - Deprecated
+///--------------------------------------
+
+@implementation PFPush (Deprecated)
+
+#pragma mark Sending Push Notifications
+
+- (void)sendPushInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self sendPushInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
+}
+
++ (void)sendPushMessageToChannelInBackground:(NSString *)channel
+                                 withMessage:(NSString *)message
+                                      target:(nullable id)target
+                                    selector:(nullable SEL)selector {
+    [self sendPushMessageToChannelInBackground:channel withMessage:message block:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
+}
+
++ (void)sendPushDataToChannelInBackground:(NSString *)channel
+                                 withData:(NSDictionary *)data
+                                   target:(nullable id)target
+                                 selector:(nullable SEL)selector {
+    [self sendPushDataToChannelInBackground:channel withData:data block:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
+}
+
+#pragma mark Managing Channel Subscriptions
+
++ (void)getSubscribedChannelsInBackgroundWithTarget:(id)target selector:(SEL)selector {
+    [self getSubscribedChannelsInBackgroundWithBlock:^(NSSet *channels, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:channels object:error];
+    }];
+}
+
++ (void)subscribeToChannelInBackground:(NSString *)channel target:(nullable id)target selector:(nullable SEL)selector {
+    [self subscribeToChannelInBackground:channel block:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
+}
+
++ (void)unsubscribeFromChannelInBackground:(NSString *)channel target:(nullable id)target selector:(nullable SEL)selector {
+    [self unsubscribeFromChannelInBackground:channel block:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
 }
 
 @end

--- a/Parse/PFQuery+Deprecated.h
+++ b/Parse/PFQuery+Deprecated.h
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Parse/PFConstants.h>
+#import <Parse/PFQuery.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PFQuery (Deprecated)
+
+///--------------------------------------
+/// @name Getting Objects by ID
+///--------------------------------------
+
+/**
+ Gets a `PFObject` asynchronously.
+
+ This mutates the PFQuery. It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
+
+ @param objectId The id of the object being requested.
+ @param target The target for the callback selector.
+ @param selector The selector for the callback.
+ It should have the following signature: `(void)callbackWithResult:(id)result error:(NSError *)error`.
+ Result will be `nil` if error is set and vice versa.
+
+ @deprecated Please use `PFQuery.-getObjectInBackgroundWithId:block:` instead.
+ */
+- (void)getObjectInBackgroundWithId:(NSString *)objectId
+                             target:(nullable id)target
+                           selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFQuery.-getObjectInBackgroundWithId:block:` instead.");
+
+///--------------------------------------
+/// @name Getting all Matches for a Query
+///--------------------------------------
+
+/**
+ Finds objects *asynchronously* and calls the given callback with the results.
+
+ @param target The object to call the selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(id)result error:(NSError *)error`.
+ Result will be `nil` if error is set and vice versa.
+
+ @deprecated Please use `PFQuery.-findObjectsInBackgroundWithBlock:` instead.
+ */
+- (void)findObjectsInBackgroundWithTarget:(nullable id)target
+                                 selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFQuery.-findObjectsInBackgroundWithBlock:` instead.");
+
+///--------------------------------------
+/// @name Getting the First Match in a Query
+///--------------------------------------
+
+/**
+ Gets an object *asynchronously* and calls the given callback with the results.
+
+ @warning This method mutates the query. It will reset the limit to `1`.
+
+ @param target The object to call the selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(PFObject *)result error:(NSError *)error`.
+ `result` will be `nil` if `error` is set OR no object was found matching the query.
+ `error` will be `nil` if `result` is set OR if the query succeeded, but found no results.
+
+ @deprecated Please use `PFQuery.-getFirstObjectInBackgroundWithBlock:` instead.
+ */
+- (void)getFirstObjectInBackgroundWithTarget:(nullable id)target
+                                    selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFQuery.-getFirstObjectInBackgroundWithBlock:` instead.");
+
+///--------------------------------------
+/// @name Counting the Matches in a Query
+///--------------------------------------
+
+/**
+ Counts objects *asynchronously* and calls the given callback with the count.
+
+ @param target The object to call the selector on.
+ @param selector The selector to call.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+
+ @deprecated Please use `PFQuery.-countObjectsInBackgroundWithBlock:` instead.
+ */
+- (void)countObjectsInBackgroundWithTarget:(nullable id)target
+                                  selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFQuery.-countObjectsInBackgroundWithBlock:` instead.");
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -573,21 +573,6 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
 - (void)getObjectInBackgroundWithId:(NSString *)objectId
                               block:(nullable void (^)(PFGenericObject __nullable object, NSError *__nullable error))block;
 
-/*
- Gets a `PFObject` asynchronously.
-
- This mutates the PFQuery. It will reset limit to `1`, skip to `0` and remove all conditions, leaving only `objectId`.
-
- @param objectId The id of the object being requested.
- @param target The target for the callback selector.
- @param selector The selector for the callback.
- It should have the following signature: `(void)callbackWithResult:(id)result error:(NSError *)error`.
- Result will be `nil` if error is set and vice versa.
- */
-- (void)getObjectInBackgroundWithId:(NSString *)objectId
-                             target:(nullable id)target
-                           selector:(nullable SEL)selector;
-
 ///--------------------------------------
 /// @name Getting User Objects
 ///--------------------------------------
@@ -649,16 +634,6 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (void)findObjectsInBackgroundWithBlock:(nullable PFQueryArrayResultBlock)block;
 
-/*
- Finds objects *asynchronously* and calls the given callback with the results.
-
- @param target The object to call the selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(id)result error:(NSError *)error`.
- Result will be `nil` if error is set and vice versa.
- */
-- (void)findObjectsInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
-
 ///--------------------------------------
 /// @name Getting the First Match in a Query
 ///--------------------------------------
@@ -704,19 +679,6 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  */
 - (void)getFirstObjectInBackgroundWithBlock:(nullable void (^)(PFGenericObject __nullable object, NSError *__nullable error))block;
 
-/*
- Gets an object *asynchronously* and calls the given callback with the results.
-
- @warning This method mutates the query. It will reset the limit to `1`.
-
- @param target The object to call the selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(PFObject *)result error:(NSError *)error`.
- `result` will be `nil` if `error` is set OR no object was found matching the query.
- `error` will be `nil` if `result` is set OR if the query succeeded, but found no results.
- */
-- (void)getFirstObjectInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
-
 ///--------------------------------------
 /// @name Counting the Matches in a Query
 ///--------------------------------------
@@ -751,15 +713,6 @@ typedef void (^PFQueryArrayResultBlock)(NSArray PF_GENERIC(PFGenericObject) * __
  It should have the following argument signature: `^(int count, NSError *error)`
  */
 - (void)countObjectsInBackgroundWithBlock:(nullable PFIntegerResultBlock)block;
-
-/*
- Counts objects *asynchronously* and calls the given callback with the count.
-
- @param target The object to call the selector on.
- @param selector The selector to call.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- */
-- (void)countObjectsInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
 
 ///--------------------------------------
 /// @name Cancelling a Query

--- a/Parse/PFQuery.m
+++ b/Parse/PFQuery.m
@@ -738,12 +738,6 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
     }
 }
 
-- (void)getObjectInBackgroundWithId:(NSString *)objectId target:(id)target selector:(SEL)selector {
-    [self getObjectInBackgroundWithId:objectId block:^(PFObject *object, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:object object:error];
-    }];
-}
-
 - (BFTask *)_getObjectWithIdAsync:(NSString *)objectId cachePolicy:(PFCachePolicy)cachePolicy after:(BFTask *)task {
     self.limit = 1;
     self.skip = 0;
@@ -817,12 +811,6 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
     }
 }
 
-- (void)findObjectsInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:objects object:error];
-    }];
-}
-
 - (BFTask *)_findObjectsAsyncForQueryState:(PFQueryState *)queryState after:(BFTask *)previous {
     BFCancellationTokenSource *cancellationTokenSource = _cancellationTokenSource;
     if (!previous) {
@@ -888,12 +876,6 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
     }
 }
 
-- (void)getFirstObjectInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self getFirstObjectInBackgroundWithBlock:^(PFObject *result, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:result object:error];
-    }];
-}
-
 - (BFTask *)_getFirstObjectAsyncWithCachePolicy:(PFCachePolicy)cachePolicy after:(BFTask *)task {
     self.limit = 1;
 
@@ -931,12 +913,6 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
     PFConsistencyAssert(self.state.cachePolicy != kPFCachePolicyCacheThenNetwork,
                         @"kPFCachePolicyCacheThenNetwork can only be used with methods that have a callback.");
     return [self _countObjectsAsyncForQueryState:[self _queryStateCopy] after:nil];
-}
-
-- (void)countObjectsInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self countObjectsInBackgroundWithBlock:^(int number, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(number) object:error];
-    }];
 }
 
 - (void)countObjectsInBackgroundWithBlock:(PFIntegerResultBlock)block {
@@ -1134,6 +1110,46 @@ static void PFQueryAssertValidOrderingClauseClass(id object) {
         return [BFTask taskWithResult:nil];
     }
     return [[Parse _currentManager].coreManager.currentUserController getCurrentObjectAsync];
+}
+
+@end
+
+///--------------------------------------
+#pragma mark - Deprecated
+///--------------------------------------
+
+@implementation PFQuery (Deprecated)
+
+#pragma mark - Getting Objects by ID
+
+- (void)getObjectInBackgroundWithId:(NSString *)objectId target:(nullable id)target selector:(nullable SEL)selector {
+    [self getObjectInBackgroundWithId:objectId block:^(PFObject *object, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:object object:error];
+    }];
+}
+
+#pragma mark Getting all Matches for a Query
+
+- (void)findObjectsInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self findObjectsInBackgroundWithBlock:^(NSArray *objects, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:objects object:error];
+    }];
+}
+
+#pragma mark Getting the First Match in a Query
+
+- (void)getFirstObjectInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self getFirstObjectInBackgroundWithBlock:^(PFObject *result, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:result object:error];
+    }];
+}
+
+#pragma mark Counting the Matches in a Query
+
+- (void)countObjectsInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self countObjectsInBackgroundWithBlock:^(int number, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(number) object:error];
+    }];
 }
 
 @end

--- a/Parse/PFUser+Deprecated.h
+++ b/Parse/PFUser+Deprecated.h
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Parse/PFConstants.h>
+#import <Parse/PFUser.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PFUser (Deprecated)
+
+///--------------------------------------
+/// @name Creating a New User
+///--------------------------------------
+
+/**
+ Signs up the user *asynchronously*.
+
+ This will also enforce that the username isn't already taken.
+
+ @warning Make sure that password and username are set before calling this method.
+
+ @param target Target object for the selector.
+ @param selector The selector that will be called when the asynchrounous request is complete.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFUser.-signUpInBackgroundWithBlock:` instead.
+ */
+- (void)signUpInBackgroundWithTarget:(nullable id)target
+                            selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFUser.-signUpInBackgroundWithBlock:` instead.");
+
+///--------------------------------------
+/// @name Logging In
+///--------------------------------------
+
+/**
+ Makes an *asynchronous* request to login a user with specified credentials.
+
+ Returns an instance of the successfully logged in `PFUser`.
+ This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
+
+ @param username The username of the user.
+ @param password The password of the user.
+ @param target Target object for the selector.
+ @param selector The selector that will be called when the asynchrounous request is complete.
+ It should have the following signature: `(void)callbackWithUser:(PFUser *)user error:(NSError *)error`.
+
+ @deprecated Please use `PFUser.+logInWithUsernameInBackground:password:block:` instead.
+ */
++ (void)logInWithUsernameInBackground:(NSString *)username
+                             password:(NSString *)password
+                               target:(nullable id)target
+                             selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFUser.+logInWithUsernameInBackground:password:block:` instead.");
+
+///--------------------------------------
+/// @name Becoming a User
+///--------------------------------------
+
+/**
+ Makes an *asynchronous* request to become a user with the given session token.
+
+ Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
+ so that calls to `+currentUser` will use the latest logged in user.
+
+ @param sessionToken The session token for the user.
+ @param target Target object for the selector.
+ @param selector The selector that will be called when the asynchrounous request is complete.
+ It should have the following signature: `(void)callbackWithUser:(PFUser *)user error:(NSError *)error`.
+
+ @deprecated Please use `PFUser.+becomeInBackground:block:` instead.
+ */
++ (void)becomeInBackground:(NSString *)sessionToken
+                    target:(nullable id)target
+                  selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFUser.+becomeInBackground:block:` instead.");
+
+///--------------------------------------
+/// @name Requesting a Password Reset
+///--------------------------------------
+
+/**
+ Send a password reset request *asynchronously* for a specified email and sets an error object.
+
+ If a user account exists with that email, an email will be sent to that address
+ with instructions on how to reset their password.
+
+ @param email Email of the account to send a reset password request.
+ @param target Target object for the selector.
+ @param selector The selector that will be called when the asynchronous request is complete.
+ It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
+ `error` will be `nil` on success and set if there was an error.
+ `[result boolValue]` will tell you whether the call succeeded or not.
+
+ @deprecated Please use `PFUser.+requestPasswordResetForEmailInBackground:block:` instead.
+ */
++ (void)requestPasswordResetForEmailInBackground:(NSString *)email
+                                          target:(nullable id)target
+                                        selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFUser.+requestPasswordResetForEmailInBackground:block:` instead.");
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -155,21 +155,6 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  */
 - (void)signUpInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
-/**
- Signs up the user *asynchronously*.
-
- This will also enforce that the username isn't already taken.
-
- @warning Make sure that password and username are set before calling this method.
-
- @param target Target object for the selector.
- @param selector The selector that will be called when the asynchrounous request is complete.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-- (void)signUpInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector;
-
 ///--------------------------------------
 /// @name Logging In
 ///--------------------------------------
@@ -186,8 +171,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @return Returns an instance of the `PFUser` on success.
  If login failed for either wrong password or wrong username, returns `nil`.
  */
-+ (nullable instancetype)logInWithUsername:(NSString *)username
-                                  password:(NSString *)password PF_SWIFT_UNAVAILABLE;
++ (nullable instancetype)logInWithUsername:(NSString *)username password:(NSString *)password PF_SWIFT_UNAVAILABLE;
 
 /**
  Makes a *synchronous* request to login a user with specified credentials.
@@ -202,9 +186,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @return Returns an instance of the `PFUser` on success.
  If login failed for either wrong password or wrong username, returns `nil`.
  */
-+ (nullable instancetype)logInWithUsername:(NSString *)username
-                                  password:(NSString *)password
-                                     error:(NSError **)error;
++ (nullable instancetype)logInWithUsername:(NSString *)username password:(NSString *)password error:(NSError **)error;
 
 /**
  Makes an *asynchronous* request to login a user with specified credentials.
@@ -217,25 +199,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 
  @return The task, that encapsulates the work being done.
  */
-+ (BFTask PF_GENERIC(__kindof PFUser *)*)logInWithUsernameInBackground:(NSString *)username
-                                                              password:(NSString *)password;
-
-/**
- Makes an *asynchronous* request to login a user with specified credentials.
-
- Returns an instance of the successfully logged in `PFUser`.
- This also caches the user locally so that calls to `+currentUser` will use the latest logged in user.
-
- @param username The username of the user.
- @param password The password of the user.
- @param target Target object for the selector.
- @param selector The selector that will be called when the asynchrounous request is complete.
- It should have the following signature: `(void)callbackWithUser:(PFUser *)user error:(NSError *)error`.
- */
-+ (void)logInWithUsernameInBackground:(NSString *)username
-                             password:(NSString *)password
-                               target:(nullable id)target
-                             selector:(nullable SEL)selector;
++ (BFTask PF_GENERIC(__kindof PFUser *)*)logInWithUsernameInBackground:(NSString *)username password:(NSString *)password;
 
 /**
  Makes an *asynchronous* request to log in a user with specified credentials.
@@ -248,9 +212,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @param block The block to execute.
  It should have the following argument signature: `^(PFUser *user, NSError *error)`.
  */
-+ (void)logInWithUsernameInBackground:(NSString *)username
-                             password:(NSString *)password
-                                block:(nullable PFUserResultBlock)block;
++ (void)logInWithUsernameInBackground:(NSString *)username password:(NSString *)password block:(nullable PFUserResultBlock)block;
 
 ///--------------------------------------
 /// @name Becoming a User
@@ -306,21 +268,6 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  The block should have the following argument signature: `^(PFUser *user, NSError *error)`.
  */
 + (void)becomeInBackground:(NSString *)sessionToken block:(nullable PFUserResultBlock)block;
-
-/**
- Makes an *asynchronous* request to become a user with the given session token.
-
- Returns an instance of the successfully logged in `PFUser`. This also caches the user locally
- so that calls to `+currentUser` will use the latest logged in user.
-
- @param sessionToken The session token for the user.
- @param target Target object for the selector.
- @param selector The selector that will be called when the asynchrounous request is complete.
- It should have the following signature: `(void)callbackWithUser:(PFUser *)user error:(NSError *)error`.
- */
-+ (void)becomeInBackground:(NSString *)sessionToken
-                    target:(__nullable id)target
-                  selector:(__nullable SEL)selector;
 
 ///--------------------------------------
 /// @name Revocable Session
@@ -427,25 +374,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
  @param block The block to execute.
  It should have the following argument signature: `^(BOOL succeeded, NSError *error)`.
  */
-+ (void)requestPasswordResetForEmailInBackground:(NSString *)email
-                                           block:(nullable PFBooleanResultBlock)block;
-
-/**
- Send a password reset request *asynchronously* for a specified email and sets an error object.
-
- If a user account exists with that email, an email will be sent to that address
- with instructions on how to reset their password.
-
- @param email Email of the account to send a reset password request.
- @param target Target object for the selector.
- @param selector The selector that will be called when the asynchronous request is complete.
- It should have the following signature: `(void)callbackWithResult:(NSNumber *)result error:(NSError *)error`.
- `error` will be `nil` on success and set if there was an error.
- `[result boolValue]` will tell you whether the call succeeded or not.
- */
-+ (void)requestPasswordResetForEmailInBackground:(NSString *)email
-                                          target:(__nullable id)target
-                                        selector:(__nullable SEL)selector;
++ (void)requestPasswordResetForEmailInBackground:(NSString *)email block:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
 /// @name Third-party Authentication

--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -817,15 +817,6 @@ static BOOL revocableSessionEnabled_;
     [[self logInWithUsernameInBackground:username password:password] thenCallBackOnMainThreadAsync:block];
 }
 
-+ (void)logInWithUsernameInBackground:(NSString *)username
-                             password:(NSString *)password
-                               target:(id)target
-                             selector:(SEL)selector {
-    [self logInWithUsernameInBackground:username password:password block:^(PFUser *user, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:user object:error];
-    }];
-}
-
 ///--------------------------------------
 #pragma mark - Third-party Authentication
 ///--------------------------------------
@@ -949,12 +940,6 @@ static BOOL revocableSessionEnabled_;
     [[self becomeInBackground:sessionToken] thenCallBackOnMainThreadAsync:block];
 }
 
-+ (void)becomeInBackground:(NSString *)sessionToken target:(id)target selector:(SEL)selector {
-    [self becomeInBackground:sessionToken block:^(PFUser *user, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:user object:error];
-    }];
-}
-
 ///--------------------------------------
 #pragma mark - Revocable Sessions
 ///--------------------------------------
@@ -993,12 +978,6 @@ static BOOL revocableSessionEnabled_;
 
 + (void)requestPasswordResetForEmailInBackground:(NSString *)email block:(PFBooleanResultBlock)block {
     [[self requestPasswordResetForEmailInBackground:email] thenCallBackOnMainThreadWithBoolValueAsync:block];
-}
-
-+ (void)requestPasswordResetForEmailInBackground:(NSString *)email target:(id)target selector:(SEL)selector {
-    [self requestPasswordResetForEmailInBackground:email block:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
 }
 
 ///--------------------------------------
@@ -1164,12 +1143,6 @@ static BOOL revocableSessionEnabled_;
     }];
 }
 
-- (void)signUpInBackgroundWithTarget:(id)target selector:(SEL)selector {
-    [self signUpInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
-        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
-    }];
-}
-
 - (BOOL)isAuthenticated {
     PFUser *currentUser = [[self class] currentUser];
     return [self _isAuthenticatedWithCurrentUser:currentUser];
@@ -1224,6 +1197,49 @@ static BOOL revocableSessionEnabled_;
                                             objectId:(NSString *)objectId
                                           isComplete:(BOOL)complete {
     return [PFUserState stateWithParseClassName:className objectId:objectId isComplete:complete];
+}
+
+@end
+
+///--------------------------------------
+#pragma mark - Deprecated
+///--------------------------------------
+
+@implementation PFUser (Deprecated)
+
+#pragma mark Creating a new User
+
+- (void)signUpInBackgroundWithTarget:(nullable id)target selector:(nullable SEL)selector {
+    [self signUpInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
+}
+
+#pragma mark Logging In
+
++ (void)logInWithUsernameInBackground:(NSString *)username
+                             password:(NSString *)password
+                               target:(nullable id)target
+                             selector:(nullable SEL)selector {
+    [self logInWithUsernameInBackground:username password:password block:^(PFUser *user, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:user object:error];
+    }];
+}
+
+#pragma mark Becoming a User
+
++ (void)becomeInBackground:(NSString *)sessionToken target:(nullable id)target selector:(nullable SEL)selector {
+    [self becomeInBackground:sessionToken block:^(PFUser *user, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:user object:error];
+    }];
+}
+
+#pragma mark Requesting a Password Reset
+
++ (void)requestPasswordResetForEmailInBackground:(NSString *)email target:(nullable id)target selector:(nullable SEL)selector {
+    [self requestPasswordResetForEmailInBackground:email block:^(BOOL succeeded, NSError *error) {
+        [PFInternalUtils safePerformSelector:selector withTarget:target object:@(succeeded) object:error];
+    }];
 }
 
 @end

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -15,6 +15,7 @@
 #import <Parse/PFAnonymousUtils.h>
 #import <Parse/PFAnonymousUtils+Deprecated.h>
 #import <Parse/PFCloud.h>
+#import <Parse/PFCloud+Deprecated.h>
 #import <Parse/PFConfig.h>
 #import <Parse/PFConstants.h>
 #import <Parse/PFFile.h>

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -19,6 +19,7 @@
 #import <Parse/PFConfig.h>
 #import <Parse/PFConstants.h>
 #import <Parse/PFFile.h>
+#import <Parse/PFFile+Deprecated.h>
 #import <Parse/PFGeoPoint.h>
 #import <Parse/PFObject+Subclass.h>
 #import <Parse/PFObject.h>

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -24,6 +24,7 @@
 #import <Parse/PFObject+Subclass.h>
 #import <Parse/PFObject.h>
 #import <Parse/PFQuery.h>
+#import <Parse/PFQuery+Deprecated.h>
 #import <Parse/PFRelation.h>
 #import <Parse/PFRole.h>
 #import <Parse/PFSession.h>

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -36,6 +36,7 @@
 #import <Parse/PFInstallation.h>
 #import <Parse/PFNetworkActivityIndicatorManager.h>
 #import <Parse/PFPush.h>
+#import <Parse/PFPush+Deprecated.h>
 #import <Parse/PFProduct.h>
 #import <Parse/PFPurchase.h>
 
@@ -43,6 +44,7 @@
 
 #import <Parse/PFInstallation.h>
 #import <Parse/PFPush.h>
+#import <Parse/PFPush+Deprecated.h>
 
 #elif TARGET_OS_TV
 

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -30,6 +30,7 @@
 #import <Parse/PFSession.h>
 #import <Parse/PFSubclassing.h>
 #import <Parse/PFUser.h>
+#import <Parse/PFUser+Deprecated.h>
 #import <Parse/PFUserAuthenticationDelegate.h>
 
 #if TARGET_OS_IOS

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -13,6 +13,7 @@
 #import <Parse/PFACL.h>
 #import <Parse/PFAnalytics.h>
 #import <Parse/PFAnonymousUtils.h>
+#import <Parse/PFAnonymousUtils+Deprecated.h>
 #import <Parse/PFCloud.h>
 #import <Parse/PFConfig.h>
 #import <Parse/PFConstants.h>

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -21,8 +21,9 @@
 #import <Parse/PFFile.h>
 #import <Parse/PFFile+Deprecated.h>
 #import <Parse/PFGeoPoint.h>
-#import <Parse/PFObject+Subclass.h>
 #import <Parse/PFObject.h>
+#import <Parse/PFObject+Subclass.h>
+#import <Parse/PFObject+Deprecated.h>
 #import <Parse/PFQuery.h>
 #import <Parse/PFQuery+Deprecated.h>
 #import <Parse/PFRelation.h>

--- a/Tests/Unit/AnonymousUtilsTests.m
+++ b/Tests/Unit/AnonymousUtilsTests.m
@@ -123,7 +123,12 @@
     OCMExpect([observer callbackWithUser:user error:nil]).andDo(^(NSInvocation *invocation) {
         [expectation fulfill];
     });
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [PFAnonymousUtils logInWithTarget:observer selector:@selector(callbackWithUser:error:)];
+#pragma clang diagnostic pop
+
     [self waitForTestExpectations];
     OCMVerifyAll(authController);
 }

--- a/Tests/Unit/CloudUnitTests.m
+++ b/Tests/Unit/CloudUnitTests.m
@@ -111,10 +111,14 @@
     OCMStub([mock callbackWithResult:[OCMArg isEqual:result]
                                error:[OCMArg isNil]]).andCall(expectation, @selector(fulfill));
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [PFCloud callFunctionInBackground:@"yolo"
                        withParameters:nil
                                target:mock
                              selector:@selector(callbackWithResult:error:)];
+#pragma clang diagnostic pop
+
     [self waitForTestExpectations];
 }
 
@@ -154,10 +158,14 @@
     OCMStub([mock callbackWithResult:[OCMArg isNil]
                                error:[OCMArg isEqual:error]]).andCall(expectation, @selector(fulfill));
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [PFCloud callFunctionInBackground:@"yolo"
                        withParameters:nil
                                target:mock
                              selector:@selector(callbackWithResult:error:)];
+#pragma clang diagnostic pop
+
     [self waitForTestExpectations];
 }
 

--- a/Tests/Unit/FileUnitTests.m
+++ b/Tests/Unit/FileUnitTests.m
@@ -286,7 +286,11 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     OCMStub([verifier verifyObject:@YES error:nil]).andDo(^(NSInvocation *invocation) {
         [expectation fulfill];
     });
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [file saveInBackgroundWithTarget:verifier selector:@selector(verifyObject:error:)];
+#pragma clang diagnostic pop
 
     [self waitForTestExpectations];
 }
@@ -417,7 +421,11 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     OCMStub([verifier verifyObject:expectedData error:nil]).andDo(^(NSInvocation *invocation) {
         [expectation fulfill];
     });
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [file getDataInBackgroundWithTarget:verifier selector:@selector(verifyObject:error:)];
+#pragma clang diagnostic pop
 
     wait_next;
     expectation = [self expectationForSelector:@selector(getDataDownloadStreamInBackground)];

--- a/Tests/Unit/PushUnitTests.m
+++ b/Tests/Unit/PushUnitTests.m
@@ -261,7 +261,11 @@
     };
 
     self.expectationToFulfuill = backgroundTargetSelectorExpectation;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [thePush sendPushInBackgroundWithTarget:self selector:@selector(validateObjectResults:error:)];
+#pragma clang diagnostic pop
 
     [self waitForTestExpectations];
 }
@@ -307,10 +311,13 @@
     };
 
     self.expectationToFulfuill = toChannelTargetSelectorExpectation;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [PFPush sendPushMessageToChannelInBackground:channelName
                                      withMessage:message
                                           target:self
                                         selector:@selector(validateObjectResults:error:)];
+#pragma clang diagnostic pop
 
     [self waitForTestExpectations];
 }
@@ -348,10 +355,13 @@
     };
 
     self.expectationToFulfuill = toChannelTargetSelectorExpectation;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [PFPush sendPushDataToChannelInBackground:channelName
                                      withData:payload
                                        target:self
                                      selector:@selector(validateObjectResults:error:)];
+#pragma clang diagnostic pop
 
     [self waitForTestExpectations];
 }
@@ -459,7 +469,10 @@
     };
 
     self.expectationToFulfuill = subscribeTargetSelectorExpectation;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [PFPush getSubscribedChannelsInBackgroundWithTarget:self selector:@selector(validateObjectResults:error:)];
+#pragma clang diagnostic pop
 
     [self waitForTestExpectations];
 }
@@ -496,9 +509,13 @@
     };
 
     self.expectationToFulfuill = subscribeTargetSelectorExpectation;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [PFPush subscribeToChannelInBackground:channel
                                     target:self
                                   selector:@selector(validateObjectResults:error:)];
+#pragma clang diagnostic pop
 
     [self waitForTestExpectations];
 }
@@ -535,9 +552,13 @@
     };
 
     self.expectationToFulfuill = unsubscribeTargetSelectorExpectation;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [PFPush unsubscribeFromChannelInBackground:channel
                                         target:self
                                       selector:@selector(validateObjectResults:error:)];
+#pragma clang diagnostic pop
 
     [self waitForTestExpectations];
 }

--- a/Tests/Unit/QueryUnitTests.m
+++ b/Tests/Unit/QueryUnitTests.m
@@ -695,7 +695,11 @@
         [expectation fulfill];
     });
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [query getObjectInBackgroundWithId:@"yarr" target:verifier selector:@selector(verifyObject:error:)];
+#pragma clang diagnostic pop
+
     [self waitForTestExpectations];
 }
 
@@ -847,7 +851,11 @@
         [expectation fulfill];
     });
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [query findObjectsInBackgroundWithTarget:verifier selector:@selector(verifyArray:error:)];
+#pragma clang diagnostic pop
+
     [self waitForTestExpectations];
 }
 
@@ -1050,7 +1058,11 @@
         [expectation fulfill];
     });
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [query getFirstObjectInBackgroundWithTarget:verifier selector:@selector(verifyObject:error:)];
+#pragma clang diagnostic pop
+
     [self waitForTestExpectations];
 }
 
@@ -1160,7 +1172,11 @@
         [expectation fulfill];
     });
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [query countObjectsInBackgroundWithTarget:verifier selector:@selector(verifyNumber:error:)];
+#pragma clang diagnostic pop
+
     [self waitForTestExpectations];
 }
 


### PR DESCRIPTION
This moves all the declarations into class extensions (categories) as well as adds `deprecated` attribute to all methods that end with `...target:selector:`. These methods are pretty much useless and are deprecated in favor of either block-based callbacks or task-based approach.