### PR TITLE
Use dynamic framework version of Bolts.

### DIFF
--- a/Configurations/Parse-OSX.xcconfig
+++ b/Configurations/Parse-OSX.xcconfig
@@ -17,6 +17,4 @@ MACH_O_TYPE = mh_dylib
 DEFINES_MODULE = YES
 DYLIB_INSTALL_NAME_BASE = @rpath
 
-FRAMEWORK_SEARCH_PATHS = $(inherited) $(PROJECT_DIR)/Carthage/Checkouts/Bolts-iOS/build/osx/
-
 INFOPLIST_FILE = $(PROJECT_DIR)/Parse/Resources/Parse-OSX.Info.plist

--- a/Configurations/Parse-iOS.xcconfig
+++ b/Configurations/Parse-iOS.xcconfig
@@ -17,8 +17,6 @@ APPLICATION_EXTENSION_API_ONLY = YES
 MACH_O_TYPE = staticlib
 DEFINES_MODULE = YES
 
-FRAMEWORK_SEARCH_PATHS = $(inherited) $(PROJECT_DIR)/Carthage/Checkouts/Bolts-iOS/build/ios/
-
 INFOPLIST_FILE = $(PROJECT_DIR)/Parse/Resources/Parse-iOS.Info.plist
 
 OTHER_CFLAGS[sdk=iphoneos9.*] = $(inherited) -fembed-bitcode

--- a/Configurations/Parse-tvOS.xcconfig
+++ b/Configurations/Parse-tvOS.xcconfig
@@ -19,6 +19,4 @@ DEFINES_MODULE = YES
 
 OTHER_LDFLAGS = $(inherited) -ObjC
 
-FRAMEWORK_SEARCH_PATHS = $(inherited) $(PROJECT_DIR)/Carthage/Checkouts/Bolts-iOS/build/tvOS/
-
 INFOPLIST_FILE = $(PROJECT_DIR)/Parse/Resources/Parse-tvOS.Info.plist

--- a/Configurations/Parse-watchOS.xcconfig
+++ b/Configurations/Parse-watchOS.xcconfig
@@ -20,6 +20,4 @@ ENABLE_BITCODE = YES
 
 OTHER_LDFLAGS = $(inherited) -ObjC
 
-FRAMEWORK_SEARCH_PATHS = $(inherited) $(PROJECT_DIR)/Carthage/Checkouts/Bolts-iOS/build/watchOS/
-
 INFOPLIST_FILE = $(PROJECT_DIR)/Parse/Resources/Parse-watchOS.Info.plist

--- a/Configurations/ParseUnitTests-OSX.xcconfig
+++ b/Configurations/ParseUnitTests-OSX.xcconfig
@@ -15,9 +15,7 @@ PRODUCT_MODULE_NAME = ParseUnitTests
 PRODUCT_BUNDLE_IDENTIFIER = com.parse.unit.osx
 
 INFOPLIST_FILE = $(SRCROOT)/Tests/Resources/ParseUnitTests-OSX-Info.plist
-LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/../Frameworks
-
-FRAMEWORK_SEARCH_PATHS = $(inherited) $(BUILT_PRODUCTS_DIR) $(PROJECT_DIR)/Carthage/Checkouts/Bolts-iOS/build/osx
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/../Frameworks @executable_path/Frameworks @loader_path/Frameworks
 
 USER_HEADER_SEARCH_PATHS = $(inherited) $(PARSE_DIR)/Parse/Internal/**
 

--- a/Configurations/ParseUnitTests-iOS.xcconfig
+++ b/Configurations/ParseUnitTests-iOS.xcconfig
@@ -18,8 +18,6 @@ IPHONEOS_DEPLOYMENT_TARGET = 8.0
 
 INFOPLIST_FILE = $(SRCROOT)/Tests/Resources/ParseUnitTests-iOS-Info.plist
 
-FRAMEWORK_SEARCH_PATHS = $(inherited) $(BUILT_PRODUCTS_DIR) $(PROJECT_DIR)/Carthage/Checkouts/Bolts-iOS/build/ios
-
 USER_HEADER_SEARCH_PATHS = $(inherited) $(PARSE_DIR)/Parse/Internal/**
 
 // Swift

--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -341,6 +341,8 @@
 		810ECC7E1B573D28002944D4 /* PFTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 810ECC791B573D28002944D4 /* PFTestCase.m */; };
 		810ECC7F1B573D28002944D4 /* PFUnitTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 810ECC7C1B573D28002944D4 /* PFUnitTestCase.m */; };
 		810ECC801B573D28002944D4 /* PFUnitTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 810ECC7C1B573D28002944D4 /* PFUnitTestCase.m */; };
