### PR TITLE
Use property accessors via dot-syntax where possible instead of method invocations.

### DIFF
--- a/Parse/Internal/Analytics/Utilities/PFAnalyticsUtilities.m
+++ b/Parse/Internal/Analytics/Utilities/PFAnalyticsUtilities.m
@@ -17,14 +17,15 @@
     if (!payload || payload == [NSNull null]) {
         payload = @"";
     } else if ([payload isKindOfClass:[NSDictionary class]]) {
-        NSDictionary *dict = payload;
-        NSArray *keys = [[dict allKeys] sortedArrayUsingSelector:@selector(compare:)];
-        NSMutableArray *components = [NSMutableArray arrayWithCapacity:[dict count] * 2];
+        NSDictionary *dictionary = payload;
+        NSArray *keys = [dictionary.allKeys sortedArrayUsingSelector:@selector(compare:)];
+
+        NSMutableArray *components = [NSMutableArray arrayWithCapacity:dictionary.count * 2];
         [keys enumerateObjectsUsingBlock:^(id key, NSUInteger idx, BOOL *stop) {
             [components addObject:key];
 
             // alert[@"loc-args"] can be an NSArray
-            id value = dict[key];
+            id value = dictionary[key];
             if ([value isKindOfClass:[NSArray class]]) {
                 value = [value componentsJoinedByString:@""];
             }

--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
@@ -101,7 +101,7 @@
 
         //TODO (nlutsenko): Check for error here.
         NSNumber *fileSize = [PFInternalUtils fileSizeOfFileAtPath:contentFilePath error:nil];
-        [request setValue:[fileSize stringValue] forHTTPHeaderField:PFHTTPRequestHeaderNameContentLength];
+        [request setValue:fileSize.stringValue forHTTPHeaderField:PFHTTPRequestHeaderNameContentLength];
 
         return request;
     }];

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -239,7 +239,7 @@
             return task;
         }
 
