### PR TITLE
Removes -[PFFile getData:] warning when data is cached/available

### DIFF
--- a/Parse/PFFile.m
+++ b/Parse/PFFile.m
@@ -536,7 +536,8 @@ static const unsigned long long PFFileMaxFileSize = 10 * 1024 * 1024; // 10 MB
 }
 
 - (NSData *)getData:(NSError **)error {
-    return [[self getDataInBackground] waitForResult:error];
+    BOOL enableWarning = !self.isDataAvailable;
+    return [[self getDataInBackground] waitForResult:error withMainThreadWarning:enableWarning];
 }
 
 - (NSInputStream *)getDataStream {
@@ -544,7 +545,8 @@ static const unsigned long long PFFileMaxFileSize = 10 * 1024 * 1024; // 10 MB
 }
 
 - (NSInputStream *)getDataStream:(NSError **)error {
-    return [[self getDataStreamInBackground] waitForResult:error];
+    BOOL enableWarning = !self.isDataAvailable;
+    return [[self getDataStreamInBackground] waitForResult:error withMainThreadWarning:enableWarning];
 }
 
 @end


### PR DESCRIPTION
Imagine the following scenario:

I have a `PFFile` as one of his `PFConfig` parameters. Whenever the config is fetched, runs the following code in the completion block:

```obj-c
PFFile *myFile = config[@"myFile"];
if (!myFile.isDataAvailable) {
      [myFile getDataInBackground];
}
```

As most of the time the file will not be changed, it's set to only get the file data (in background, of course) when it's not available in the cache. Somewhere else in the code, where I need the file, I call:

```obj-c
- (NSData *)myData {
      PFFile *myFile = config[@"myFile"];
      if (!myFile.isDataAvailable) {
            return someFallbackData;
      }
      return [PFFile getData];
}
```

In the above case, `getData` will only be called when the data is available locally. It means that PFFile will get from the cache, and there will be no need of downloading the file. Even this way, there is a warning being logged (`Warning: A long-running operation is being executed on the main thread`), because the standard implementation of `-[BFTask waitForResult:]` called automatically `-[BFTask waitForResult:withMainThreadWarning:YES]`.

To conclude: I added a check on get `-[PFFile getData:]` and `-[PFFile getDataStream:]` so it only enables warning if the file is not cached.

WDYT, @nlutsenko @richardjrossiii ?