+		81101B411C34D1B800AA3734 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81EC57891C34D0C4002DF851 /* Bolts.framework */; };
+		81101B421C34D1D800AA3734 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81EC57891C34D0C4002DF851 /* Bolts.framework */; };
 		811083F21BA2580100FC7F65 /* PFUserAuthenticationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 811083F11BA2580100FC7F65 /* PFUserAuthenticationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		811083F31BA2580100FC7F65 /* PFUserAuthenticationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 811083F11BA2580100FC7F65 /* PFUserAuthenticationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		811214731B3E1CF10052741B /* PFObjectBatchController.h in Headers */ = {isa = PBXBuildFile; fileRef = 811214711B3E1CF10052741B /* PFObjectBatchController.h */; };
@@ -651,8 +653,6 @@
 		815619011A1F79AC0076504A /* PFDateFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 815618FE1A1F79AC0076504A /* PFDateFormatter.h */; };
 		815619021A1F79AC0076504A /* PFDateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 815618FF1A1F79AC0076504A /* PFDateFormatter.m */; };
 		815619031A1F79AC0076504A /* PFDateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 815618FF1A1F79AC0076504A /* PFDateFormatter.m */; };
-		815868E21AF9818D009A5751 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8103FA44198FC267000BAE3F /* Bolts.framework */; };
-		815868E71AF98731009A5751 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8103FA44198FC267000BAE3F /* Bolts.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		815960A11ABCA3B30069EBCC /* PFFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8159609F1ABCA3B30069EBCC /* PFFileManager.h */; };
 		815960A21ABCA3B30069EBCC /* PFFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8159609F1ABCA3B30069EBCC /* PFFileManager.h */; };
 		815960A31ABCA3B30069EBCC /* PFFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 815960A01ABCA3B30069EBCC /* PFFileManager.m */; };
@@ -1131,7 +1131,6 @@
 		816F44771A8E8933009CDB32 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 6393F38B15D3018400C4F78D /* libsqlite3.dylib */; };
 		816F44781A8E8933009CDB32 /* Accounts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63CA84EA1612660F002E09F8 /* Accounts.framework */; };
 		816F44791A8E8933009CDB32 /* Social.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63CBA36B1612829C0062C84A /* Social.framework */; };
-		816F447C1A8E8933009CDB32 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8103FA42198FC25B000BAE3F /* Bolts.framework */; };
 		8171E99F19AE091000EAE6C1 /* PFFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DEF07E199C42A300D86A21 /* PFFile.m */; };
 		8171E9BA19AE37F000EAE6C1 /* PFThreadsafety.h in Headers */ = {isa = PBXBuildFile; fileRef = 818D049919A3B84500BEE20F /* PFThreadsafety.h */; };
 		8171E9BB19AE37F500EAE6C1 /* PFThreadsafety.m in Sources */ = {isa = PBXBuildFile; fileRef = 818D049A19A3B84500BEE20F /* PFThreadsafety.m */; };
@@ -1274,7 +1273,6 @@
 		81BF4ABE1B0BF64B00A3D75B /* PFCurrentConfigController.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BF4ABB1B0BF64B00A3D75B /* PFCurrentConfigController.m */; };
 		81BF4ABF1B0BF64B00A3D75B /* PFCurrentConfigController.m in Sources */ = {isa = PBXBuildFile; fileRef = 81BF4ABB1B0BF64B00A3D75B /* PFCurrentConfigController.m */; };
 		81C09F891AF97EA70043B49C /* Parse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97010FAC1630B18F00AB761E /* Parse.framework */; };