-        if ([[task.error userInfo][@"temporary"] boolValue] && attempts > 1) {
+        if ([task.error.userInfo[@"temporary"] boolValue] && attempts > 1) {
             PFLogError(PFLoggingTagCommon,
                        @"Network connection failed. Making attempt %lu after sleeping for %f seconds.",
                        (unsigned long)(_retryAttempts - attempts + 1), (double)delay);

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.m
@@ -104,7 +104,7 @@
 }
 
 - (void)_writeDataOutputStreamData:(NSData *)data {
-    NSInteger length = [data length];
+    NSInteger length = data.length;
     while (YES) {
         NSInteger bytesWritten = 0;
         if ([self.dataOutputStream hasSpaceAvailable]) {

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionJSONDataTaskDelegate.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionJSONDataTaskDelegate.m
@@ -55,7 +55,7 @@
         errorDictionary[NSUnderlyingErrorKey] = self.error;
         errorDictionary[@"temporary"] = @(self.response.statusCode >= 500 || self.response.statusCode < 400);
 
-        NSString *description = [self.error localizedDescription] ?: [self.error localizedFailureReason];
+        NSString *description = self.error.localizedDescription ?: self.error.localizedFailureReason;
         if (description) {
             errorDictionary[@"error"] = description;
         }

--- a/Parse/Internal/Commands/PFRESTCommand.m
+++ b/Parse/Internal/Commands/PFRESTCommand.m
@@ -149,8 +149,8 @@ static const int PFRESTCommandCacheKeyVersion = 1;
         if (objectId) {
             self.localId = nil;
 
-            NSArray *components = [self.httpPath pathComponents];
-            if ([components count] == 2) {
+            NSArray *components = self.httpPath.pathComponents;
+            if (components.count == 2) {
                 self.httpPath = [NSString pathWithComponents:[components arrayByAddingObject:objectId]];
             }
 

--- a/Parse/Internal/Commands/PFRESTObjectBatchCommand.m
+++ b/Parse/Internal/Commands/PFRESTObjectBatchCommand.m
@@ -20,13 +20,13 @@ NSUInteger const PFRESTObjectBatchCommandSubcommandsLimit = 50;
 + (nonnull instancetype)batchCommandWithCommands:(nonnull NSArray PF_GENERIC(PFRESTCommand *)*)commands
                                     sessionToken:(nullable NSString *)sessionToken
                                        serverURL:(nonnull NSURL *)serverURL {
-    PFParameterAssert([commands count] <= PFRESTObjectBatchCommandSubcommandsLimit,
+    PFParameterAssert(commands.count <= PFRESTObjectBatchCommandSubcommandsLimit,
                       @"Max of %d commands are allowed in a single batch command",
                       (int)PFRESTObjectBatchCommandSubcommandsLimit);
 
-    NSMutableArray *requests = [NSMutableArray arrayWithCapacity:[commands count]];
+    NSMutableArray *requests = [NSMutableArray arrayWithCapacity:commands.count];
     for (PFRESTCommand *command in commands) {
-        NSURL *commandURL = [PFURLConstructor URLFromAbsoluteString:[serverURL absoluteString]
+        NSURL *commandURL = [PFURLConstructor URLFromAbsoluteString:serverURL.absoluteString
                                                                path:command.httpPath
                                                               query:nil];
         NSMutableDictionary *requestDictionary = [@{ @"method" : command.httpMethod,

--- a/Parse/Internal/Commands/PFRESTPushCommand.m
+++ b/Parse/Internal/Commands/PFRESTPushCommand.m
@@ -28,12 +28,12 @@
         parameters[@"where"] = queryParameters[@"where"];
     } else {
         if (state.channels) {
-            parameters[@"channels"] = [state.channels allObjects];
+            parameters[@"channels"] = state.channels.allObjects;
         }
     }
 
     // If there are no conditions set, then push to everyone by specifying empty query conditions.
-    if ([parameters count] == 0) {
+    if (parameters.count == 0) {
         parameters[@"where"] = @{};
     }
 

--- a/Parse/Internal/Commands/PFRESTQueryCommand.m
+++ b/Parse/Internal/Commands/PFRESTQueryCommand.m
@@ -103,7 +103,7 @@
                                   tracingEnabled:(BOOL)trace {
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 
-    if ([order length]) {
+    if (order.length) {
         parameters[@"order"] = order;
     }
     if (selectedKeys) {
@@ -111,7 +111,7 @@
         NSArray *keysArray = [selectedKeys sortedArrayUsingDescriptors:sortDescriptors];
         parameters[@"keys"] = [keysArray componentsJoinedByString:@","];
     }
-    if ([includedKeys count] > 0) {
+    if (includedKeys.count > 0) {
         NSArray *sortDescriptors = @[ [NSSortDescriptor sortDescriptorWithKey:@"self" ascending:YES selector:@selector(compare:)] ];
         NSArray *keysArray = [includedKeys sortedArrayUsingDescriptors:sortDescriptors];
         parameters[@"include"] = [keysArray componentsJoinedByString:@","];
@@ -130,7 +130,7 @@
         parameters[key] = obj;
     }];
 
-    if ([conditions count] > 0) {
+    if (conditions.count > 0) {
         NSMutableDictionary *whereData = [[NSMutableDictionary alloc] init];
         [conditions enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
             if ([key isEqualToString:@"$or"]) {
@@ -154,7 +154,7 @@
                                                                     tracingEnabled:NO];
 
                     queryDict = queryDict[@"where"];
-                    if ([queryDict count] > 0) {
+                    if (queryDict.count > 0) {
                         [newArray addObject:queryDict];
                     } else {
                         [newArray addObject:@{}];

--- a/Parse/Internal/FieldOperation/PFFieldOperation.m
+++ b/Parse/Internal/FieldOperation/PFFieldOperation.m
@@ -238,7 +238,7 @@
     self = [super init];
     if (!self) return nil;
 
-    _objects = [[NSSet setWithArray:array] allObjects];
+    _objects = [NSSet setWithArray:array].allObjects;
 
     return self;
 }
@@ -294,7 +294,7 @@
                 if (index == NSNotFound) {
                     [newValue addObject:objectToAdd];
                 } else {
-                    [newValue replaceObjectAtIndex:index withObject:objectToAdd];
+                    newValue[index] = objectToAdd;
                 }
             } else if (![newValue containsObject:objectToAdd]) {
                 [newValue addObject:objectToAdd];
@@ -372,7 +372,7 @@
                     return ([obj isKindOfClass:[PFObject class]] &&
                             [[obj objectId] isEqualToString:[objectToRemove objectId]]);
                 }];
-                if ([indexes count] != 0) {
+                if (indexes.count != 0) {
                     [newValue removeObjectsAtIndexes:indexes];
                 }
             }
@@ -405,7 +405,7 @@
 + (instancetype)addRelationToObjects:(NSArray *)targets {
     PFRelationOperation *op = [[self alloc] init];
     if (targets.count > 0) {
-        op.targetClass = [[targets firstObject] parseClassName];
+        op.targetClass = [targets.firstObject parseClassName];
     }
 
     for (PFObject *target in targets) {

--- a/Parse/Internal/File/Controller/PFFileController.m
+++ b/Parse/Internal/File/Controller/PFFileController.m
@@ -260,7 +260,7 @@ static NSString *const PFFileControllerCacheDirectoryName_ = @"PFFileCache";
         return nil;
     }
 
-    NSString *filename = [fileState.secureURLString lastPathComponent];
+    NSString *filename = fileState.secureURLString.lastPathComponent;
     NSString *path = [self.cacheFilesDirectoryPath stringByAppendingPathComponent:filename];
     return path;
 }
@@ -272,8 +272,7 @@ static NSString *const PFFileControllerCacheDirectoryName_ = @"PFFileCache";
 }
 
 - (BFTask *)clearFileCacheAsync {
-    NSString *path = [self cacheFilesDirectoryPath];
-    return [PFFileManager removeDirectoryContentsAsyncAtPath:path];
+    return [PFFileManager removeDirectoryContentsAsyncAtPath:self.cacheFilesDirectoryPath];
 }
 
 @end

--- a/Parse/Internal/File/Controller/PFFileStagingController.m
+++ b/Parse/Internal/File/Controller/PFFileStagingController.m
@@ -60,7 +60,7 @@ static NSString *const PFFileStagingControllerDirectoryName_ = @"PFFileStaging";
 
 - (BFTask *)stageFileAsyncAtPath:(NSString *)filePath name:(NSString *)name uniqueId:(uint64_t)uniqueId {
     return [_taskQueue enqueue:^id(BFTask *task) {
-        return [[PFFileManager createDirectoryIfNeededAsyncAtPath:[self stagedFilesDirectoryPath]] continueWithBlock:^id(BFTask *task) {
+        return [[PFFileManager createDirectoryIfNeededAsyncAtPath:self.stagedFilesDirectoryPath] continueWithBlock:^id(BFTask *task) {
             NSString *destinationPath = [self stagedFilePathForFileWithName:name uniqueId:uniqueId];
             return [[PFFileManager copyItemAsyncAtPath:filePath toPath:destinationPath] continueWithSuccessResult:destinationPath];
         }];
@@ -69,7 +69,7 @@ static NSString *const PFFileStagingControllerDirectoryName_ = @"PFFileStaging";
 
 - (BFTask *)stageFileAsyncWithData:(NSData *)fileData name:(NSString *)name uniqueId:(uint64_t)uniqueId {
     return [_taskQueue enqueue:^id(BFTask *task) {
-        return [[PFFileManager createDirectoryIfNeededAsyncAtPath:[self stagedFilesDirectoryPath]] continueWithBlock:^id(BFTask *task) {
+        return [[PFFileManager createDirectoryIfNeededAsyncAtPath:self.stagedFilesDirectoryPath] continueWithBlock:^id(BFTask *task) {
             NSString *destinationPath = [self stagedFilePathForFileWithName:name uniqueId:uniqueId];
             return [[PFFileManager writeDataAsync:fileData toFile:destinationPath] continueWithSuccessResult:destinationPath];
         }];
@@ -78,7 +78,7 @@ static NSString *const PFFileStagingControllerDirectoryName_ = @"PFFileStaging";
 
 - (NSString *)stagedFilePathForFileWithName:(NSString *)name uniqueId:(uint64_t)uniqueId {
     NSString *fileName = [NSString stringWithFormat:@"%llX_%@", uniqueId, name];
-    return [[self stagedFilesDirectoryPath] stringByAppendingPathComponent:fileName];
+    return [self.stagedFilesDirectoryPath stringByAppendingPathComponent:fileName];
 }
 
 ///--------------------------------------
@@ -87,7 +87,7 @@ static NSString *const PFFileStagingControllerDirectoryName_ = @"PFFileStaging";
 
 - (BFTask *)_clearStagedFilesAsync {
     return [_taskQueue enqueue:^id(BFTask *task) {
-        NSString *stagedFilesDirectoryPath = [self stagedFilesDirectoryPath];
+        NSString *stagedFilesDirectoryPath = self.stagedFilesDirectoryPath;
         return [PFFileManager removeItemAtPathAsync:stagedFilesDirectoryPath withFileLock:NO];
     }];
 }

--- a/Parse/Internal/File/FileDataStream/PFFileDataStream.m
+++ b/Parse/Internal/File/FileDataStream/PFFileDataStream.m
@@ -72,7 +72,7 @@
 }
 
 - (void)open {
-    _fd = open([_path UTF8String], O_RDONLY | O_NONBLOCK);
+    _fd = open(_path.UTF8String, O_RDONLY | O_NONBLOCK);
     [_inputStream open];
 }
 

--- a/Parse/Internal/File/State/PFFileState.m
+++ b/Parse/Internal/File/State/PFFileState.m
@@ -79,15 +79,15 @@ static NSString *const _PFFileStateSecureDomain = @"files.parsetfss.com";
         return self.urlString;
     }
 
-    NSString *scheme = [components scheme];
+    NSString *scheme = components.scheme;
     if (![scheme isEqualToString:@"http"]) {
         return self.urlString;
     }
 
-    if ([[components host] isEqualToString:_PFFileStateSecureDomain]) {
+    if ([components.host isEqualToString:_PFFileStateSecureDomain]) {
         components.scheme = @"https";
     }
-    _secureURLString = [[components URL] absoluteString];
+    _secureURLString = components.URL.absoluteString;
     return _secureURLString;
 }
 

--- a/Parse/Internal/HTTPRequest/PFHTTPURLRequestConstructor.m
+++ b/Parse/Internal/HTTPRequest/PFHTTPURLRequestConstructor.m
@@ -41,9 +41,9 @@ static NSString *const PFHTTPURLRequestContentTypeJSON = @"application/json; cha
         [request setValue:PFHTTPURLRequestContentTypeJSON forHTTPHeaderField:PFHTTPRequestHeaderNameContentType];
 
         NSError *error = nil;
-        [request setHTTPBody:[NSJSONSerialization dataWithJSONObject:parameters
-                                                             options:(NSJSONWritingOptions)0
-                                                               error:&error]];
+        request.HTTPBody = [NSJSONSerialization dataWithJSONObject:parameters
+                                                           options:(NSJSONWritingOptions)0
+                                                             error:&error];
         PFConsistencyAssert(error == nil, @"Failed to serialize JSON with error = %@", error);
     }
     return request;

--- a/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.m
+++ b/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.m
@@ -107,7 +107,7 @@ NSString *const PFCurrentInstallationPinName = @"_currentInstallation";
             PFInstallation *installation = task.result;
             //TODO: (nlutsenko) Make it not terrible aka actually use task chaining here.
             NSString *installationId = [[self.installationIdentifierStore getInstallationIdentifierAsync] waitForResult:nil];
-            installationId = [installationId  lowercaseString];
+            installationId = installationId.lowercaseString;
             if (!installation || ![installationId isEqualToString:installation.installationId]) {
                 // If there's no installation object, or the object's installation
                 // ID doesn't match this device's installation ID, create a new
@@ -210,9 +210,9 @@ NSString *const PFCurrentInstallationPinName = @"_currentInstallation";
 
         return [[query findObjectsInBackground] continueWithSuccessBlock:^id(BFTask *task) {
             NSArray *results = task.result;
-            if ([results count] == 1) {
-                return [BFTask taskWithResult:[results firstObject]];
-            } else if ([results count] != 0) {
+            if (results.count == 1) {
+                return [BFTask taskWithResult:results.firstObject];
+            } else if (results.count != 0) {
                 return [[PFObject unpinAllObjectsInBackgroundWithName:PFCurrentInstallationPinName]
                         continueWithSuccessResult:nil];
             }

--- a/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.m
+++ b/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.m
@@ -104,7 +104,7 @@ static NSString *const PFInstallationIdentifierFileName = @"installationId";
                     return installationId;
                 }
             }
-            installationId = [[[NSUUID UUID] UUIDString] lowercaseString];
+            installationId = [NSUUID UUID].UUIDString.lowercaseString;
             return [[group setDataAsync:[installationId dataUsingEncoding:NSUTF8StringEncoding]
                                 forKey:PFInstallationIdentifierFileName] continueWithSuccessResult:installationId];
         }] continueWithBlock:^id(BFTask PF_GENERIC(NSString *)*task) {

--- a/Parse/Internal/KeyValueCache/PFKeyValueCache.m
+++ b/Parse/Internal/KeyValueCache/PFKeyValueCache.m
@@ -120,8 +120,8 @@ static NSString *const PFKeyValueCacheDiskCachePathKey = @"path";
 }
 
 - (void)setObject:(NSString *)value forKey:(NSString *)key {
-    NSUInteger keyBytes = [key maximumLengthOfBytesUsingEncoding:[key fastestEncoding]];
-    NSUInteger valueBytes = [value maximumLengthOfBytesUsingEncoding:[value fastestEncoding]];
+    NSUInteger keyBytes = [key maximumLengthOfBytesUsingEncoding:key.fastestEncoding];
+    NSUInteger valueBytes = [value maximumLengthOfBytesUsingEncoding:value.fastestEncoding];
 
     if ((keyBytes + valueBytes) < self.maxMemoryCacheBytesPerRecord) {
         [self.memoryCache setObject:[PFKeyValueCacheEntry cacheEntryWithValue:value] forKey:key];
@@ -217,7 +217,7 @@ static NSString *const PFKeyValueCacheDiskCachePathKey = @"path";
 ///--------------------------------------
 
 - (NSString *)_diskCacheEntryForURL:(NSURL *)url {
-    NSData *bytes = [self.fileManager contentsAtPath:[url path]];
+    NSData *bytes = [self.fileManager contentsAtPath:url.path];
     if (!bytes) {
         return nil;
     }
@@ -227,7 +227,7 @@ static NSString *const PFKeyValueCacheDiskCachePathKey = @"path";
 }
 
 - (void)_createDiskCacheEntry:(NSString *)value atURL:(NSURL *)url {
-    NSString *path = [url path];
+    NSString *path = url.path;
     NSData *bytes = [value dataUsingEncoding:NSUTF8StringEncoding];
     NSDate *creationDate = [NSDate date];
 
@@ -256,8 +256,8 @@ static NSString *const PFKeyValueCacheDiskCachePathKey = @"path";
     }
 
     NSDate *modificationDate = [self _modificationDateOfCacheEntryAtURL:_cacheDirectoryURL];
-    NSTimeInterval knownInterval = [_lastDiskCacheModDate timeIntervalSinceReferenceDate];
-    NSTimeInterval actualInterval = [modificationDate timeIntervalSinceReferenceDate];
+    NSTimeInterval knownInterval = _lastDiskCacheModDate.timeIntervalSinceReferenceDate;
+    NSTimeInterval actualInterval = modificationDate.timeIntervalSinceReferenceDate;
 
     // NOTE: Most file systems (HFS) can only store up to 1 second of precision, whereas NSDate is super high resolution
     // Yes, this is actually really bad to have hard coded, as this does give some window where we can get unwanted
@@ -280,7 +280,7 @@ static NSString *const PFKeyValueCacheDiskCachePathKey = @"path";
     _lastDiskCacheSize = 0;
     _lastDiskCacheAttributes = [[NSMutableArray alloc] init];
 
-    NSDirectoryEnumerator *enumerator = [self.fileManager enumeratorAtPath:[_cacheDirectoryURL path]];
+    NSDirectoryEnumerator *enumerator = [self.fileManager enumeratorAtPath:_cacheDirectoryURL.path];
     NSString *path = nil;
 
     while ((path = [enumerator nextObject]) != nil) {
@@ -322,12 +322,12 @@ static NSString *const PFKeyValueCacheDiskCachePathKey = @"path";
     }
 
     while (_lastDiskCacheAttributes.count > _maxDiskCacheRecords || _lastDiskCacheSize > _maxDiskCacheBytes) {
-        NSDictionary *attributes = [_lastDiskCacheAttributes firstObject];
+        NSDictionary *attributes = _lastDiskCacheAttributes.firstObject;
         NSString *toRemove = attributes[PFKeyValueCacheDiskCachePathKey];
         NSNumber *fileSize = attributes[NSFileSize];
 
         [self.fileManager removeItemAtURL:[self _cacheURLForKey:toRemove] error:NULL];
-        _lastDiskCacheSize -= [fileSize unsignedIntegerValue];
+        _lastDiskCacheSize -= fileSize.unsignedIntegerValue;
 
         [_lastDiskCacheAttributes removeObjectAtIndex:0];
     }

--- a/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
+++ b/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
@@ -109,10 +109,10 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
     if ([key rangeOfString:@"."].location != NSNotFound) {
         NSArray *parts = [key componentsSeparatedByString:@"."];
 
-        NSString *firstKey = [parts firstObject];
+        NSString *firstKey = parts.firstObject;
         NSString *rest = nil;
-        if ([parts count] > 1) {
-            NSRange range = NSMakeRange(1, [parts count] - 1);
+        if (parts.count > 1) {
+            NSRange range = NSMakeRange(1, parts.count - 1);
             rest = [[parts subarrayWithRange:range] componentsJoinedByString:@"."];
         }
         id value = [self valueForContainer:container key:firstKey depth:depth + 1];
@@ -387,7 +387,7 @@ greaterThanOrEqualTo:(id)constraint {
     }
     PFGeoPoint *point1 = constraint;
     PFGeoPoint *point2 = value;
-    return [point1 distanceInRadiansTo:point2] <= [maxDistance doubleValue];
+    return [point1 distanceInRadiansTo:point2] <= maxDistance.doubleValue;
 }
 
 /**
@@ -689,10 +689,10 @@ greaterThanOrEqualTo:(id)constraint {
     // Descend into the container and try again
     NSArray *parts = [include componentsSeparatedByString:@"."];
 
-    NSString *key = [parts firstObject];
+    NSString *key = parts.firstObject;
     NSString *rest = nil;
-    if ([parts count] > 1) {
-        NSRange range = NSMakeRange(1, [parts count] - 1);
+    if (parts.count > 1) {
+        NSRange range = NSMakeRange(1, parts.count - 1);
         rest = [[parts subarrayWithRange:range] componentsJoinedByString:@"."];
     }
 
@@ -727,11 +727,11 @@ greaterThanOrEqualTo:(id)constraint {
         return YES;
     }
 
-    PFACL *acl = [object ACL];
+    PFACL *acl = object.ACL;
     if (acl == nil) {
         return YES;
     }
-    if ([acl getPublicReadAccess]) {
+    if (acl.publicReadAccess) {
         return YES;
     }
     if (user != nil && [acl getReadAccessForUser:user]) {
@@ -747,11 +747,11 @@ greaterThanOrEqualTo:(id)constraint {
         return YES;
     }
 
-    PFACL *acl = [object ACL];
+    PFACL *acl = object.ACL;
     if (acl == nil) {
         return YES;
     }
-    if ([acl getPublicWriteAccess]) {
+    if (acl.publicWriteAccess) {
         return YES;
     }
     if (user != nil && [acl getWriteAccessForUser:user]) {

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -154,8 +154,8 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
         }] forKey:object];
         uuidTask = [self.objectToUUIDMap objectForKey:object];
     }
-    NSString *className = [object parseClassName];
-    NSString *objectId = [object objectId];
+    NSString *className = object.parseClassName;
+    NSString *objectId = object.objectId;
 
     // If this gets set, then it will contain data from offline store that need to be merged
     // into existing object in memory
@@ -266,7 +266,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
             return object;
         }];
 
-        NSArray *objectValues = [offlineObjects allValues];
+        NSArray *objectValues = offlineObjects.allValues;
         return [[BFTask taskForCompletionOfAllTasks:objectValues] continueWithSuccessBlock:^id(BFTask *task) {
             PFDecoder *decoder = [PFOfflineDecoder decoderWithOfflineObjects:offlineObjects];
             [object mergeFromRESTDictionary:parsedJson withDecoder:decoder];
@@ -369,7 +369,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
 - (BFTask *)saveObjectLocallyAsync:(PFObject *)object
                                key:(NSString *)key
                           database:(PFSQLiteDatabase *)database {
-    if ([object objectId] != nil && !object.dataAvailable &&
+    if (object.objectId != nil && !object.dataAvailable &&
         ![object _hasChanges] && ![object _hasOutstandingOperations]) {
         return [BFTask taskWithResult:nil];
     }
@@ -390,8 +390,8 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
         return [encoder encodeFinished];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         // Time to actually save the object
-        NSString *className = [object parseClassName];
-        NSString *objectId = [object objectId];
+        NSString *className = object.parseClassName;
+        NSString *objectId = object.objectId;
         NSString *encodedString = [PFJSONSerialization stringFromJSONObject:encoded];
         NSString *updateFields = nil;
         NSArray *queryParams = nil;
@@ -837,7 +837,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
 
 - (BFTask *)getOrCreateUUIDAsyncForObject:(PFObject *)object
                                  database:(PFSQLiteDatabase *)database {
-    NSString *newUUID = [[NSUUID UUID] UUIDString];
+    NSString *newUUID = [NSUUID UUID].UUIDString;
     BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
 
     @synchronized (self.lock) {
@@ -863,7 +863,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
     NSString *query = [NSString stringWithFormat:@"INSERT INTO %@(%@, %@) VALUES(?, ?);",
                        PFOfflineStoreTableOfObjects, PFOfflineStoreKeyOfUUID, PFOfflineStoreKeyOfClassName];
     [[database executeSQLAsync:query
-          withArgumentsInArray:@[ newUUID, [object parseClassName]]] continueWithSuccessBlock:^id(BFTask *task) {
+          withArgumentsInArray:@[ newUUID, object.parseClassName] ] continueWithSuccessBlock:^id(BFTask *task) {
         [tcs setResult:newUUID];
         return nil;
     }];

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.m
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.m
@@ -119,7 +119,7 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
         [[PFMultiProcessFileLockController sharedController] beginLockedContentAccessForFileAtPath:self.databasePath];
 
         sqlite3 *db;
-        int resultCode = sqlite3_open([self.databasePath UTF8String], &db);
+        int resultCode = sqlite3_open(self.databasePath.UTF8String, &db);
         if (resultCode != SQLITE_OK) {
             return [BFTask taskWithError:[self _errorWithErrorCode:resultCode]];
         }
@@ -183,7 +183,7 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
     PFSQLiteStatement *statement = enableCaching ? [self _cachedStatementForQuery:sql] : nil;
     if (!statement) {
         sqlite3_stmt *sqliteStatement = nil;
-        resultCode = sqlite3_prepare_v2(self.database, [sql UTF8String], -1, &sqliteStatement, 0);
+        resultCode = sqlite3_prepare_v2(self.database, sql.UTF8String, -1, &sqliteStatement, 0);
         if (resultCode != SQLITE_OK) {
             sqlite3_finalize(sqliteStatement);
             return [BFTask taskWithError:[self _errorWithErrorCode:resultCode]];
@@ -198,8 +198,8 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
     }
 
     // Make parameter
-    int queryCount = sqlite3_bind_parameter_count([statement sqliteStatement]);
-    int argumentCount = (int)[args count];
+    int queryCount = sqlite3_bind_parameter_count(statement.sqliteStatement);
+    int argumentCount = (int)args.count;
     if (queryCount != argumentCount) {
         if (!enableCaching) {
             [statement close];
@@ -272,7 +272,7 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
  */
 - (void)_bindObject:(id)obj toColumn:(int)idx inStatement:(PFSQLiteStatement *)statement {
     if ((!obj) || ((NSNull *)obj == [NSNull null])) {
-        sqlite3_bind_null([statement sqliteStatement], idx);
+        sqlite3_bind_null(statement.sqliteStatement, idx);
     } else if ([obj isKindOfClass:[NSData class]]) {
         const void *bytes = [obj bytes];
         if (!bytes) {
@@ -280,17 +280,17 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
             // Don't pass a NULL pointer, or sqlite will bind a SQL null instead of a blob.
             bytes = "";
         }
-        sqlite3_bind_blob([statement sqliteStatement], idx, bytes, (int)[obj length], SQLITE_TRANSIENT);
+        sqlite3_bind_blob(statement.sqliteStatement, idx, bytes, (int)[obj length], SQLITE_TRANSIENT);
     } else if ([obj isKindOfClass:[NSDate class]]) {
-        sqlite3_bind_double([statement sqliteStatement], idx, [obj timeIntervalSince1970]);
+        sqlite3_bind_double(statement.sqliteStatement, idx, [obj timeIntervalSince1970]);
     } else if ([obj isKindOfClass:[NSNumber class]]) {
         if (CFNumberIsFloatType((__bridge CFNumberRef)obj)) {
-            sqlite3_bind_double([statement sqliteStatement], idx, [obj doubleValue]);
+            sqlite3_bind_double(statement.sqliteStatement, idx, [obj doubleValue]);
         } else {
-            sqlite3_bind_int64([statement sqliteStatement], idx, [obj longLongValue]);
+            sqlite3_bind_int64(statement.sqliteStatement, idx, [obj longLongValue]);
         }
     } else {
-        sqlite3_bind_text([statement sqliteStatement], idx, [[obj description] UTF8String], -1, SQLITE_TRANSIENT);
+        sqlite3_bind_text(statement.sqliteStatement, idx, [obj description].UTF8String, -1, SQLITE_TRANSIENT);
     }
 }
 
@@ -299,7 +299,7 @@ int const PFSQLiteDatabaseDatabaseAlreadyClosed = 4;
 ///--------------------------------------
 
 - (void)_clearCachedStatements {
-    for (PFSQLiteStatement *statement in [_cachedStatements allValues]) {
+    for (PFSQLiteStatement *statement in _cachedStatements.allValues) {
         [statement close];
     }
 

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.m
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.m
@@ -165,9 +165,9 @@
 }
 
 - (int)columnIndexForName:(NSString *)columnName {
-    NSNumber *index = self.columnNameToIndexMap[[columnName lowercaseString]];
+    NSNumber *index = self.columnNameToIndexMap[columnName.lowercaseString];
     if (index) {
-        return [index intValue];
+        return index.intValue;
     }
     // not found
     return -1;
@@ -176,11 +176,11 @@
 - (NSDictionary *)columnNameToIndexMap {
     if (!_columnNameToIndexMap) {
         PFThreadsafetySafeDispatchSync(_databaseQueue, ^{
-            int columnCount = sqlite3_column_count([self.statement sqliteStatement]);
+            int columnCount = sqlite3_column_count(self.statement.sqliteStatement);
             NSMutableDictionary *mutableColumnNameToIndexMap = [[NSMutableDictionary alloc] initWithCapacity:columnCount];
             for (int i = 0; i < columnCount; ++i) {
-                NSString *key = [NSString stringWithUTF8String:sqlite3_column_name([self.statement sqliteStatement], i)];
-                mutableColumnNameToIndexMap[[key lowercaseString]] = @(i);
+                NSString *key = [NSString stringWithUTF8String:sqlite3_column_name(self.statement.sqliteStatement, i)];
+                mutableColumnNameToIndexMap[key.lowercaseString] = @(i);
             }
             _columnNameToIndexMap = mutableColumnNameToIndexMap;
         });

--- a/Parse/Internal/MultiProcessLock/PFMultiProcessFileLock.m
+++ b/Parse/Internal/MultiProcessLock/PFMultiProcessFileLock.m
@@ -41,9 +41,8 @@ static const NSTimeInterval PFMultiProcessLockAttemptsDelay = 0.001;
     _filePath = [path copy];
     _lockFilePath = [path stringByAppendingPathExtension:@"pflock"];
 
-    NSString *queueName = [NSString stringWithFormat:@"com.parse.multiprocess.%@",
-                           [[path lastPathComponent] stringByDeletingPathExtension]];
-    _synchronizationQueue = dispatch_queue_create([queueName UTF8String], DISPATCH_QUEUE_SERIAL);
+    NSString *queueName = [NSString stringWithFormat:@"com.parse.multiprocess.%@", path.lastPathComponent.stringByDeletingPathExtension];
+    _synchronizationQueue = dispatch_queue_create(queueName.UTF8String, DISPATCH_QUEUE_SERIAL);
 
     return self;
 }
@@ -94,7 +93,7 @@ static const NSTimeInterval PFMultiProcessLockAttemptsDelay = 0.001;
 ///--------------------------------------
 
 - (BOOL)_tryLock {
-    const char *filePath = [self.lockFilePath fileSystemRepresentation];
+    const char *filePath = self.lockFilePath.fileSystemRepresentation;
 
     // Atomically create a lock file if it doesn't exist and acquire the lock.
     _fileDescriptor = open(filePath, (O_RDWR | O_CREAT | O_EXLOCK),

--- a/Parse/Internal/Object/BatchController/PFObjectBatchController.m
+++ b/Parse/Internal/Object/BatchController/PFObjectBatchController.m
@@ -126,7 +126,7 @@
             BFTask *task = [[commandRunner runCommandAsync:command
                                                withOptions:PFCommandRunningOptionRetryIfFailed] continueWithSuccessBlock:^id(BFTask *task) {
                 PFCommandResult *result = task.result;
-                return [self _processDeleteResultsAsync:[result result] forObjects:batch];
+                return [self _processDeleteResultsAsync:result.result forObjects:batch];
             }];
             [tasks addObject:task];
         }
@@ -192,7 +192,7 @@
         return objects;
     }
 
-    NSMutableSet *set = [NSMutableSet setWithCapacity:[objects count]];
+    NSMutableSet *set = [NSMutableSet setWithCapacity:objects.count];
     NSString *className = [objects.firstObject parseClassName];
     for (PFObject *object in objects) {
         @synchronized (object.lock) {
@@ -209,7 +209,7 @@
             [set addObject:object];
         }
     }
-    return [set allObjects];
+    return set.allObjects;
 }
 
 + (NSArray *)uniqueObjectsArrayFromArray:(NSArray *)objects usingFilter:(BOOL (^)(PFObject *object))filter {
@@ -229,7 +229,7 @@
             uniqueObjects[objectIdentifier] = object;
         }
     }
-    return [uniqueObjects allValues];
+    return uniqueObjects.allValues;
 }
 
 @end

--- a/Parse/Internal/Object/Coder/File/PFObjectFileCodingLogic.m
+++ b/Parse/Internal/Object/Coder/File/PFObjectFileCodingLogic.m
@@ -45,8 +45,8 @@
     NSDictionary *newPointers = dictionary[@"pointers"];
     NSMutableDictionary *pointersDictionary = [NSMutableDictionary dictionaryWithCapacity:newPointers.count];
     [newPointers enumerateKeysAndObjectsUsingBlock:^(id key, NSArray *pointerArray, BOOL *stop) {
-        PFObject *pointer = [PFObject objectWithoutDataWithClassName:[pointerArray firstObject]
-                                                            objectId:[pointerArray lastObject]];
+        PFObject *pointer = [PFObject objectWithoutDataWithClassName:pointerArray.firstObject
+                                                            objectId:pointerArray.lastObject];
         pointersDictionary[key] = pointer;
     }];
 

--- a/Parse/Internal/Object/EstimatedData/PFObjectEstimatedData.m
+++ b/Parse/Internal/Object/EstimatedData/PFObjectEstimatedData.m
@@ -68,7 +68,7 @@
 }
 
 - (NSArray *)allKeys {
-    return [_dataDictionary allKeys];
+    return _dataDictionary.allKeys;
 }
 
 - (NSDictionary *)dictionaryRepresentation {

--- a/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
+++ b/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
@@ -121,13 +121,13 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
  * Returns Yes if localId has the right basic format for a local id.
  */
 + (BOOL)isLocalId:(NSString *)localId {
-    if ([localId length] != 22U) {
+    if (localId.length != 22U) {
         return NO;
     }
     if (![localId hasPrefix:@"local_"]) {
         return NO;
     }
-    for (int i = 6; i < [localId length]; ++i) {
+    for (int i = 6; i < localId.length; ++i) {
         if (!ishexnumber([localId characterAtIndex:i])) {
             return NO;
         }
@@ -239,7 +239,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
             entry.objectId = objectId;
             [self putMapEntry:entry forLocalId:localId];
         }
-        [_inMemoryCache setObject:objectId forKey:localId];
+        _inMemoryCache[localId] = objectId;
     }
 }
 
@@ -266,7 +266,7 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
     @synchronized (_lock) {
         [self clearInMemoryCache];
 
-        BOOL empty = ([[[[NSFileManager defaultManager] enumeratorAtPath:_diskPath] allObjects] count] == 0);
+        BOOL empty = ([[NSFileManager defaultManager] enumeratorAtPath:_diskPath].allObjects.count == 0);
 
         [[NSFileManager defaultManager] removeItemAtPath:_diskPath error:nil];
 

--- a/Parse/Internal/Object/OperationSet/PFOperationSet.h
+++ b/Parse/Internal/Object/OperationSet/PFOperationSet.h
@@ -55,9 +55,10 @@
 /// @name Accessors
 ///--------------------------------------
 
+@property (nonatomic, assign, readonly) NSUInteger count;
+
 - (id)objectForKey:(id)aKey;
 - (id)objectForKeyedSubscript:(id)aKey;
-- (NSUInteger)count;
 - (NSEnumerator *)keyEnumerator;
 
 - (void)enumerateKeysAndObjectsUsingBlock:(void (^)(NSString *key, PFFieldOperation *operation, BOOL *stop))block;

--- a/Parse/Internal/Object/OperationSet/PFOperationSet.m
+++ b/Parse/Internal/Object/OperationSet/PFOperationSet.m
@@ -34,7 +34,7 @@ static NSString *const PFOperationSetKeyACL = @"ACL";
 ///--------------------------------------
 
 - (instancetype)init {
-    return [self initWithUUID:[[NSUUID UUID] UUIDString]];
+    return [self initWithUUID:[NSUUID UUID].UUIDString];
 }
 
 - (instancetype)initWithUUID:(NSString *)uuid {
@@ -102,7 +102,7 @@ static NSString *const PFOperationSetKeyACL = @"ACL";
 
     NSNumber *saveEventuallyFlag = mutableData[PFOperationSetKeyIsSaveEventually];
     if (saveEventuallyFlag) {
-        operationSet.saveEventually = [saveEventuallyFlag boolValue];
+        operationSet.saveEventually = saveEventuallyFlag.boolValue;
         [mutableData removeObjectForKey:PFOperationSetKeyIsSaveEventually];
     }
 
@@ -141,7 +141,7 @@ static NSString *const PFOperationSetKeyACL = @"ACL";
 }
 
 - (NSUInteger)count {
-    return [self.dictionary count];
+    return self.dictionary.count;
 }
 
 - (NSEnumerator *)keyEnumerator {

--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassInfo.m
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassInfo.m
@@ -145,7 +145,7 @@ static objc_property_t getAccessorMutatorPair(Class klass, SEL sel, SEL outPair[
         }
 
         NSString *objcTypes = ([NSString stringWithFormat:(isSetter ? @"v@:%@" : @"%@@:"), typeEncoding]);
-        result = [NSMethodSignature signatureWithObjCTypes:[objcTypes UTF8String]];
+        result = [NSMethodSignature signatureWithObjCTypes:objcTypes.UTF8String];
 
         _knownMethodSignatures[selectorString] = result;
     });

--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
@@ -175,8 +175,8 @@ static PFObjectSubclassingController *defaultController_;
     PFConsistencyAssert(invocation.methodSignature.numberOfArguments == 2, @"Getter should take no arguments!");
     PFConsistencyAssert(invocation.methodSignature.methodReturnType[0] != 'v', @"A getter cannot return void!");
 
-    const char *methodReturnType = [invocation.methodSignature methodReturnType];
-    void *returnValueBytes = alloca([invocation.methodSignature methodReturnLength]);
+    const char *methodReturnType = invocation.methodSignature.methodReturnType;
+    void *returnValueBytes = alloca(invocation.methodSignature.methodReturnLength);
 
     if (propertyInfo.ivar) {
         object_getIvarValue_safe(object, propertyInfo.ivar, returnValueBytes, propertyInfo.associationType);

--- a/Parse/Internal/PFApplication.m
+++ b/Parse/Internal/PFApplication.m
@@ -43,7 +43,7 @@
 }
 
 - (BOOL)isExtensionEnvironment {
-    return [[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"];
+    return [[NSBundle mainBundle].bundlePath hasSuffix:@".appex"];
 }
 
 - (NSInteger)iconBadgeNumber {

--- a/Parse/Internal/PFBaseState.m
+++ b/Parse/Internal/PFBaseState.m
@@ -261,7 +261,7 @@
 }
 
 - (id)debugQuickLookObject {
-    return [[self dictionaryRepresentation] description];
+    return [self dictionaryRepresentation].description;
 }
 
 @end

--- a/Parse/Internal/PFCommandCache.m
+++ b/Parse/Internal/PFCommandCache.m
@@ -56,7 +56,7 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
                                             coreDataSource:(id<PFObjectLocalIdStoreProvider>)coreDataSource
                                            cacheFolderPath:(NSString *)cacheFolderPath {
     NSString *diskCachePath = [cacheFolderPath stringByAppendingPathComponent:_PFCommandCacheDiskCacheDirectoryName];
-    diskCachePath = [diskCachePath stringByStandardizingPath];
+    diskCachePath = diskCachePath.stringByStandardizingPath;
     PFCommandCache *cache = [[PFCommandCache alloc] initWithDataSource:dataSource
                                                         coreDataSource:coreDataSource
                                                       maxAttemptsCount:PFEventuallyQueueDefaultMaxAttemptsCount
@@ -96,7 +96,7 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
     [super removeAllCommands];
 
     NSArray *commandIdentifiers = [self _pendingCommandIdentifiers];
-    NSMutableArray *tasks = [NSMutableArray arrayWithCapacity:[commandIdentifiers count]];
+    NSMutableArray *tasks = [NSMutableArray arrayWithCapacity:commandIdentifiers.count];
 
     for (NSString *identifier in commandIdentifiers) {
         BFTask *task = [self _removeFileForCommandWithIdentifier:identifier];
@@ -127,7 +127,7 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
             PFCommandCachePrefixString,
             (unsigned long long)[NSDate timeIntervalSinceReferenceDate],
             _fileCounter++,
-            [[NSUUID UUID] UUIDString]];
+            [NSUUID UUID].UUIDString];
 }
 
 - (NSArray *)_pendingCommandIdentifiers {
@@ -151,7 +151,7 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
 
     if (innerError || !jsonData) {
         NSString *message = [NSString stringWithFormat:@"Failed to read command from cache. %@",
-                             innerError ? [innerError localizedDescription] : @""];
+                             innerError ? innerError.localizedDescription : @""];
         innerError = [PFErrorUtilities errorWithCode:kPFErrorInternalServer
                                              message:message];
         if (error) {
@@ -165,7 +165,7 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
                                                       error:&innerError];
     if (innerError) {
         NSString *message = [NSString stringWithFormat:@"Failed to deserialiaze command from cache. %@",
-                             [innerError localizedDescription]];
+                             innerError.localizedDescription];
         innerError = [PFErrorUtilities errorWithCode:kPFErrorInternalServer
                                              message:message];
     } else {
@@ -234,10 +234,10 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
 
         NSString *identifier = nil;
         while ((identifier = [enumerator nextObject])) {
-            NSNumber *fileSize = [enumerator fileAttributes][NSFileSize];
+            NSNumber *fileSize = enumerator.fileAttributes[NSFileSize];
             if (fileSize) {
                 commandSizes[identifier] = fileSize;
-                size += [fileSize unsignedIntegerValue];
+                size += fileSize.unsignedIntegerValue;
             }
         }
 
@@ -245,7 +245,7 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
 
         if (size > self.diskCacheSize) {
             // Get identifiers and sort them to remove oldest commands first
-            NSArray *identifiers = [[commandSizes allKeys] sortedArrayUsingSelector:@selector(compare:)];
+            NSArray *identifiers = [commandSizes.allKeys sortedArrayUsingSelector:@selector(compare:)];
             for (NSString *identifier in identifiers) @autoreleasepool {
                 [self _removeFileForCommandWithIdentifier:identifier];
                 size -= [commandSizes[identifier] unsignedIntegerValue];
@@ -284,7 +284,7 @@ static unsigned long long const PFCommandCacheDefaultDiskCacheSize = 10 * 1024 *
         NSData *data = [NSJSONSerialization dataWithJSONObject:[command dictionaryRepresentation]
                                                        options:0
                                                          error:&error];
-        NSUInteger commandSize = [data length];
+        NSUInteger commandSize = data.length;
         if (commandSize > self.diskCacheSize) {
             error = [PFErrorUtilities errorWithCode:kPFErrorInternalServer
                                             message:@"Failed to run command, because it's too big."];

--- a/Parse/Internal/PFDateFormatter.m
+++ b/Parse/Internal/PFDateFormatter.m
@@ -71,7 +71,7 @@
 
 - (NSString *)preciseStringFromDate:(NSDate *)date {
     __block NSString *string = nil;
-    NSTimeInterval interval = [date timeIntervalSince1970];
+    NSTimeInterval interval = date.timeIntervalSince1970;
     dispatch_sync(_synchronizationQueue, ^{
         sqlite3_bind_double(_dateToStringStatement, 1, interval);
 
@@ -93,7 +93,7 @@
     __block sqlite3_int64 interval = 0;
     __block double seconds = 0.0;
     dispatch_sync(_synchronizationQueue, ^{
-        const char *utf8String = [string UTF8String];
+        const char *utf8String = string.UTF8String;
 
         sqlite3_bind_text(_stringToDateStatement, 1, utf8String, -1, SQLITE_STATIC);
         sqlite3_bind_text(_stringToDateStatement, 2, utf8String, -1, SQLITE_STATIC);

--- a/Parse/Internal/PFDecoder.m
+++ b/Parse/Internal/PFDecoder.m
@@ -95,7 +95,7 @@
         }
     }
 
-    NSMutableDictionary *newDictionary = [NSMutableDictionary dictionaryWithCapacity:[dictionary count]];
+    NSMutableDictionary *newDictionary = [NSMutableDictionary dictionaryWithCapacity:dictionary.count];
     [dictionary enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         newDictionary[key] = [self decodeObject:obj];
     }];

--- a/Parse/Internal/PFDevice.m
+++ b/Parse/Internal/PFDevice.m
@@ -24,7 +24,7 @@
 #include <dirent.h>
 
 static NSString *PFDeviceSysctlByName(NSString *name) {
-    const char *charName = [name UTF8String];
+    const char *charName = name.UTF8String;
     NSString *string = nil;
     size_t size = 0;
     char *answer = NULL;

--- a/Parse/Internal/PFEventuallyPin.m
+++ b/Parse/Internal/PFEventuallyPin.m
@@ -87,7 +87,7 @@ static NSString *const PFEventuallyPinKeyCommand = @"command";
 ///--------------------------------------
 
 + (BFTask *)pinEventually:(PFObject *)object forCommand:(id<PFNetworkCommand>)command {
-    return [self pinEventually:object forCommand:command withUUID:[[NSUUID UUID] UUIDString]];
+    return [self pinEventually:object forCommand:command withUUID:[NSUUID UUID].UUIDString];
 }
 
 + (BFTask *)pinEventually:(PFObject *)object forCommand:(id<PFNetworkCommand>)command withUUID:(NSString *)uuid {
@@ -172,8 +172,8 @@ static NSString *const PFEventuallyPinKeyCommand = @"command";
 
 + (PFEventuallyPinType)_pinTypeForCommand:(id<PFNetworkCommand>)command {
     PFEventuallyPinType type = PFEventuallyPinTypeCommand;
-    NSString *path = [(PFRESTCommand *)command httpPath];
-    NSString *method = [(PFRESTCommand *)command httpMethod];
+    NSString *path = ((PFRESTCommand *)command).httpPath;
+    NSString *method = ((PFRESTCommand *)command).httpMethod;
     if ([path hasPrefix:@"classes"]) {
         if ([method isEqualToString:PFHTTPRequestMethodPOST] ||
             [method isEqualToString:PFHTTPRequestMethodPUT]) {

--- a/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Internal/PFEventuallyQueue.m
@@ -63,19 +63,17 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
     // Set up all the queues
     NSString *queueBaseLabel = [NSString stringWithFormat:@"com.parse.%@", NSStringFromClass([self class])];
 
-    _synchronizationQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@.synchronization",
-                                                    queueBaseLabel] UTF8String],
+    _synchronizationQueue = dispatch_queue_create([NSString stringWithFormat:@"%@.synchronization", queueBaseLabel].UTF8String,
                                                   DISPATCH_QUEUE_SERIAL);
     PFMarkDispatchQueue(_synchronizationQueue);
     _synchronizationExecutor = [BFExecutor executorWithDispatchQueue:_synchronizationQueue];
 
-    _processingQueue = dispatch_queue_create([[NSString stringWithFormat:@"%@.processing",
-                                               queueBaseLabel] UTF8String],
+    _processingQueue = dispatch_queue_create([NSString stringWithFormat:@"%@.processing", queueBaseLabel].UTF8String,
                                              DISPATCH_QUEUE_SERIAL);
     PFMarkDispatchQueue(_processingQueue);
 
     _processingQueueSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_DATA_ADD, 0, 0, _processingQueue);
-
+    
     _commandEnqueueTaskQueue = [[PFTaskQueue alloc] init];
 
     _taskCompletionSources = [NSMutableDictionary dictionary];
@@ -174,7 +172,7 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
 }
 
 - (NSUInteger)commandCount {
-    return [[self _pendingCommandIdentifiers] count];
+    return [self _pendingCommandIdentifiers].count;
 }
 
 ///--------------------------------------
@@ -266,8 +264,8 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
 
         if (error) {
             BOOL permanent = (![error.userInfo[@"temporary"] boolValue] &&
-                              ([[error domain] isEqualToString:PFParseErrorDomain] ||
-                               [error code] != kPFErrorConnectionFailed));
+                              ([error.domain isEqualToString:PFParseErrorDomain] ||
+                               error.code != kPFErrorConnectionFailed));
 
             if (!permanent) {
                 PFLogWarning(PFLoggingTagCommon,
@@ -443,7 +441,7 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
 
 /** Test helper to return how many commands are being retained in memory by the cache. */
 - (int)_commandsInMemory {
-    return (int)[_taskCompletionSources count];
+    return (int)_taskCompletionSources.count;
 }
 
 /** Called by PFObject whenever an object has been updated after a saveEventually. */

--- a/Parse/Internal/PFFileManager.m
+++ b/Parse/Internal/PFFileManager.m
@@ -142,11 +142,11 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
         return contents;
     }] continueWithSuccessBlock:^id(BFTask *task) {
         NSArray *contents = task.result;
-        if ([contents count] == 0) {
+        if (contents.count == 0) {
             return nil;
         }
 
-        NSMutableArray *tasks = [NSMutableArray arrayWithCapacity:[contents count]];
+        NSMutableArray *tasks = [NSMutableArray arrayWithCapacity:contents.count];
         for (NSString *path in contents) {
             BFTask *task = [BFTask taskFromExecutor:[BFExecutor defaultPriorityBackgroundExecutor] withBlock:^id{
                 NSError *error = nil;
@@ -254,7 +254,7 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
     NSString *directoryPath = nil;
     if (self.applicationGroupIdentifier) {
         NSURL *containerPath = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:self.applicationGroupIdentifier];
-        directoryPath = [[containerPath path] stringByAppendingPathComponent:_PFFileManagerParseDirectoryName];
+        directoryPath = [containerPath.path stringByAppendingPathComponent:_PFFileManagerParseDirectoryName];
         directoryPath = [directoryPath stringByAppendingPathComponent:self.applicationIdentifier];
     } else {
         return [self parseLocalSandboxDataDirectoryPath];
@@ -296,7 +296,7 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
 
 - (NSString *)parseCacheItemPathForPathComponent:(NSString *)component {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString *folderPath = [paths firstObject];
+    NSString *folderPath = paths.firstObject;
     folderPath = [folderPath stringByAppendingPathComponent:_PFFileManagerParseDirectoryName];
 #if !TARGET_OS_IPHONE
     // We append the applicationId in case the OS X application isn't sandboxed,
@@ -304,7 +304,7 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
     folderPath = [folderPath stringByAppendingPathComponent:self.applicationIdentifier];
 #endif
     folderPath = [folderPath stringByAppendingPathComponent:component];
-    return [folderPath stringByStandardizingPath];
+    return folderPath.stringByStandardizingPath;
 }
 
 ///--------------------------------------

--- a/Parse/Internal/PFInternalUtils.m
+++ b/Parse/Internal/PFInternalUtils.m
@@ -97,38 +97,38 @@ static NSString *parseServer_;
 ///--------------------------------------
 
 + (NSNumber *)addNumber:(NSNumber *)first withNumber:(NSNumber *)second {
-    const char *objcType = [first objCType];
+    const char *objcType = first.objCType;
 
     if (strcmp(objcType, @encode(BOOL)) == 0) {
-        return @([first boolValue] + [second boolValue]);
+        return @(first.boolValue + second.boolValue);
     } else if (strcmp(objcType, @encode(char)) == 0) {
-        return @([first charValue] + [second charValue]);
+        return @(first.charValue + second.charValue);
     } else if (strcmp(objcType, @encode(double)) == 0) {
-        return @([first doubleValue] + [second doubleValue]);
+        return @(first.doubleValue + second.doubleValue);
     } else if (strcmp(objcType, @encode(float)) == 0) {
-        return @([first floatValue] + [second floatValue]);
+        return @(first.floatValue + second.floatValue);
     } else if (strcmp(objcType, @encode(int)) == 0) {
-        return @([first intValue] + [second intValue]);
+        return @(first.intValue + second.intValue);
     } else if (strcmp(objcType, @encode(long)) == 0) {
-        return @([first longValue] + [second longValue]);
+        return @(first.longValue + second.longValue);
     } else if (strcmp(objcType, @encode(long long)) == 0) {
-        return @([first longLongValue] + [second longLongValue]);
+        return @(first.longLongValue + second.longLongValue);
     } else if (strcmp(objcType, @encode(short)) == 0) {
-        return @([first shortValue] + [second shortValue]);
+        return @(first.shortValue + second.shortValue);
     } else if (strcmp(objcType, @encode(unsigned char)) == 0) {
-        return @([first unsignedCharValue] + [second unsignedCharValue]);
+        return @(first.unsignedCharValue + second.unsignedCharValue);
     } else if (strcmp(objcType, @encode(unsigned int)) == 0) {
-        return @([first unsignedIntValue] + [second unsignedIntValue]);
+        return @(first.unsignedIntValue + second.unsignedIntValue);
     } else if (strcmp(objcType, @encode(unsigned long)) == 0) {
-        return @([first unsignedLongValue] + [second unsignedLongValue]);
+        return @(first.unsignedLongValue + second.unsignedLongValue);
     } else if (strcmp(objcType, @encode(unsigned long long)) == 0) {
-        return @([first unsignedLongLongValue] + [second unsignedLongLongValue]);
+        return @(first.unsignedLongLongValue + second.unsignedLongLongValue);
     } else if (strcmp(objcType, @encode(unsigned short)) == 0) {
-        return @([first unsignedShortValue] + [second unsignedShortValue]);
+        return @(first.unsignedShortValue + second.unsignedShortValue);
     }
 
     // Fall back to int?
-    return @([first intValue] + [second intValue]);
+    return @(first.intValue + second.intValue);
 }
 
 ///--------------------------------------
@@ -165,7 +165,7 @@ static NSString *parseServer_;
 + (void)appendDictionary:(NSDictionary *)dictionary toString:(NSMutableString *)string {
     [string appendString:@"{"];
 
-    NSArray *keys = [[dictionary allKeys] sortedArrayUsingSelector:@selector(compare:)];
+    NSArray *keys = [dictionary.allKeys sortedArrayUsingSelector:@selector(compare:)];
     for (NSString *key in keys) {
         [string appendFormat:@"%@:", key];
 
@@ -188,7 +188,7 @@ static NSString *parseServer_;
 }
 
 + (void)appendNumber:(NSNumber *)number toString:(NSMutableString *)string {
-    [string appendFormat:@"%@", [number stringValue]];
+    [string appendFormat:@"%@", number.stringValue];
 }
 
 + (void)appendNullToString:(NSMutableString *)string {
@@ -238,15 +238,15 @@ static NSString *parseServer_;
 }
 
 + (NSArray *)arrayBySplittingArray:(NSArray *)array withMaximumComponentsPerSegment:(NSUInteger)components {
-    if ([array count] <= components) {
+    if (array.count <= components) {
         return @[ array ];
     }
 
     NSMutableArray *splitArray = [NSMutableArray array];
     NSInteger index = 0;
 
-    while (index < [array count]) {
-        NSInteger length = MIN([array count] - index, components);
+    while (index < array.count) {
+        NSInteger length = MIN(array.count - index, components);
 
         NSArray *subarray = [array subarrayWithRange:NSMakeRange(index, length)];
         [splitArray addObject:subarray];

--- a/Parse/Internal/PFKeychainStore.m
+++ b/Parse/Internal/PFKeychainStore.m
@@ -33,7 +33,7 @@ NSString *const PFKeychainStoreDefaultService = @"com.parse.sdk";
 
 + (NSDictionary *)_keychainQueryTemplateForService:(NSString *)service {
     NSMutableDictionary *query = [NSMutableDictionary dictionary];
-    if ([service length]) {
+    if (service.length) {
         query[(__bridge NSString *)kSecAttrService] = service;
     }
     query[(__bridge NSString *)kSecClass] = (__bridge id)kSecClassGenericPassword;
@@ -64,7 +64,7 @@ NSString *const PFKeychainStoreDefaultService = @"com.parse.sdk";
     _keychainQueryTemplate = [[self class] _keychainQueryTemplateForService:service];
 
     NSString *queueLabel = [NSString stringWithFormat:@"com.parse.keychain.%@", service];
-    _synchronizationQueue = dispatch_queue_create([queueLabel UTF8String], DISPATCH_QUEUE_CONCURRENT);
+    _synchronizationQueue = dispatch_queue_create(queueLabel.UTF8String, DISPATCH_QUEUE_CONCURRENT);
     PFMarkDispatchQueue(_synchronizationQueue);
 
     return self;

--- a/Parse/Internal/PFLocationManager.m
+++ b/Parse/Internal/PFLocationManager.m
@@ -41,7 +41,7 @@
     dispatch_block_t block = ^{
         manager = [[CLLocationManager alloc] init];
     };
-    if ([[NSThread currentThread] isMainThread]) {
+    if ([NSThread currentThread].isMainThread) {
         block();
     } else {
         dispatch_sync(dispatch_get_main_queue(), block);
@@ -133,7 +133,7 @@
 ///--------------------------------------
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
-    CLLocation *location = [locations lastObject];
+    CLLocation *location = locations.lastObject;
 
     [manager stopUpdatingLocation];
 

--- a/Parse/Internal/PFPinningEventuallyQueue.m
+++ b/Parse/Internal/PFPinningEventuallyQueue.m
@@ -139,7 +139,7 @@
 ///--------------------------------------
 
 - (NSString *)_newIdentifierForCommand:(id<PFNetworkCommand>)command {
-    return [[NSUUID UUID] UUIDString];
+    return [NSUUID UUID].UUIDString;
 }
 
 - (NSArray *)_pendingCommandIdentifiers {

--- a/Parse/Internal/PFReachability.m
+++ b/Parse/Internal/PFReachability.m
@@ -191,7 +191,7 @@ static void _reachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReac
 
 - (void)_startMonitoringReachabilityWithURL:(NSURL *)url {
     dispatch_barrier_async(_synchronizationQueue, ^{
-        _networkReachability = SCNetworkReachabilityCreateWithName(NULL, [[url host] UTF8String]);
+        _networkReachability = SCNetworkReachabilityCreateWithName(NULL, url.host.UTF8String);
         if (_networkReachability != NULL) {
             // Set the initial flags
             SCNetworkReachabilityFlags flags;

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -221,7 +221,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
     __block PFKeychainStore *store = nil;
     dispatch_sync(_keychainStoreAccessQueue, ^{
         if (!_keychainStore) {
-            NSString *bundleIdentifier = (self.configuration.containingApplicationBundleIdentifier ?: [[NSBundle mainBundle] bundleIdentifier]);
+            NSString *bundleIdentifier = (self.configuration.containingApplicationBundleIdentifier ?: [NSBundle mainBundle].bundleIdentifier);
             NSString *service = [NSString stringWithFormat:@"%@.%@", bundleIdentifier, PFKeychainStoreDefaultService];
             _keychainStore = [[PFKeychainStore alloc] initWithService:service];
         }
@@ -459,7 +459,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
     NSString *localSandboxDataPath = [self.fileManager parseLocalSandboxDataDirectoryPath];
     NSString *dataPath = [self.fileManager parseDefaultDataDirectoryPath];
     NSArray *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:localSandboxDataPath error:nil];
-    if ([contents count] != 0) {
+    if (contents.count != 0) {
         // If moving files fails - just log the error, but don't fail.
         NSError *error = nil;
         [[PFFileManager moveContentsOfDirectoryAsyncAtPath:localSandboxDataPath

--- a/Parse/Internal/ParseModule.h
+++ b/Parse/Internal/ParseModule.h
@@ -17,10 +17,11 @@
 
 @interface ParseModuleCollection : NSObject <ParseModule>
 
+@property (nonatomic, assign, readonly) NSUInteger modulesCount;
+
 - (void)addParseModule:(id<ParseModule>)module;
 - (void)removeParseModule:(id<ParseModule>)module;
 
 - (BOOL)containsModule:(id<ParseModule>)module;
-- (NSUInteger)modulesCount;
 
 @end

--- a/Parse/Internal/ParseModule.m
+++ b/Parse/Internal/ParseModule.m
@@ -73,7 +73,7 @@ typedef void (^ParseModuleEnumerationBlock)(id<ParseModule> module, BOOL *stop, 
 }
 
 - (NSUInteger)modulesCount {
-    return [self.modules count];
+    return self.modules.count;
 }
 
 ///--------------------------------------

--- a/Parse/Internal/Persistence/PFPersistenceController.m
+++ b/Parse/Internal/Persistence/PFPersistenceController.m
@@ -111,7 +111,7 @@ static NSString *const PFUserDefaultsPersistenceParseKey = @"com.parse";
 #else
     if (self.applicationGroupIdentifier) {
         NSURL *containerPath = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:self.applicationGroupIdentifier];
-        directoryPath = [[containerPath path] stringByAppendingPathComponent:PFFilePersistenceParseDirectoryName];
+        directoryPath = [containerPath.path stringByAppendingPathComponent:PFFilePersistenceParseDirectoryName];
         directoryPath = [directoryPath stringByAppendingPathComponent:self.applicationIdentifier];
     } else {
         NSString *library = [NSHomeDirectory() stringByAppendingPathComponent:@"Library"];

--- a/Parse/Internal/PropertyInfo/PFPropertyInfo.m
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo.m
@@ -56,10 +56,10 @@ static inline NSString *stringByCapitalizingFirstCharacter(NSString *string) {
     _name = [propertyName copy];
     _associationType = associationType;
 
-    objc_property_t objcProperty = class_getProperty(kls, [_name UTF8String]);
+    objc_property_t objcProperty = class_getProperty(kls, _name.UTF8String);
 
     do {
-        _ivar = class_getInstanceVariable(kls, [safeStringWithPropertyAttributeValue(objcProperty, "V") UTF8String]);
+        _ivar = class_getInstanceVariable(kls, safeStringWithPropertyAttributeValue(objcProperty, "V").UTF8String);
         if (_ivar) break;
 
         // Walk the superclass heirarchy for the property definition. Because property attributes are not inherited
@@ -68,10 +68,10 @@ static inline NSString *stringByCapitalizingFirstCharacter(NSString *string) {
         // with different iVars, we take the class furthest from the root class as the 'source of truth'.
         Class superClass = class_getSuperclass(kls);
         while (superClass) {
-            objc_property_t superProperty = class_getProperty(superClass, [_name UTF8String]);
+            objc_property_t superProperty = class_getProperty(superClass, _name.UTF8String);
             if (!superProperty) break;
 
-            _ivar = class_getInstanceVariable(superClass, [safeStringWithPropertyAttributeValue(superProperty, "V") UTF8String]);
+            _ivar = class_getInstanceVariable(superClass, safeStringWithPropertyAttributeValue(superProperty, "V").UTF8String);
             if (_ivar) break;
 
             superClass = class_getSuperclass(superClass);
@@ -80,10 +80,10 @@ static inline NSString *stringByCapitalizingFirstCharacter(NSString *string) {
         if (_ivar) break;
 
         // Attempt to infer the variable name.
-        _ivar = class_getInstanceVariable(kls, [[@"_" stringByAppendingString:_name] UTF8String]);
+        _ivar = class_getInstanceVariable(kls, [@"_" stringByAppendingString:_name].UTF8String);
         if (_ivar) break;
 
-        _ivar = class_getInstanceVariable(kls, [_name UTF8String]);
+        _ivar = class_getInstanceVariable(kls, _name.UTF8String);
     } while (0);
 
     _typeEncoding = safeStringWithPropertyAttributeValue(objcProperty, "T");
@@ -174,8 +174,8 @@ static inline NSString *stringByCapitalizingFirstCharacter(NSString *string) {
         NSMethodSignature *methodSignature = [one methodSignatureForSelector:self.getterSelector];
         invocation = [NSInvocation invocationWithMethodSignature:methodSignature];
 
-        [invocation setTarget:one];
-        [invocation setSelector:self.getterSelector];
+        invocation.target = one;
+        invocation.selector = self.getterSelector;
     }
 
     [invocation invoke];

--- a/Parse/Internal/Purchase/Controller/PFPurchaseController.m
+++ b/Parse/Internal/Purchase/Controller/PFPurchaseController.m
@@ -135,7 +135,7 @@
                            withProgressBlock:(PFProgressBlock)progressBlock
                                 sessionToken:(NSString *)sessionToken {
     NSString *productIdentifier = transaction.payment.productIdentifier;
-    NSURL *appStoreReceiptURL = [self.bundle appStoreReceiptURL];
+    NSURL *appStoreReceiptURL = self.bundle.appStoreReceiptURL;
     if (!productIdentifier || !appStoreReceiptURL) {
         return [BFTask taskWithError:[NSError errorWithDomain:PFParseErrorDomain
                                                          code:kPFErrorReceiptMissing
@@ -177,7 +177,7 @@
 
         NSString *finalFilePath = [self assetContentPathForProductWithIdentifier:transaction.payment.productIdentifier
                                                                         fileName:file.name];
-        NSString *directoryPath = [finalFilePath stringByDeletingLastPathComponent];
+        NSString *directoryPath = finalFilePath.stringByDeletingLastPathComponent;
         return [[[[[PFFileManager createDirectoryIfNeededAsyncAtPath:directoryPath] continueWithBlock:^id(BFTask *task) {
             if (task.faulted) {
                 return [BFTask taskWithError:[NSError errorWithDomain:PFParseErrorDomain

--- a/Parse/Internal/Push/State/PFPushState.m
+++ b/Parse/Internal/Push/State/PFPushState.m
@@ -47,7 +47,7 @@
 
 - (void)setPushDate:(NSDate *)pushDate {
     if (self.pushDate != pushDate) {
-        NSTimeInterval interval = [pushDate timeIntervalSinceNow];
+        NSTimeInterval interval = pushDate.timeIntervalSinceNow;
         PFParameterAssert(interval > 0, @"Can't set the scheduled push time in the past.");
         PFParameterAssert(interval <= 60 * 24 * 14, @"Can't set the schedule push time more than two weeks from now.");
         _pushDate = pushDate;

--- a/Parse/Internal/Push/Utilites/PFPushUtilities.m
+++ b/Parse/Internal/Push/Utilites/PFPushUtilities.m
@@ -71,8 +71,8 @@
     SystemSoundID soundId = -1;
 
     if (audioFileName) {
-        NSURL *bundlePath = [[NSBundle mainBundle] URLForResource:[audioFileName stringByDeletingPathExtension]
-                                                    withExtension:[audioFileName pathExtension]];
+        NSURL *bundlePath = [[NSBundle mainBundle] URLForResource:audioFileName.stringByDeletingPathExtension
+                                                    withExtension:audioFileName.pathExtension];
 
         AudioServicesCreateSystemSoundID((__bridge CFURLRef)bundlePath, &soundId);
     }

--- a/Parse/Internal/Query/Controller/PFCachedQueryController.m
+++ b/Parse/Internal/Query/Controller/PFCachedQueryController.m
@@ -199,7 +199,7 @@
 - (BFTask *)_saveCommandResultAsync:(PFCommandResult *)result forCommandCacheKey:(NSString *)cacheKey {
     NSString *resultString = result.resultString;
     if (resultString) {
-        [self.commonDataSource.keyValueCache setObject:resultString forKey:cacheKey];
+        self.commonDataSource.keyValueCache[cacheKey] = resultString;
     }
     // Roll-forward the original result.
     return [BFTask taskWithResult:result];

--- a/Parse/Internal/Query/Controller/PFQueryController.m
+++ b/Parse/Internal/Query/Controller/PFQueryController.m
@@ -91,11 +91,11 @@
             }
         }
 
-        NSString *traceLog = [result.result objectForKey:@"trace"];
+        NSString *traceLog = result.result[@"trace"];
         if (traceLog != nil) {
             NSLog(@"Pre-processing took %f seconds\n%@Client side parsing took %f seconds",
                   [querySent timeIntervalSinceDate:queryStart], traceLog,
-                  [queryReceived timeIntervalSinceNow]);
+                  queryReceived.timeIntervalSinceNow);
         }
 
         return foundObjects;

--- a/Parse/Internal/Query/Utilities/PFQueryUtilities.m
+++ b/Parse/Internal/Query/Utilities/PFQueryUtilities.m
@@ -169,7 +169,7 @@
                      // Remove negation from any subpredicates.
                      NSMutableArray *newSubpredicates =
                      [NSMutableArray arrayWithCapacity:compound.subpredicates.count];
-                     for (NSPredicate *subPredicate in [compound subpredicates]) {
+                     for (NSPredicate *subPredicate in compound.subpredicates) {
                          [newSubpredicates addObject:[self removeNegation:subPredicate]];
                      }
 
@@ -192,7 +192,7 @@
     return [self _mapPredicate:predicate
                  compoundBlock:nil
                comparisonBlock:^NSPredicate *(NSComparisonPredicate *predicate) {
-                   if ([predicate predicateOperatorType] == NSBetweenPredicateOperatorType) {
+                   if (predicate.predicateOperatorType == NSBetweenPredicateOperatorType) {
                        NSComparisonPredicate *between = (NSComparisonPredicate *)predicate;
                        NSExpression *rhs = between.rightExpression;
 
@@ -246,7 +246,7 @@
                        comparison.rightExpression.expressionType == NSKeyPathExpressionType) {
                        // This is a Yoda condition.
                        NSPredicateOperatorType newType;
-                       switch ([comparison predicateOperatorType]) {
+                       switch (comparison.predicateOperatorType) {
                            case NSEqualToPredicateOperatorType: {
                                newType = NSEqualToPredicateOperatorType;
                                break;

--- a/Parse/Internal/Relation/State/PFMutableRelationState.m
+++ b/Parse/Internal/Relation/State/PFMutableRelationState.m
@@ -54,8 +54,8 @@
     if (_parent != parent || ![self.parentClassName isEqualToString:parent.parseClassName] ||
         ![self.parentObjectId isEqualToString:parent.objectId]) {
         _parent = parent;
-        _parentClassName = [[parent parseClassName] copy];
-        _parentObjectId = [[parent objectId] copy];
+        _parentClassName = [parent.parseClassName copy];
+        _parentObjectId = [parent.objectId copy];
     }
 }
 

--- a/Parse/Internal/ThreadSafety/PFThreadsafety.m
+++ b/Parse/Internal/ThreadSafety/PFThreadsafety.m
@@ -13,7 +13,7 @@ static void *const PFThreadsafetyQueueIDKey = (void *)&PFThreadsafetyQueueIDKey;
 
 dispatch_queue_t PFThreadsafetyCreateQueueForObject(id object) {
     NSString *label = [NSStringFromClass([object class]) stringByAppendingString:@".synchronizationQueue"];
-    dispatch_queue_t queue = dispatch_queue_create([label UTF8String], DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_t queue = dispatch_queue_create(label.UTF8String, DISPATCH_QUEUE_SERIAL);
 
     void *uuid = calloc(1, sizeof(uuid));
     dispatch_queue_set_specific(queue, PFThreadsafetyQueueIDKey, uuid, free);

--- a/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.m
+++ b/Parse/Internal/User/AuthenticationProviders/Providers/Anonymous/PFAnonymousAuthenticationProvider.m
@@ -29,7 +29,7 @@ NSString *const PFAnonymousUserAuthenticationType = @"anonymous";
 
 - (NSDictionary *)authData {
     NSString *uuidString = [NSUUID UUID].UUIDString;
-    uuidString = [uuidString lowercaseString];
+    uuidString = uuidString.lowercaseString;
     return @{ @"id" : uuidString };
 }
 

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
@@ -223,9 +223,9 @@
         // Silence the warning if we are loading from LDS
         task = [[query findObjectsInBackground] continueWithSuccessBlock:^id(BFTask *task) {
             NSArray *results = task.result;
-            if ([results count] == 1) {
+            if (results.count == 1) {
                 return results.firstObject;
-            } else if ([results count] != 0) {
+            } else if (results.count != 0) {
                 return [[PFObject unpinAllObjectsInBackgroundWithName:PFUserCurrentUserPinName] continueWithSuccessResult:nil];
             }
 
@@ -308,7 +308,7 @@
             if (user.sessionToken) {
                 userData[PFUserSessionTokenRESTKey] = [user.sessionToken copy];
             }
-            if ([user.authData count]) {
+            if (user.authData.count) {
                 userData[PFUserAuthDataRESTKey] = [user.authData copy];
             }
         }

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -405,7 +405,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     }
 
     // TODO: (nlutsenko) Get rid of this once we allow localIds in batches.
-    NSArray *remaining = [uniqueObjects allObjects];
+    NSArray *remaining = uniqueObjects.allObjects;
     NSMutableArray *finished = [NSMutableArray array];
     while (remaining.count > 0) {
         // Partition the objects into two sets: those that can be save immediately,
@@ -988,7 +988,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                     PFConsistencyAssert(remoteOperationSet, @"'remoteOperationSet' should not be nil.");
                     NSUInteger index = [operationSetQueue indexOfObject:localOperationSet];
                     [remoteOperationSet mergeOperationSet:localOperationSet];
-                    [operationSetQueue replaceObjectAtIndex:index withObject:remoteOperationSet];
+                    operationSetQueue[index] = remoteOperationSet;
                 }
 
                 return;
@@ -1170,7 +1170,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 
         PFFieldOperation *oldOperation = [self unsavedChanges][key];
         PFFieldOperation *newOperation = [operation mergeWithPrevious:oldOperation];
-        [[self unsavedChanges] setObject:newOperation forKey:key];
+        [self unsavedChanges][key] = newOperation;
         [_availableKeys addObject:key];
     }
 }
@@ -1201,7 +1201,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
  */
 - (BOOL)_hasChanges {
     @synchronized (lock) {
-        return [[self unsavedChanges] count] > 0;
+        return [self unsavedChanges].count > 0;
     }
 }
 
@@ -1402,7 +1402,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                 [self startSave];
                 BFTask *childrenTask = [self _saveChildrenInBackgroundWithCurrentUser:currentUser
                                                                          sessionToken:sessionToken];
-                if (!dirty && ![changes count]) {
+                if (!dirty && changes.count != 0) {
                     return childrenTask;
                 }
                 return [[childrenTask continueWithSuccessBlock:^id(BFTask *task) {

--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -440,7 +440,7 @@ static BOOL revocableSessionEnabled_;
             } else {
                 // Otherwise, treat this as a fresh login, and switch the current user to the new user.
                 PFUser *newUser = [[self class] _objectFromDictionary:result.result
-                                                     defaultClassName:[self parseClassName]
+                                                     defaultClassName:self.parseClassName
                                                          completeData:YES];
                 @synchronized ([newUser lock]) {
                     [newUser startSave];
@@ -530,7 +530,7 @@ static BOOL revocableSessionEnabled_;
                             }
 
                             @synchronized(self.lock) {
-                                [operationSetQueue replaceObjectAtIndex:0 withObject:selfOperations];
+                                operationSetQueue[0] = selfOperations;
                                 [self rebuildEstimatedData];
                             }
                         }

--- a/Tests/Other/NetworkMocking/PFMockURLProtocol.m
+++ b/Tests/Other/NetworkMocking/PFMockURLProtocol.m
@@ -72,7 +72,7 @@ static PFTestSwizzledMethod *_swizzledURLSessionMethod;
     }
     [_mocksArray addObject:mock];
 
-    if ([_mocksArray count] == 1) {
+    if (_mocksArray.count == 1) {
         [NSURLProtocol registerClass:self];
         Class cls = NSClassFromString(@"__NSCFURLSessionConfiguration") ?: [NSURLSessionConfiguration class];
         _swizzledURLSessionMethod = [PFTestSwizzlingUtilities swizzleMethod:@selector(protocolClasses)

--- a/Tests/Unit/ParseModuleUnitTests.m
+++ b/Tests/Unit/ParseModuleUnitTests.m
@@ -57,7 +57,7 @@
     // Run a single runloop tick to trigger the parse initializaiton.
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate distantPast]];
 
-    XCTAssertEqual([collection modulesCount], 0);
+    XCTAssertEqual(collection.modulesCount, 0);
 }
 
 - (void)testModuleRemove {
@@ -73,16 +73,16 @@
 
     XCTAssertTrue([collection containsModule:moduleB]);
     XCTAssertFalse([collection containsModule:moduleA]);
-    XCTAssertEqual([collection modulesCount], 1);
+    XCTAssertEqual(collection.modulesCount, 1);
 }
 
 - (void)testNilModule {
     ParseModuleCollection *collection = [[ParseModuleCollection alloc] init];
 
     XCTAssertNoThrow([collection addParseModule:nil]);
-    XCTAssertEqual([collection modulesCount], 0);
+    XCTAssertEqual(collection.modulesCount, 0);
     XCTAssertNoThrow([collection removeParseModule:nil]);
-    XCTAssertEqual([collection modulesCount], 0);
+    XCTAssertEqual(collection.modulesCount, 0);
 }
 
 @end


### PR DESCRIPTION
Convert the entire codebase to use dot-syntax for properties instead of method invocations.