### PR TITLE
Fixed potential issue with wrong result type set on pin/unpin methods of PFObject.

### DIFF
--- a/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
+++ b/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
@@ -12,6 +12,7 @@
 #import <Parse/PFConstants.h>
 
 #import "PFDataProvider.h"
+#import "PFMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -41,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return `BFTask` with `PFPin` result if pinning succeeds.
  */
-- (BFTask *)fetchPinAsyncWithName:(NSString *)name;
+- (BFTask PF_GENERIC(PFPin *)*)fetchPinAsyncWithName:(NSString *)name;
 
 /**
  Pins given objects to the pin. Creates new pin if the pin with such name is not found.
@@ -50,11 +51,11 @@ NS_ASSUME_NONNULL_BEGIN
  @param name            Pin Name.
  @param includeChildren Whether children of `objects` should be pinned as well.
 
- @return `BFTask` with `@YES` result.
+ @return `BFTask` with no result.
  */
-- (BFTask *)pinObjectsAsync:(nullable NSArray *)objects
-                withPinName:(NSString *)name
-            includeChildren:(BOOL)includeChildren;
+- (BFTask PF_GENERIC(PFVoid)*)pinObjectsAsync:(nullable NSArray *)objects
+                                  withPinName:(NSString *)name
+                              includeChildren:(BOOL)includeChildren;
 
 ///--------------------------------------
 /// @name Unpin
@@ -66,18 +67,18 @@ NS_ASSUME_NONNULL_BEGIN
  @param objects Objects to unpin.
  @param name    Pin name.
 
- @return `BFTask` with `@YES` result.
+ @return `BFTask` with no result.
  */
-- (BFTask *)unpinObjectsAsync:(nullable NSArray *)objects withPinName:(NSString *)name;
+- (BFTask PF_GENERIC(PFVoid)*)unpinObjectsAsync:(nullable NSArray *)objects withPinName:(NSString *)name;
 
 /**
  Unpins all objects from the pin.
 
  @param name Pin name.
 
- @return `BFTask` with `YES` result.
+ @return `BFTask` with no result.
  */
-- (BFTask *)unpinAllObjectsAsyncWithPinName:(NSString *)name;
+- (BFTask PF_GENERIC(PFVoid)*)unpinAllObjectsAsyncWithPinName:(NSString *)name;
 
 @end
 

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -2386,7 +2386,9 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 }
 
 + (BFTask PF_GENERIC(NSNumber *)*)_pinAllInBackground:(NSArray *)objects withName:(NSString *)name includeChildren:(BOOL)includeChildren {
-    return [[self pinningObjectStore] pinObjectsAsync:objects withPinName:name includeChildren:includeChildren];
+    return [[[self pinningObjectStore] pinObjectsAsync:objects
+                                           withPinName:name
+                                       includeChildren:includeChildren] continueWithSuccessResult:@YES];
 }
 
 ///--------------------------------------