-		81C09F8D1AF9816D0043B49C /* Bolts.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 8103FA44198FC267000BAE3F /* Bolts.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		81C1EE491AE1EF960031C438 /* PFWeakValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 81C1EE471AE1EF960031C438 /* PFWeakValue.h */; };
 		81C1EE4A1AE1EF960031C438 /* PFWeakValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C1EE481AE1EF960031C438 /* PFWeakValue.m */; };
 		81C1EE4B1AE1EFA10031C438 /* PFWeakValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C1EE481AE1EF960031C438 /* PFWeakValue.m */; };
@@ -1449,6 +1447,7 @@
 		81EBF3461B33E7DE00991947 /* PFPushChannelsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8124C8841B27588800758E00 /* PFPushChannelsController.m */; };
 		81EBF3471B33E7E500991947 /* PFPushState.m in Sources */ = {isa = PBXBuildFile; fileRef = 81CB7F8D1B1795C000DC601D /* PFPushState.m */; };
 		81EBF3481B33E7EB00991947 /* PFInstallation.m in Sources */ = {isa = PBXBuildFile; fileRef = 44B78E12157D21B000A5E97F /* PFInstallation.m */; };
+		81EC579D1C34D0D9002DF851 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81EC57871C34D0C4002DF851 /* Bolts.framework */; };
 		81EDD4D21B59A6EC002F69C0 /* PFCommandRunning.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EDD4D11B59A6EC002F69C0 /* PFCommandRunning.h */; };
 		81EDD4D31B59A6EC002F69C0 /* PFCommandRunning.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EDD4D11B59A6EC002F69C0 /* PFCommandRunning.h */; };
 		81EEE1B01B446D600087AC4D /* PFCurrentUserController.h in Headers */ = {isa = PBXBuildFile; fileRef = 81EEE1AE1B446D600087AC4D /* PFCurrentUserController.h */; };
@@ -1639,6 +1638,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		81101B321C34D1AC00AA3734 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8EDDA62817E17DDC00655F8A;
+			remoteInfo = "Bolts-OSX";
+		};
+		81101B431C34D28300AA3734 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 81E94D521C2B8BF200A6291E;
+			remoteInfo = "Bolts-tvOS-Dynamic";
+		};
+		81101B451C34D28B00AA3734 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 819573D91C2B8ECB00BFCA39;
+			remoteInfo = "Bolts-watchOS-Dynamic";
+		};
 		811167461B8402DA003CB026 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 09D33641139C54930098E916 /* Project object */;
@@ -1722,6 +1742,90 @@
 			proxyType = 1;
 			remoteGlobalIDString = 030EF0A714632FD000B04273;
 			remoteInfo = OCMock;
