### PR TITLE
Use shields.io badge for Travis-CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ of patent rights can be found in the PATENTS file in the same directory.
  [bolts-framework]: https://github.com/BoltsFramework/Bolts-iOS
  [ocmock-framework]: http://ocmock.org
 
- [build-status-svg]: https://travis-ci.org/ParsePlatform/Parse-SDK-iOS-OSX.svg
+ [build-status-svg]: https://img.shields.io/travis/ParsePlatform/Parse-SDK-iOS-OSX/master.svg
  [build-status-link]: https://travis-ci.org/ParsePlatform/Parse-SDK-iOS-OSX/branches
 
  [coverage-status-svg]: https://img.shields.io/codecov/c/github/ParsePlatform/Parse-SDK-iOS-OSX/master.svg


### PR DESCRIPTION
Looks like Travis default badge is using any latest branch available, which doesn't quite suite us, since we care only about `master`.
Use the `shields.io` version of it that supports branches.