@@ -2426,7 +2428,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 }
 
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllObjectsInBackgroundWithName:(NSString *)name {
-    return [[self pinningObjectStore] unpinAllObjectsAsyncWithPinName:name];
+    return [[[self pinningObjectStore] unpinAllObjectsAsyncWithPinName:name] continueWithSuccessResult:@YES];
 }
 
 + (BFTask *)unpinAllInBackground:(NSArray *)objects {
@@ -2438,7 +2440,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 }
 
 + (BFTask PF_GENERIC(NSNumber *)*)unpinAllInBackground:(NSArray *)objects withName:(NSString *)name {
-    return [[self pinningObjectStore] unpinObjectsAsync:objects withPinName:name];
+    return [[[self pinningObjectStore] unpinObjectsAsync:objects withPinName:name] continueWithSuccessResult:@YES];
 }
 
 + (void)unpinAllInBackground:(NSArray *)objects withName:(NSString *)name block:(PFBooleanResultBlock)block {

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -2342,7 +2342,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 #pragma mark - Pinning
 ///--------------------------------------
 
-- (BFTask *)pinInBackground {
+- (BFTask PF_GENERIC(NSNumber *)*)pinInBackground {
     return [self pinInBackgroundWithName:PFObjectDefaultPin];
 }
 
@@ -2354,11 +2354,11 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     [[self pinInBackgroundWithName:name] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
 
-- (BFTask *)pinInBackgroundWithName:(NSString *)name {
+- (BFTask PF_GENERIC(NSNumber *)*)pinInBackgroundWithName:(NSString *)name {
     return [self _pinInBackgroundWithName:name includeChildren:YES];
 }
 
-- (BFTask *)_pinInBackgroundWithName:(NSString *)name includeChildren:(BOOL)includeChildren {
+- (BFTask PF_GENERIC(NSNumber *)*)_pinInBackgroundWithName:(NSString *)name includeChildren:(BOOL)includeChildren {
     return [[self class] _pinAllInBackground:@[ self ] withName:name includeChildren:includeChildren];
 }
 
@@ -2366,7 +2366,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 #pragma mark - Pinning Many Objects
 ///--------------------------------------
 
-+ (BFTask *)pinAllInBackground:(NSArray *)objects {
++ (BFTask PF_GENERIC(NSNumber *)*)pinAllInBackground:(NSArray *)objects {
     return [self pinAllInBackground:objects withName:PFObjectDefaultPin];
 }
 
@@ -2375,7 +2375,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     [[self pinAllInBackground:objects] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
 
-+ (BFTask *)pinAllInBackground:(NSArray *)objects withName:(NSString *)name {
++ (BFTask PF_GENERIC(NSNumber *)*)pinAllInBackground:(NSArray *)objects withName:(NSString *)name {
     return [self _pinAllInBackground:objects withName:name includeChildren:YES];
 }
 
@@ -2385,9 +2385,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     [[self pinAllInBackground:objects withName:name] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
 
-+ (BFTask *)_pinAllInBackground:(NSArray *)objects
-                       withName:(NSString *)name
-                includeChildren:(BOOL)includeChildren {
++ (BFTask PF_GENERIC(NSNumber *)*)_pinAllInBackground:(NSArray *)objects withName:(NSString *)name includeChildren:(BOOL)includeChildren {
     return [[self pinningObjectStore] pinObjectsAsync:objects withPinName:name includeChildren:includeChildren];
 }
 
@@ -2395,7 +2393,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 #pragma mark - Unpinning
 ///--------------------------------------
 
-- (BFTask *)unpinInBackground {
+- (BFTask PF_GENERIC(NSNumber *)*)unpinInBackground {
     return [self unpinInBackgroundWithName:PFObjectDefaultPin];
 }
 
@@ -2403,7 +2401,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     [[self unpinInBackground] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
 
-- (BFTask *)unpinInBackgroundWithName:(NSString *)name {
+- (BFTask PF_GENERIC(NSNumber *)*)unpinInBackgroundWithName:(NSString *)name {
     return [[self class] unpinAllInBackground:@[ self ] withName:name];
 }
 
@@ -2415,7 +2413,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
 #pragma mark - Unpinning Many Objects
 ///--------------------------------------
 
-+ (BFTask *)unpinAllObjectsInBackground {
++ (BFTask PF_GENERIC(NSNumber *)*)unpinAllObjectsInBackground {
     return [self unpinAllObjectsInBackgroundWithName:PFObjectDefaultPin];
 }
 
@@ -2427,7 +2425,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     [[self unpinAllObjectsInBackgroundWithName:name] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
 
-+ (BFTask *)unpinAllObjectsInBackgroundWithName:(NSString *)name {
++ (BFTask PF_GENERIC(NSNumber *)*)unpinAllObjectsInBackgroundWithName:(NSString *)name {
     return [[self pinningObjectStore] unpinAllObjectsAsyncWithPinName:name];
 }
 
@@ -2439,7 +2437,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
     [[self unpinAllInBackground:objects] thenCallBackOnMainThreadWithBoolValueAsync:block];
 }
 
-+ (BFTask *)unpinAllInBackground:(NSArray *)objects withName:(NSString *)name {
++ (BFTask PF_GENERIC(NSNumber *)*)unpinAllInBackground:(NSArray *)objects withName:(NSString *)name {
     return [[self pinningObjectStore] unpinObjectsAsync:objects withPinName:name];
 }
 

--- a/Tests/Unit/PinningObjectStoreTests.m
+++ b/Tests/Unit/PinningObjectStoreTests.m
@@ -127,7 +127,7 @@
     PFObject *object = [PFObject objectWithClassName:@"Yarr"];
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[store pinObjectsAsync:@[ object ] withPinName:@"Yolo" includeChildren:YES] continueWithSuccessBlock:^id(BFTask *task) {
-        XCTAssertEqualObjects(task.result, @YES);
+        XCTAssertNil(task.result);
         XCTAssertEqualObjects(pin.objects, @[ object ]);
         [expectation fulfill];
         return nil;
@@ -155,7 +155,7 @@
     PFObject *object = [PFObject objectWithClassName:@"Yarr"];
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[store pinObjectsAsync:@[ object ] withPinName:@"Yolo" includeChildren:YES] continueWithSuccessBlock:^id(BFTask *task) {
-        XCTAssertEqualObjects(task.result, @YES);
+        XCTAssertNil(task.result);
         XCTAssertEqualObjects(pin.objects, (@[ existingObject, object ]));
         [expectation fulfill];
         return nil;
@@ -170,7 +170,7 @@
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[store pinObjectsAsync:nil withPinName:@"Yolo" includeChildren:YES] continueWithSuccessBlock:^id(BFTask *task) {
-        XCTAssertEqualObjects(task.result, @YES);
+        XCTAssertNil(task.result);
         [expectation fulfill];
         return nil;
     }];
@@ -195,7 +195,7 @@
     PFObject *object = [PFObject objectWithClassName:@"Yarr"];
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[store pinObjectsAsync:@[ object ] withPinName:@"Yolo" includeChildren:NO] continueWithSuccessBlock:^id(BFTask *task) {
-        XCTAssertEqualObjects(task.result, @YES);
+        XCTAssertNil(task.result);
         XCTAssertEqualObjects(pin.objects, (@[ object ]));
         [expectation fulfill];
         return nil;
@@ -221,7 +221,7 @@
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[store unpinObjectsAsync:@[ object ] withPinName:@"Yolo"] continueWithSuccessBlock:^id(BFTask *task) {
-        XCTAssertEqualObjects(task.result, @YES);
+        XCTAssertNil(task.result);
         [expectation fulfill];
         return nil;
     }];
@@ -246,7 +246,7 @@
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[store unpinObjectsAsync:@[ object ] withPinName:@"Yolo"] continueWithSuccessBlock:^id(BFTask *task) {
-        XCTAssertEqualObjects(task.result, @YES);
+        XCTAssertNil(task.result);
         [expectation fulfill];
         return nil;
     }];
@@ -260,7 +260,7 @@
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[store unpinObjectsAsync:nil withPinName:@"Yolo"] continueWithSuccessBlock:^id(BFTask *task) {
-        XCTAssertEqualObjects(task.result, @YES);
+        XCTAssertNil(task.result);
         [expectation fulfill];
         return nil;
     }];
@@ -278,7 +278,7 @@
     PFObject *object = [PFObject objectWithClassName:@"Yarr"];
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[store unpinObjectsAsync:@[ object ] withPinName:@"Yolo"] continueWithSuccessBlock:^id(BFTask *task) {
-        XCTAssertEqualObjects(task.result, @YES);
+        XCTAssertNil(task.result);
         [expectation fulfill];
         return nil;
     }];
@@ -300,7 +300,7 @@
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
     [[store unpinAllObjectsAsyncWithPinName:@"Yolo"] continueWithSuccessBlock:^id(BFTask *task) {
-        XCTAssertEqualObjects(task.result, @YES);
+        XCTAssertNil(task.result);
         [expectation fulfill];
         return nil;
     }];


### PR DESCRIPTION
Due to the fact that some of these methods might return earlier - there could be `nil` result set on `pin`/`unpin` result tasks. This fixes the issue by enforcing generic types across both `PFPinningObjectStore` and `PFObject` implementation.

Contributes to #604, #563 