+		};
+		81EC57841C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 81ED94291BE147CF00795F05;
+			remoteInfo = "Bolts-iOS";
+		};
+		81EC57861C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 1D5D7DD31BE3CE8200FD67C7;
+			remoteInfo = "Bolts-iOS-Dynamic";
+		};
+		81EC57881C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 81ED946E1BE14B5200795F05;
+			remoteInfo = "Bolts-OSX";
+		};
+		81EC578A1C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F5AFCA021BA752750076E927;
+			remoteInfo = "Bolts-tvOS";
+		};
+		81EC578C1C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 81E94D6A1C2B8BF200A6291E;
+			remoteInfo = "Bolts-tvOS-Dynamic";
+		};
+		81EC578E1C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 8178F99C1BB0F87700AD289D;
+			remoteInfo = "Bolts-watchOS";
+		};
+		81EC57901C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 819573F11C2B8ECB00BFCA39;
+			remoteInfo = "Bolts-watchOS-Dynamic";
+		};
+		81EC57921C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 8E8C8EE917F23D1D00E3F1C7;
+			remoteInfo = "BoltsTests-iOS";
+		};
+		81EC57941C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 8E8C8F1917F241DA00E3F1C7;
+			remoteInfo = "BoltsTests-OSX";
+		};
+		81EC57961C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F5AFCA131BA752770076E927;
+			remoteInfo = "BoltsTests-tvOS";
+		};
+		81EC57981C34D0C4002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 1EC3016018CDAA8400D06D07;
+			remoteInfo = BoltsTestUI;
+		};
+		81EC57A01C34D0E6002DF851 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 1D5D7DA61BE3CE8200FD67C7;
+			remoteInfo = "Bolts-iOS-Dynamic";
 		};
 		F569F07E1B14DB3C00296F73 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1820,8 +1924,6 @@
 		8103FA34198FC190000BAE3F /* BFTask+Private.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BFTask+Private.m"; sourceTree = "<group>"; };
 		8103FA35198FC190000BAE3F /* PFCategoryLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFCategoryLoader.h; sourceTree = "<group>"; };
 		8103FA36198FC190000BAE3F /* PFCategoryLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFCategoryLoader.m; sourceTree = "<group>"; };
-		8103FA42198FC25B000BAE3F /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = "Carthage/Checkouts/Bolts-iOS/build/ios/Bolts.framework"; sourceTree = "<group>"; };
-		8103FA44198FC267000BAE3F /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = "Carthage/Checkouts/Bolts-iOS/build/osx/Bolts.framework"; sourceTree = "<group>"; };
 		81068EBA1ADE462500A34D13 /* Parse_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Parse_Private.h; sourceTree = "<group>"; };
 		81068EEF1AE0845D00A34D13 /* PFEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFEncoder.h; sourceTree = "<group>"; };
 		81068EF01AE0845D00A34D13 /* PFEncoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFEncoder.m; sourceTree = "<group>"; };
@@ -2234,6 +2336,7 @@
 		81EB6632198A7FA600851598 /* PFConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFConfig.h; sourceTree = "<group>"; };
 		81EB6633198A7FA600851598 /* PFConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFConfig.m; sourceTree = "<group>"; };
 		81EBF34B1B33E82200991947 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Bolts.xcodeproj; path = "Carthage/Checkouts/Bolts-iOS/Bolts.xcodeproj"; sourceTree = "<group>"; };
 		81EDD4D11B59A6EC002F69C0 /* PFCommandRunning.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFCommandRunning.h; sourceTree = "<group>"; };
 		81EEE1AE1B446D600087AC4D /* PFCurrentUserController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFCurrentUserController.h; sourceTree = "<group>"; };
 		81EEE1AF1B446D600087AC4D /* PFCurrentUserController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFCurrentUserController.m; sourceTree = "<group>"; };
@@ -2342,6 +2445,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				81EC579D1C34D0D9002DF851 /* Bolts.framework in Frameworks */,
 				816F44741A8E8933009CDB32 /* Parse.framework in Frameworks */,
 				F5C42CC71B34C22100C720D8 /* AudioToolbox.framework in Frameworks */,
 				816F44761A8E8933009CDB32 /* StoreKit.framework in Frameworks */,
@@ -2349,7 +2453,6 @@
 				816F44781A8E8933009CDB32 /* Accounts.framework in Frameworks */,
 				81E124D01C336992007FB57F /* OCMock.framework in Frameworks */,
 				816F44791A8E8933009CDB32 /* Social.framework in Frameworks */,
-				816F447C1A8E8933009CDB32 /* Bolts.framework in Frameworks */,
 				F5B0B3151B44A21100F3EBC4 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2358,10 +2461,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				81101B421C34D1D800AA3734 /* Bolts.framework in Frameworks */,
 				81E124CF1C33698E007FB57F /* OCMock.framework in Frameworks */,
 				F5B0B3171B44A2CA00F3EBC4 /* StoreKit.framework in Frameworks */,
 				81C09F891AF97EA70043B49C /* Parse.framework in Frameworks */,
-				815868E21AF9818D009A5751 /* Bolts.framework in Frameworks */,
 				F5B0B3161B44A22300F3EBC4 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2377,12 +2480,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				81101B411C34D1B800AA3734 /* Bolts.framework in Frameworks */,
 				81B3F2021AC5DAA400A92677 /* Cocoa.framework in Frameworks */,
 				81B3F2011AC5DA7600A92677 /* libsqlite3.dylib in Frameworks */,
 				97DE045C163214C0007154E8 /* SystemConfiguration.framework in Frameworks */,
 				97DE045A16321492007154E8 /* Security.framework in Frameworks */,
 				97DE045116321428007154E8 /* CoreLocation.framework in Frameworks */,
