### PR TITLE
Mark unavailable properties for tvOS/watchOS as such in ParseMutableClientConfiguration.

### DIFF
--- a/Parse/ParseClientConfiguration.h
+++ b/Parse/ParseClientConfiguration.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  The default value is `NO`.
  */
-@property (nonatomic, assign, readwrite, getter=isLocalDatastoreEnabled) BOOL localDatastoreEnabled;
+@property (nonatomic, assign, getter=isLocalDatastoreEnabled) BOOL localDatastoreEnabled PF_TV_UNAVAILABLE;
 
 ///--------------------------------------
 /// @name Enabling Extensions Data Sharing
@@ -62,14 +62,14 @@ NS_ASSUME_NONNULL_BEGIN
  After enabling - Local Datastore, `PFUser.+currentUser`, `PFInstallation.+currentInstallation` and all eventually commands
  are going to be available to every application/extension in a group that have the same Parse applicationId.
  */
-@property (nullable, nonatomic, copy) NSString *applicationGroupIdentifier;
+@property (nullable, nonatomic, copy) NSString *applicationGroupIdentifier PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE;
 
 /**
  When set, controls the bundle identifier of the parent bundle to connect to.
 
  @warning This property should only be set from inside an extension environment.
  */
-@property (nullable, nonatomic, copy) NSString *containingApplicationBundleIdentifier;
+@property (nullable, nonatomic, copy) NSString *containingApplicationBundleIdentifier PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE;
 
 ///--------------------------------------
 /// @name Other Properties


### PR DESCRIPTION
These properties are not available on tvOS/watchOS, but were not marked as such.
Not marking the `readonly` counterpart on `ParseClientConfiguration`, as that part is not required as well as will prevent us from using them internally without extra changes.