-				815868E71AF98731009A5751 /* Bolts.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2648,26 +2751,9 @@
 		8103FA47198FC304000BAE3F /* Bolts */ = {
 			isa = PBXGroup;
 			children = (
-				8103FA48198FC30C000BAE3F /* iOS */,
-				8103FA49198FC311000BAE3F /* OSX */,
+				81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */,
 			);
 			name = Bolts;
-			sourceTree = "<group>";
-		};
-		8103FA48198FC30C000BAE3F /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				8103FA42198FC25B000BAE3F /* Bolts.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		8103FA49198FC311000BAE3F /* OSX */ = {
-			isa = PBXGroup;
-			children = (
-				8103FA44198FC267000BAE3F /* Bolts.framework */,
-			);
-			name = OSX;
 			sourceTree = "<group>";
 		};
 		810ECC601B573B96002944D4 /* Resources */ = {
@@ -3741,6 +3827,24 @@
 				F50E486D1B83ED270055094D /* PFFileStagingController.m */,
 			);
 			path = Controller;
+			sourceTree = "<group>";
+		};
+		81EC57771C34D0C4002DF851 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				81EC57851C34D0C4002DF851 /* Bolts.framework */,
+				81EC57871C34D0C4002DF851 /* Bolts.framework */,
+				81EC57891C34D0C4002DF851 /* Bolts.framework */,
+				81EC578B1C34D0C4002DF851 /* Bolts.framework */,
+				81EC578D1C34D0C4002DF851 /* Bolts.framework */,
+				81EC578F1C34D0C4002DF851 /* Bolts.framework */,
+				81EC57911C34D0C4002DF851 /* Bolts.framework */,
+				81EC57931C34D0C4002DF851 /* BoltsTests-iOS.xctest */,
+				81EC57951C34D0C4002DF851 /* BoltsTests-OSX.xctest */,
+				81EC57971C34D0C4002DF851 /* BoltsTests-tvOS.xctest */,
+				81EC57991C34D0C4002DF851 /* BoltsTestUI.app */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 		81EDD4BC1B59A6D8002F69C0 /* CommandRunner */ = {
@@ -4861,6 +4965,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				81101B461C34D28B00AA3734 /* PBXTargetDependency */,
 				812F31FF1BCF414D00FCBCD4 /* PBXTargetDependency */,
 			);
 			name = "Parse-watchOS";
@@ -4881,6 +4986,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				81101B441C34D28300AA3734 /* PBXTargetDependency */,
 				815F241F1BD04DE00054659F /* PBXTargetDependency */,
 			);
 			name = "Parse-tvOS";
@@ -4941,6 +5047,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				81EC57A11C34D0E6002DF851 /* PBXTargetDependency */,
 				F569F07F1B14DB3C00296F73 /* PBXTargetDependency */,
 			);
 			name = "Parse-iOS";
@@ -4961,6 +5068,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				81101B331C34D1AC00AA3734 /* PBXTargetDependency */,
 				81493A9A1A0D3CE3008D5504 /* PBXTargetDependency */,
 			);
 			name = "Parse-OSX";
@@ -4998,6 +5106,10 @@
 			productRefGroup = 09D3364B139C54940098E916 /* Products */;
 			projectDirPath = "";
 			projectReferences = (
+				{
+					ProductGroup = 81EC57771C34D0C4002DF851 /* Products */;
+					ProjectRef = 81EC57761C34D0C4002DF851 /* Bolts.xcodeproj */;
+				},
 				{
 					ProductGroup = 81AB68AF1B7E7ECC0053210E /* Products */;
 					ProjectRef = 81AB68AE1B7E7ECC0053210E /* OCMock.xcodeproj */;
@@ -5053,6 +5165,83 @@
 			fileType = wrapper.framework;
 			path = OCMock.framework;
 			remoteRef = 81AB68BE1B7E7ECC0053210E /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC57851C34D0C4002DF851 /* Bolts.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Bolts.framework;
+			remoteRef = 81EC57841C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC57871C34D0C4002DF851 /* Bolts.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Bolts.framework;
+			remoteRef = 81EC57861C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC57891C34D0C4002DF851 /* Bolts.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Bolts.framework;
+			remoteRef = 81EC57881C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC578B1C34D0C4002DF851 /* Bolts.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Bolts.framework;
+			remoteRef = 81EC578A1C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC578D1C34D0C4002DF851 /* Bolts.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Bolts.framework;
+			remoteRef = 81EC578C1C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC578F1C34D0C4002DF851 /* Bolts.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Bolts.framework;
+			remoteRef = 81EC578E1C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC57911C34D0C4002DF851 /* Bolts.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Bolts.framework;
+			remoteRef = 81EC57901C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC57931C34D0C4002DF851 /* BoltsTests-iOS.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "BoltsTests-iOS.xctest";
+			remoteRef = 81EC57921C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC57951C34D0C4002DF851 /* BoltsTests-OSX.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "BoltsTests-OSX.xctest";
+			remoteRef = 81EC57941C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC57971C34D0C4002DF851 /* BoltsTests-tvOS.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "BoltsTests-tvOS.xctest";
+			remoteRef = 81EC57961C34D0C4002DF851 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		81EC57991C34D0C4002DF851 /* BoltsTestUI.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = BoltsTestUI.app;
+			remoteRef = 81EC57981C34D0C4002DF851 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -6009,6 +6198,21 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		81101B331C34D1AC00AA3734 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bolts-OSX";
+			targetProxy = 81101B321C34D1AC00AA3734 /* PBXContainerItemProxy */;
+		};
+		81101B441C34D28300AA3734 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bolts-tvOS-Dynamic";
+			targetProxy = 81101B431C34D28300AA3734 /* PBXContainerItemProxy */;
+		};
+		81101B461C34D28B00AA3734 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bolts-watchOS-Dynamic";
+			targetProxy = 81101B451C34D28B00AA3734 /* PBXContainerItemProxy */;
+		};
 		811167471B8402DA003CB026 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 97010FAB1630B18F00AB761E /* Parse-OSX */;
@@ -6043,6 +6247,11 @@
 			isa = PBXTargetDependency;
 			name = OCMock;
 			targetProxy = 81AB68C71B7E7F2A0053210E /* PBXContainerItemProxy */;
+		};
+		81EC57A11C34D0E6002DF851 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bolts-iOS-Dynamic";
+			targetProxy = 81EC57A01C34D0E6002DF851 /* PBXContainerItemProxy */;
 		};
 		F569F07F1B14DB3C00296F73 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Parse.xcworkspace/contents.xcworkspacedata
+++ b/Parse.xcworkspace/contents.xcworkspacedata
@@ -8,6 +8,9 @@
       location = "container:"
       name = "Vendor">
       <FileRef
+         location = "group:Carthage/Checkouts/Bolts-iOS/Bolts.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:Carthage/Checkouts/OCMock/Source/OCMock.xcodeproj">
       </FileRef>
    </Group>

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject-Swift.xcodeproj/project.pbxproj
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject-Swift.xcodeproj/project.pbxproj
@@ -219,7 +219,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ ! -d \"Bolts.framework\" ]]; then\n  cp -R ../../../Carthage/Checkouts/Bolts-iOS/build/ios/Bolts.framework .\nfi\n";
+			shellScript = "# Remove the compiled version of Bolts.framework as we need a static one\nrm -r $BUILT_PRODUCTS_DIR/Bolts.framework\n\nif [[ ! -d \"Bolts.framework\" ]]; then\n  cp -R ../../../Carthage/Checkouts/Bolts-iOS/build/ios/Bolts.framework .\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ParseStarterProject/iOS/ParseStarterProject/ParseStarterProject.xcodeproj/project.pbxproj
+++ b/ParseStarterProject/iOS/ParseStarterProject/ParseStarterProject.xcodeproj/project.pbxproj
@@ -282,7 +282,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ ! -d \"Bolts.framework\" ]]; then\n  cp -R ../../../Carthage/Checkouts/Bolts-iOS/build/ios/Bolts.framework .\nfi\n";
+			shellScript = "# Remove the compiled version of Bolts.framework as we need a static one\nrm -r $BUILT_PRODUCTS_DIR/Bolts.framework\n\nif [[ ! -d \"Bolts.framework\" ]]; then\n  cp -R ../../../Carthage/Checkouts/Bolts-iOS/build/ios/Bolts.framework .\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
This is converting all of our dependencies to use Bolts from dynamic targets.  
Please note, that external build tool targets are still there, as updating the scripts for deployment/starter projects is required to make it work (coming in a separate PR).

Also - this removes all custom set framework search paths as they are no longer required.

Depends on #708 to prevent merge conflicts.