### PR TITLE
Replace all (at)name with pragma marks in headers.

### DIFF
--- a/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
+++ b/Parse/Internal/ACL/DefaultACLController/PFDefaultACLController.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFCurrentUserControllerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)controllerWithDataSource:(id<PFCurrentUserControllerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Default ACL
+#pragma mark - Default ACL
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/ACL/State/PFACLState.h
+++ b/Parse/Internal/ACL/State/PFACLState.h
@@ -21,7 +21,7 @@ typedef void (^PFACLStateMutationBlock)(PFMutableACLState *);
 @property (nonatomic, assign, readonly, getter=isShared) BOOL shared;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
@@ -32,7 +32,7 @@ typedef void (^PFACLStateMutationBlock)(PFMutableACLState *);
 + (instancetype)stateWithState:(PFACLState *)otherState mutatingBlock:(PFACLStateMutationBlock)mutatingBlock;
 
 ///--------------------------------------
-/// @name Mutating
+#pragma mark - Mutating
 ///--------------------------------------
 
 - (PFACLState *)copyByMutatingWithBlock:(PFACLStateMutationBlock)mutatingBlock;

--- a/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
+++ b/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFEventuallyQueueProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)controllerWithDataSource:(id<PFEventuallyQueueProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Track Event
+#pragma mark - Track Event
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/CloudCode/PFCloudCodeController.h
+++ b/Parse/Internal/CloudCode/PFCloudCodeController.h
@@ -19,7 +19,7 @@
 @property (nonatomic, strong, readonly) id<PFCommandRunnerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -28,7 +28,7 @@
 + (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Cloud Functions
+#pragma mark - Cloud Functions
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSTimeInterval initialRetryDelay;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
                                   serverURL:(NSURL *)serverURL;
 
 ///--------------------------------------
-/// @name Data Commands
+#pragma mark - Data Commands
 ///--------------------------------------
 
 /**
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
           cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 ///--------------------------------------
-/// @name File Commands
+#pragma mark - File Commands
 ///--------------------------------------
 
 - (BFTask *)runFileUploadCommandAsync:(PFRESTCommand *)command

--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunningConstants.h
@@ -10,13 +10,13 @@
 #import <Foundation/Foundation.h>
 
 ///--------------------------------------
-/// @name Running
+#pragma mark - Running
 ///--------------------------------------
 
 extern uint8_t const PFCommandRunningDefaultMaxAttemptsCount;
 
 ///--------------------------------------
-/// @name Headers
+#pragma mark - Headers
 ///--------------------------------------
 
 extern NSString *const PFCommandHeaderNameApplicationId;
@@ -29,7 +29,7 @@ extern NSString *const PFCommandHeaderNameOSVersion;
 extern NSString *const PFCommandHeaderNameSessionToken;
 
 ///--------------------------------------
-/// @name HTTP Method Override
+#pragma mark - HTTP Method Override
 ///--------------------------------------
 
 extern NSString *const PFCommandParameterNameMethodOverride;

--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
@@ -22,20 +22,20 @@
 @property (nonatomic, strong, readonly) NSURL *serverURL;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)constructorWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource serverURL:(NSURL *)serverURL;
 
 ///--------------------------------------
-/// @name Data
+#pragma mark - Data
 ///--------------------------------------
 
 - (BFTask<NSURLRequest *> *)getDataURLRequestAsyncForCommand:(PFRESTCommand *)command;
 
 ///--------------------------------------
-/// @name File Upload
+#pragma mark - File Upload
 ///--------------------------------------
 
 - (BFTask<NSURLRequest *> *)getFileUploadURLRequestAsyncForCommand:(PFRESTCommand *)command
@@ -43,7 +43,7 @@
                                              contentSourceFilePath:(NSString *)contentFilePath;
 
 ///--------------------------------------
-/// @name Headers
+#pragma mark - Headers
 ///--------------------------------------
 
 + (NSDictionary *)defaultURLRequestHeadersForApplicationId:(NSString *)applicationId

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFURLSessionDelegate> delegate;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -44,13 +44,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 delegate:(id<PFURLSessionDelegate>)delegate;
 
 ///--------------------------------------
-/// @name Teardown
+#pragma mark - Teardown
 ///--------------------------------------
 
 - (void)invalidateAndCancel;
 
 ///--------------------------------------
-/// @name Network Requests
+#pragma mark - Network Requests
 ///--------------------------------------
 
 - (BFTask *)performDataURLRequestAsync:(NSURLRequest *)request

--- a/Parse/Internal/Commands/PFRESTCommand.h
+++ b/Parse/Internal/Commands/PFRESTCommand.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy) NSString *localId;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 + (instancetype)commandWithHTTPPath:(NSString *)path

--- a/Parse/Internal/Commands/PFRESTQueryCommand.h
+++ b/Parse/Internal/Commands/PFRESTQueryCommand.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFRESTQueryCommand : PFRESTCommand
 
 ///--------------------------------------
-/// @name Find
+#pragma mark - Find
 ///--------------------------------------
 
 + (instancetype)findCommandForQueryState:(PFQueryState *)queryState withSessionToken:(nullable NSString *)sessionToken;
@@ -33,13 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
                                sessionToken:(nullable NSString *)sessionToken;
 
 ///--------------------------------------
-/// @name Count
+#pragma mark - Count
 ///--------------------------------------
 
 + (instancetype)countCommandFromFindCommand:(PFRESTQueryCommand *)findCommand;
 
 ///--------------------------------------
-/// @name Parameters
+#pragma mark - Parameters
 ///--------------------------------------
 
 + (NSDictionary *)findCommandParametersForQueryState:(PFQueryState *)queryState;

--- a/Parse/Internal/Commands/PFRESTUserCommand.h
+++ b/Parse/Internal/Commands/PFRESTUserCommand.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) BOOL revocableSessionEnabled;
 
 ///--------------------------------------
-/// @name Log In
+#pragma mark - Log In
 ///--------------------------------------
 
 + (instancetype)logInUserCommandWithUsername:(NSString *)username
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
                                          sessionToken:(nullable NSString *)sessionToken;
 
 ///--------------------------------------
-/// @name Sign Up
+#pragma mark - Sign Up
 ///--------------------------------------
 
 + (instancetype)signUpUserCommandWithParameters:(NSDictionary *)parameters
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
                                    sessionToken:(nullable NSString *)sessionToken;
 
 ///--------------------------------------
-/// @name Current User
+#pragma mark - Current User
 ///--------------------------------------
 
 + (instancetype)getCurrentUserCommandWithSessionToken:(NSString *)sessionToken;
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)logOutUserCommandWithSessionToken:(NSString *)sessionToken;
 
 ///--------------------------------------
-/// @name Password Rest
+#pragma mark - Password Rest
 ///--------------------------------------
 
 + (instancetype)resetPasswordCommandForUserWithEmail:(NSString *)email;

--- a/Parse/Internal/Config/Controller/PFConfigController.h
+++ b/Parse/Internal/Config/Controller/PFConfigController.h
@@ -24,14 +24,14 @@
 @property (nonatomic, strong, readonly) PFCurrentConfigController *currentConfigController;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider, PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------
-/// @name Fetch
+#pragma mark - Fetch
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.h
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.h
@@ -21,7 +21,7 @@
 @property (nonatomic, weak, readonly) id<PFPersistenceControllerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -30,7 +30,7 @@
 + (instancetype)controllerWithDataSource:(id<PFPersistenceControllerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Accessors
+#pragma mark - Accessors
 ///--------------------------------------
 
 - (BFTask *)getCurrentConfigAsync;

--- a/Parse/Internal/FieldOperation/PFFieldOperationDecoder.h
+++ b/Parse/Internal/FieldOperation/PFFieldOperationDecoder.h
@@ -17,13 +17,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFFieldOperationDecoder : NSObject
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 + (instancetype)defaultDecoder;
 
 ///--------------------------------------
-/// @name Decoding
+#pragma mark - Decoding
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/File/Controller/PFFileController.h
+++ b/Parse/Internal/File/Controller/PFFileController.h
@@ -28,7 +28,7 @@
 @property (nonatomic, copy, readonly) NSString *cacheFilesDirectoryPath;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -37,7 +37,7 @@
 + (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider, PFFileManagerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Download
+#pragma mark - Download
 ///--------------------------------------
 
 /**
@@ -67,7 +67,7 @@
                                progressBlock:(PFProgressBlock)progressBlock;
 
 ///--------------------------------------
-/// @name Upload
+#pragma mark - Upload
 ///--------------------------------------
 
 /**
@@ -88,7 +88,7 @@
                        progressBlock:(PFProgressBlock)progressBlock;
 
 ///--------------------------------------
-/// @name Cache
+#pragma mark - Cache
 ///--------------------------------------
 
 - (BFTask *)clearFileCacheAsync;

--- a/Parse/Internal/File/Controller/PFFileStagingController.h
+++ b/Parse/Internal/File/Controller/PFFileStagingController.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *stagedFilesDirectoryPath;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)controllerWithDataSource:(id<PFFileManagerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Staging
+#pragma mark - Staging
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/File/State/PFFileState.h
+++ b/Parse/Internal/File/State/PFFileState.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy, readonly) NSString *mimeType;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithState:(PFFileState *)state;

--- a/Parse/Internal/Installation/Controller/PFInstallationController.h
+++ b/Parse/Internal/Installation/Controller/PFInstallationController.h
@@ -22,7 +22,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallationController : NSO
 @property (nonatomic, weak, readonly) id<PFObjectControllerProvider, PFCurrentInstallationControllerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.h
+++ b/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.h
@@ -31,7 +31,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFCurrentInstallationControlle
 @property (nonatomic, weak, readonly) id<PFObjectFilePersistenceControllerProvider> coreDataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -44,7 +44,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFCurrentInstallationControlle
                            coreDataSource:(id<PFObjectFilePersistenceControllerProvider>)coreDataSource;
 
 ///--------------------------------------
-/// @name Installation
+#pragma mark - Installation
 ///--------------------------------------
 
 @property (nonatomic, strong, readonly) PFInstallation *memoryCachedCurrentInstallation;

--- a/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.h
+++ b/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.h
@@ -20,14 +20,14 @@
 @property (nonatomic, weak, readonly) id<PFPersistenceControllerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------
-/// @name Accessors
+#pragma mark - Accessors
 ///--------------------------------------
 
 /**
@@ -36,7 +36,7 @@
 - (BFTask<NSString *> *)getInstallationIdentifierAsync;
 
 ///--------------------------------------
-/// @name Clear
+#pragma mark - Clear
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/KeyValueCache/PFKeyValueCache.h
+++ b/Parse/Internal/KeyValueCache/PFKeyValueCache.h
@@ -16,27 +16,27 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *cacheDirectoryPath;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithCacheDirectoryPath:(NSString *)path;
 
 ///--------------------------------------
-/// @name Setting
+#pragma mark - Setting
 ///--------------------------------------
 
 - (void)setObject:(NSString *)object forKey:(NSString *)key;
 - (void)setObject:(NSString *)object forKeyedSubscript:(NSString *)key;
 
 ///--------------------------------------
-/// @name Getting
+#pragma mark - Getting
 ///--------------------------------------
 
 - (NSString *)objectForKey:(NSString *)key maxAge:(NSTimeInterval)age;
 
 ///--------------------------------------
-/// @name Removing
+#pragma mark - Removing
 ///--------------------------------------
 
 - (void)removeObjectForKey:(NSString *)key;

--- a/Parse/Internal/KeyValueCache/PFKeyValueCache_Private.h
+++ b/Parse/Internal/KeyValueCache/PFKeyValueCache_Private.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFKeyValueCache ()
 
 ///--------------------------------------
-/// @name Properties
+#pragma mark - Properties
 ///--------------------------------------
 
 @property (nullable, nonatomic, strong, readwrite) NSFileManager *fileManager;
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) NSUInteger maxMemoryCacheBytesPerRecord;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithCacheDirectoryURL:(nullable NSURL *)url
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
                               memoryCache:(nullable NSCache *)cache NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------
-/// @name Waiting
+#pragma mark - Waiting
 ///--------------------------------------
 
 - (void)waitForOutstandingOperations;
@@ -43,14 +43,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFKeyValueCacheEntry : NSObject
 
 ///--------------------------------------
-/// @name Properties
+#pragma mark - Properties
 ///--------------------------------------
 
 @property (atomic, copy, readonly) NSString *value;
 @property (atomic, strong, readonly) NSDate *creationTime;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 + (instancetype)cacheEntryWithValue:(NSString *)value;

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.h
@@ -32,7 +32,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions) {
 @property (nonatomic, strong, readonly) PFFileManager *fileManager;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -40,7 +40,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions) {
                             options:(PFOfflineStoreOptions)options NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------
-/// @name Fetch
+#pragma mark - Fetch
 ///--------------------------------------
 
 - (BFTask<PFObject *> *)fetchObjectLocallyAsync:(PFObject *)object;
@@ -56,7 +56,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions) {
 - (BFTask<PFObject *> *)fetchObjectLocallyAsync:(PFObject *)object database:(PFSQLiteDatabase *)database;
 
 ///--------------------------------------
-/// @name Save
+#pragma mark - Save
 ///--------------------------------------
 
 //TODO: (nlutsenko) Remove `includChildren` method, replace with PFLocalStore that wraps OfflineStore + Pin.
@@ -81,7 +81,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions) {
                                   database:(PFSQLiteDatabase *)database;
 
 ///--------------------------------------
-/// @name Find
+#pragma mark - Find
 ///--------------------------------------
 
 /**
@@ -131,7 +131,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions) {
                           database:(PFSQLiteDatabase *)database;
 
 ///--------------------------------------
-/// @name Update Internal State
+#pragma mark - Update Internal State
 ///--------------------------------------
 
 /**
@@ -142,7 +142,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions) {
 - (BFTask<PFVoid> *)updateDataForObjectAsync:(PFObject *)object;
 
 ///--------------------------------------
-/// @name Delete
+#pragma mark - Delete
 ///--------------------------------------
 
 /**
@@ -151,13 +151,13 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions) {
 - (BFTask<PFVoid> *)deleteDataForObjectAsync:(PFObject *)object;
 
 ///--------------------------------------
-/// @name Unpin
+#pragma mark - Unpin
 ///--------------------------------------
 
 - (BFTask<PFVoid> *)unpinObjectAsync:(PFObject *)object;
 
 ///--------------------------------------
-/// @name Internal Helper Methods
+#pragma mark - Internal Helper Methods
 ///--------------------------------------
 
 /**
@@ -184,7 +184,7 @@ typedef NS_OPTIONS(uint8_t, PFOfflineStoreOptions) {
                     newObjectId:(NSString *)newObjectId;
 
 ///--------------------------------------
-/// @name Unit Test Helper Methods
+#pragma mark - Unit Test Helper Methods
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/LocalDataStore/Pin/PFPin.h
+++ b/Parse/Internal/LocalDataStore/Pin/PFPin.h
@@ -24,7 +24,7 @@ extern NSString *const PFPinKeyObjects;
 @property (nonatomic, strong) NSMutableArray *objects;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithName:(NSString *)name;

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabase.h
@@ -44,19 +44,19 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFSQLiteDatabase : NSObject
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithPath:(NSString *)path;
 
 ///--------------------------------------
-/// @name Database Creation
+#pragma mark - Database Creation
 ///--------------------------------------
 
 + (instancetype)databaseWithPath:(NSString *)path;
 
 ///--------------------------------------
-/// @name Connection
+#pragma mark - Connection
 ///--------------------------------------
 
 /**
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask *)closeAsync;
 
 ///--------------------------------------
-/// @name Transaction
+#pragma mark - Transaction
 ///--------------------------------------
 
 /**
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask *)rollbackAsync;
 
 ///--------------------------------------
-/// @name Query Methods
+#pragma mark - Query Methods
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) PFFileManager *fileManager;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)controllerWithFileManager:(PFFileManager *)fileManager;
 
 ///--------------------------------------
-/// @name Opening
+#pragma mark - Opening
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseResult.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)close;
 
 ///--------------------------------------
-/// @name Get Column Value
+#pragma mark - Get Column Value
 ///--------------------------------------
 
 - (int)intForColumn:(NSString *)columnName;

--- a/Parse/Internal/MultiProcessLock/PFMultiProcessFileLock.h
+++ b/Parse/Internal/MultiProcessLock/PFMultiProcessFileLock.h
@@ -16,7 +16,7 @@
 @property (nonatomic, copy, readonly) NSString *lockFilePath;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Parse/Internal/Object/BatchController/PFObjectBatchController.h
+++ b/Parse/Internal/Object/BatchController/PFObjectBatchController.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFCommandRunnerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -32,19 +32,19 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Fetch
+#pragma mark - Fetch
 ///--------------------------------------
 
 - (BFTask *)fetchObjectsAsync:(nullable NSArray *)objects withSessionToken:(nullable NSString *)sessionToken;
 
 ///--------------------------------------
-/// @name Delete
+#pragma mark - Delete
 ///--------------------------------------
 
 - (BFTask *)deleteObjectsAsync:(nullable NSArray *)objects withSessionToken:(nullable NSString *)sessionToken;
 
 ///--------------------------------------
-/// @name Utilities
+#pragma mark - Utilities
 ///--------------------------------------
 
 + (nullable NSArray *)uniqueObjectsArrayFromArray:(nullable NSArray *)objects omitObjectsWithData:(BOOL)omitFetched;

--- a/Parse/Internal/Object/Coder/File/PFObjectFileCoder.h
+++ b/Parse/Internal/Object/Coder/File/PFObjectFileCoder.h
@@ -22,13 +22,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFObjectFileCoder : NSObject
 
 ///--------------------------------------
-/// @name Encode
+#pragma mark - Encode
 ///--------------------------------------
 
 + (NSData *)dataFromObject:(PFObject *)object usingEncoder:(PFEncoder *)encoder;
 
 ///--------------------------------------
-/// @name Decode
+#pragma mark - Decode
 ///--------------------------------------
 
 + (PFObject *)objectFromData:(NSData *)data usingDecoder:(PFDecoder *)decoder;

--- a/Parse/Internal/Object/Coder/File/PFObjectFileCodingLogic.h
+++ b/Parse/Internal/Object/Coder/File/PFObjectFileCodingLogic.h
@@ -17,13 +17,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFObjectFileCodingLogic : NSObject
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 + (instancetype)codingLogic;
 
 ///--------------------------------------
-/// @name Logic
+#pragma mark - Logic
 ///--------------------------------------
 
 - (void)updateObject:(PFObject *)object fromDictionary:(NSDictionary *)dictionary usingDecoder:(PFDecoder *)decoder;

--- a/Parse/Internal/Object/Controller/OfflineController/PFOfflineObjectController.h
+++ b/Parse/Internal/Object/Controller/OfflineController/PFOfflineObjectController.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFCommandRunnerProvider, PFOfflineStoreProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider, PFOfflineStoreProvider>)dataSource NS_DESIGNATED_INITIALIZER;

--- a/Parse/Internal/Object/Controller/PFObjectController.h
+++ b/Parse/Internal/Object/Controller/PFObjectController.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFCommandRunnerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Parse/Internal/Object/Controller/PFObjectController_Private.h
+++ b/Parse/Internal/Object/Controller/PFObjectController_Private.h
@@ -14,7 +14,7 @@
 @interface PFObjectController ()
 
 ///--------------------------------------
-/// @name Fetch
+#pragma mark - Fetch
 ///--------------------------------------
 
 - (BFTask *)_runFetchCommand:(PFRESTCommand *)command forObject:(PFObject *)object;

--- a/Parse/Internal/Object/Controller/PFObjectControlling.h
+++ b/Parse/Internal/Object/Controller/PFObjectControlling.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol PFObjectControlling <NSObject>
 
 ///--------------------------------------
-/// @name Fetch
+#pragma mark - Fetch
 ///--------------------------------------
 
 /**
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask *)processFetchResultAsync:(NSDictionary *)result forObject:(PFObject *)object;
 
 ///--------------------------------------
-/// @name Delete
+#pragma mark - Delete
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/Object/CurrentController/PFCurrentObjectControlling.h
+++ b/Parse/Internal/Object/CurrentController/PFCurrentObjectControlling.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSUInteger, PFCurrentObjectStorageType) {
 @property (nonatomic, assign, readonly) PFCurrentObjectStorageType storageType;
 
 ///--------------------------------------
-/// @name Current
+#pragma mark - Current
 ///--------------------------------------
 
 - (BFTask *)getCurrentObjectAsync;

--- a/Parse/Internal/Object/EstimatedData/PFObjectEstimatedData.h
+++ b/Parse/Internal/Object/EstimatedData/PFObjectEstimatedData.h
@@ -15,7 +15,7 @@
 @interface PFObjectEstimatedData : NSObject
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithServerData:(NSDictionary *)serverData
@@ -24,7 +24,7 @@
                           operationSetQueue:(NSArray *)operationSetQueue;
 
 ///--------------------------------------
-/// @name Read
+#pragma mark - Read
 ///--------------------------------------
 
 - (id)objectForKey:(NSString *)key;
@@ -36,7 +36,7 @@
 @property (nonatomic, copy, readonly) NSDictionary *dictionaryRepresentation;
 
 ///--------------------------------------
-/// @name Write
+#pragma mark - Write
 ///--------------------------------------
 
 - (id)applyFieldOperation:(PFFieldOperation *)operation forKey:(NSString *)key;

--- a/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
+++ b/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
@@ -22,7 +22,7 @@
 @property (nonatomic, weak, readonly) id<PFPersistenceControllerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -30,7 +30,7 @@
 + (instancetype)controllerWithDataSource:(id<PFPersistenceControllerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Objects
+#pragma mark - Objects
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/Object/OperationSet/PFOperationSet.h
+++ b/Parse/Internal/Object/OperationSet/PFOperationSet.h
@@ -52,7 +52,7 @@
                                       usingDecoder:(PFDecoder *)decoder;
 
 ///--------------------------------------
-/// @name Accessors
+#pragma mark - Accessors
 ///--------------------------------------
 
 @property (nonatomic, assign, readonly) NSUInteger count;

--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -41,7 +41,7 @@
 @required
 
 ///--------------------------------------
-/// @name State
+#pragma mark - State
 ///--------------------------------------
 
 + (PFObjectState *)_newObjectStateWithParseClassName:(NSString *)className
@@ -51,7 +51,7 @@
 @optional
 
 ///--------------------------------------
-/// @name Before Save
+#pragma mark - Before Save
 ///--------------------------------------
 
 /**
@@ -107,7 +107,7 @@
 #endif
 
 ///--------------------------------------
-/// @name Validation
+#pragma mark - Validation
 ///--------------------------------------
 
 - (BFTask<PFVoid> *)_validateFetchAsync NS_REQUIRES_SUPER;
@@ -122,7 +122,7 @@
 - (BFTask<PFVoid> *)_validateSaveEventuallyAsync NS_REQUIRES_SUPER;
 
 ///--------------------------------------
-/// @name Pin
+#pragma mark - Pin
 ///--------------------------------------
 - (BFTask *)_pinInBackgroundWithName:(NSString *)name includeChildren:(BOOL)includeChildren;
 + (BFTask *)_pinAllInBackground:(NSArray *)objects withName:(NSString *)name includeChildren:(BOOL)includeChildren;

--- a/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
+++ b/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFOfflineStoreProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)storeWithDataSource:(id<PFOfflineStoreProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Pin
+#pragma mark - Pin
 ///--------------------------------------
 
 /**
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
                     includeChildren:(BOOL)includeChildren;
 
 ///--------------------------------------
-/// @name Unpin
+#pragma mark - Unpin
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/Object/State/PFMutableObjectState.h
+++ b/Parse/Internal/Object/State/PFMutableObjectState.h
@@ -25,7 +25,7 @@
 @property (nonatomic, assign, readwrite, getter=isDeleted) BOOL deleted;
 
 ///--------------------------------------
-/// @name Accessors
+#pragma mark - Accessors
 ///--------------------------------------
 
 - (void)setServerDataObject:(id)object forKey:(NSString *)key;
@@ -36,7 +36,7 @@
 - (void)setUpdatedAtFromString:(NSString *)string;
 
 ///--------------------------------------
-/// @name Apply
+#pragma mark - Apply
 ///--------------------------------------
 
 - (void)applyState:(PFObjectState *)state;

--- a/Parse/Internal/Object/State/PFObjectState.h
+++ b/Parse/Internal/Object/State/PFObjectState.h
@@ -28,7 +28,7 @@ typedef void(^PFObjectStateMutationBlock)(PFMutableObjectState *state);
 @property (nonatomic, assign, readonly, getter=isDeleted) BOOL deleted;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
@@ -47,7 +47,7 @@ typedef void(^PFObjectStateMutationBlock)(PFMutableObjectState *state);
                              isComplete:(BOOL)complete;
 
 ///--------------------------------------
-/// @name Coding
+#pragma mark - Coding
 ///--------------------------------------
 
 /**
@@ -62,7 +62,7 @@ typedef void(^PFObjectStateMutationBlock)(PFMutableObjectState *state);
 - (NSDictionary *)dictionaryRepresentationWithObjectEncoder:(PFEncoder *)objectEncoder NS_REQUIRES_SUPER;
 
 ///--------------------------------------
-/// @name Mutating
+#pragma mark - Mutating
 ///--------------------------------------
 
 - (PFObjectState *)copyByMutatingWithBlock:(PFObjectStateMutationBlock)block;

--- a/Parse/Internal/Object/State/PFObjectState_Private.h
+++ b/Parse/Internal/Object/State/PFObjectState_Private.h
@@ -37,7 +37,7 @@
 @interface PFObjectState (Mutable)
 
 ///--------------------------------------
-/// @name Accessors
+#pragma mark - Accessors
 ///--------------------------------------
 
 - (void)setServerDataObject:(id)object forKey:(NSString *)key;
@@ -48,7 +48,7 @@
 - (void)setUpdatedAtFromString:(NSString *)string;
 
 ///--------------------------------------
-/// @name Apply
+#pragma mark - Apply
 ///--------------------------------------
 
 - (void)applyState:(PFObjectState *)state NS_REQUIRES_SUPER;

--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.h
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.h
@@ -15,7 +15,7 @@
 @interface PFObjectSubclassingController : NSObject
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 //TODO: (nlutsenko, richardross) Make it not terrible aka don't have singletons.
@@ -23,7 +23,7 @@
 + (void)clearDefaultController;
 
 ///--------------------------------------
-/// @name Registration
+#pragma mark - Registration
 ///--------------------------------------
 
 - (Class<PFSubclassing>)subclassForParseClassName:(NSString *)parseClassName;
@@ -31,7 +31,7 @@
 - (void)unregisterSubclass:(Class<PFSubclassing>)kls;
 
 ///--------------------------------------
-/// @name Forwarding
+#pragma mark - Forwarding
 ///--------------------------------------
 
 - (NSMethodSignature *)forwardingMethodSignatureForSelector:(SEL)cmd ofClass:(Class)kls;

--- a/Parse/Internal/Object/Utilities/PFObjectUtilities.h
+++ b/Parse/Internal/Object/Utilities/PFObjectUtilities.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFObjectUtilities : NSObject
 
 ///--------------------------------------
-/// @name Operations
+#pragma mark - Operations
 ///--------------------------------------
 
 + (id)newValueByApplyingFieldOperation:(PFFieldOperation *)operation
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)applyOperationSet:(PFOperationSet *)operationSet toDictionary:(NSMutableDictionary *)dictionary;
 
 ///--------------------------------------
-/// @name Equality
+#pragma mark - Equality
 ///--------------------------------------
 
 + (BOOL)isObject:(nullable id<NSObject>)objectA equalToObject:(nullable id<NSObject>)objectB;

--- a/Parse/Internal/PFCommandCache.h
+++ b/Parse/Internal/PFCommandCache.h
@@ -30,7 +30,7 @@
 @property (nonatomic, assign, readonly) unsigned long long diskCacheSize;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/PFCoreDataProvider.h
+++ b/Parse/Internal/PFCoreDataProvider.h
@@ -13,7 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 ///--------------------------------------
-/// @name Default ACL
+#pragma mark - Default ACL
 ///--------------------------------------
 
 @class PFDefaultACLController;
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 ///--------------------------------------
-/// @name Object
+#pragma mark - Object
 ///--------------------------------------
 
 @class PFObjectController;
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 ///--------------------------------------
-/// @name User
+#pragma mark - User
 ///--------------------------------------
 
 @class PFUserAuthenticationController;
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 ///--------------------------------------
-/// @name Installation
+#pragma mark - Installation
 ///--------------------------------------
 
 @class PFCurrentInstallationController;

--- a/Parse/Internal/PFCoreManager.h
+++ b/Parse/Internal/PFCoreManager.h
@@ -64,7 +64,7 @@ PFUserControllerProvider
 @property (null_resettable, nonatomic, strong) PFSessionController *sessionController;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -73,7 +73,7 @@ PFUserControllerProvider
 + (instancetype)managerWithDataSource:(id<PFCoreManagerDataSource>)dataSource;
 
 ///--------------------------------------
-/// @name ObjectFilePersistenceController
+#pragma mark - ObjectFilePersistenceController
 ///--------------------------------------
 
 - (void)unloadObjectFilePersistenceController;

--- a/Parse/Internal/PFDateFormatter.h
+++ b/Parse/Internal/PFDateFormatter.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedFormatter;
 
 ///--------------------------------------
-/// @name String from Date
+#pragma mark - String from Date
 ///--------------------------------------
 
 /**
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)preciseStringFromDate:(NSDate *)date;
 
 ///--------------------------------------
-/// @name Date from String
+#pragma mark - Date from String
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/PFEncoder.h
+++ b/Parse/Internal/PFEncoder.h
@@ -19,7 +19,7 @@
 @class PFSQLiteDatabase;
 
 ///--------------------------------------
-/// @name Encoders
+#pragma mark - Encoders
 ///--------------------------------------
 
 @interface PFEncoder : NSObject

--- a/Parse/Internal/PFEventuallyQueue.h
+++ b/Parse/Internal/PFEventuallyQueue.h
@@ -43,7 +43,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 @property (nonatomic, strong, readonly) PFEventuallyQueueTestHelper *testHelper;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -52,14 +52,14 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
                      retryInterval:(NSTimeInterval)retryInterval NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------
-/// @name Running Commands
+#pragma mark - Running Commands
 ///--------------------------------------
 
 - (BFTask *)enqueueCommandInBackground:(id<PFNetworkCommand>)command;
 - (BFTask *)enqueueCommandInBackground:(id<PFNetworkCommand>)command withObject:(PFObject *)object;
 
 ///--------------------------------------
-/// @name Controlling Queue
+#pragma mark - Controlling Queue
 ///--------------------------------------
 
 - (void)start NS_REQUIRES_SUPER;

--- a/Parse/Internal/PFEventuallyQueue_Private.h
+++ b/Parse/Internal/PFEventuallyQueue_Private.h
@@ -58,14 +58,14 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
                           resultTask:(BFTask *)resultTask;
 
 ///--------------------------------------
-/// @name Reachability
+#pragma mark - Reachability
 ///--------------------------------------
 
 - (void)_startMonitoringNetworkReachability;
 - (void)_stopMonitoringNetworkReachability;
 
 ///--------------------------------------
-/// @name Test Helper
+#pragma mark - Test Helper
 ///--------------------------------------
 
 - (void)_setMaxAttemptsCount:(NSUInteger)attemptsCount;
@@ -83,7 +83,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 @protocol PFEventuallyQueueSubclass <NSObject>
 
 ///--------------------------------------
-/// @name Pending Commands
+#pragma mark - Pending Commands
 ///--------------------------------------
 
 
@@ -111,7 +111,7 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 - (id<PFNetworkCommand>)_commandWithIdentifier:(NSString *)identifier error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Running Commands
+#pragma mark - Running Commands
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/PFFileManager.h
+++ b/Parse/Internal/PFFileManager.h
@@ -23,7 +23,7 @@ typedef NS_OPTIONS(uint8_t, PFFileManagerOptions) {
 @interface PFFileManager : NSObject
 
 ///--------------------------------------
-/// @name Class
+#pragma mark - Class
 ///--------------------------------------
 
 + (BOOL)isApplicationGroupContainerReachableForGroupIdentifier:(NSString *)applicationGroup;
@@ -48,7 +48,7 @@ typedef NS_OPTIONS(uint8_t, PFFileManagerOptions) {
 + (BFTask *)removeDirectoryContentsAsyncAtPath:(NSString *)path;
 
 ///--------------------------------------
-/// @name Instance
+#pragma mark - Instance
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Parse/Internal/PFLogger.h
+++ b/Parse/Internal/PFLogger.h
@@ -18,7 +18,7 @@ typedef uint8_t PFLoggingTag;
 @property (atomic, assign) PFLogLevel logLevel;
 
 ///--------------------------------------
-/// @name Shared Logger
+#pragma mark - Shared Logger
 ///--------------------------------------
 
 /**
@@ -29,7 +29,7 @@ A shared instance of `PFLogger` that should be used for all logging.
 + (instancetype)sharedLogger; //TODO: (nlutsenko) Convert to use an instance everywhere instead of a shared singleton.
 
 ///--------------------------------------
-/// @name Logging Messages
+#pragma mark - Logging Messages
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/PFMacros.h
+++ b/Parse/Internal/PFMacros.h
@@ -40,7 +40,7 @@ dispatch_queue_set_specific((queue), \
                             NULL)
 
 ///--------------------------------------
-/// @name Memory Management
+#pragma mark - Memory Management
 ///
 /// The following macros are influenced and include portions of libextobjc.
 ///--------------------------------------
@@ -62,7 +62,7 @@ try {} @catch (...) {} \
 __strong __typeof__(var) var = var ## _weak;
 
 ///--------------------------------------
-/// @name KVC
+#pragma mark - KVC
 ///--------------------------------------
 
 /**
@@ -73,7 +73,7 @@ __strong __typeof__(var) var = var ## _weak;
 (((void)(NO && ((void)((TYPE *)(nil)).PATH, NO)), # PATH))
 
 ///--------------------------------------
-/// @name Runtime
+#pragma mark - Runtime
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/PFNetworkCommand.h
+++ b/Parse/Internal/PFNetworkCommand.h
@@ -12,7 +12,7 @@
 @protocol PFNetworkCommand <NSObject>
 
 ///--------------------------------------
-/// @name Properties
+#pragma mark - Properties
 ///--------------------------------------
 
 @property (nonatomic, copy, readonly) NSString *sessionToken;
@@ -23,7 +23,7 @@
 @property (nonatomic, copy) NSString *localId;
 
 ///--------------------------------------
-/// @name Encoding/Decoding
+#pragma mark - Encoding/Decoding
 ///--------------------------------------
 
 + (instancetype)commandFromDictionaryRepresentation:(NSDictionary *)dictionary;
@@ -32,7 +32,7 @@
 + (BOOL)isValidDictionaryRepresentation:(NSDictionary *)dictionary;
 
 ///--------------------------------------
-/// @name Local Identifiers
+#pragma mark - Local Identifiers
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/PFPinningEventuallyQueue.h
+++ b/Parse/Internal/PFPinningEventuallyQueue.h
@@ -14,7 +14,7 @@
 @interface PFPinningEventuallyQueue : PFEventuallyQueue
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 + (instancetype)newDefaultPinningEventuallyQueueWithDataSource:(id<PFCommandRunnerProvider>)dataSource;

--- a/Parse/Internal/ParseManager.h
+++ b/Parse/Internal/ParseManager.h
@@ -49,7 +49,7 @@ PFInstallationIdentifierStoreProvider>
 #endif
 
 ///--------------------------------------
-/// @name Initialization
+#pragma mark - Initialization
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -70,25 +70,25 @@ PFInstallationIdentifierStoreProvider>
 - (void)startManaging;
 
 ///--------------------------------------
-/// @name Offline Store
+#pragma mark - Offline Store
 ///--------------------------------------
 
 - (void)loadOfflineStoreWithOptions:(PFOfflineStoreOptions)options;
 
 ///--------------------------------------
-/// @name Eventually Queue
+#pragma mark - Eventually Queue
 ///--------------------------------------
 
 - (void)clearEventuallyQueue;
 
 ///--------------------------------------
-/// @name Core Manager
+#pragma mark - Core Manager
 ///--------------------------------------
 
 - (void)unloadCoreManager;
 
 ///--------------------------------------
-/// @name Preloading
+#pragma mark - Preloading
 ///--------------------------------------
 
 - (BFTask *)preloadDiskObjectsToMemoryAsync;

--- a/Parse/Internal/Persistence/Group/PFPersistenceGroup.h
+++ b/Parse/Internal/Persistence/Group/PFPersistenceGroup.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol PFPersistenceGroup <NSObject>
 
 ///--------------------------------------
-/// @name Data
+#pragma mark - Data
 ///--------------------------------------
 
 - (BFTask<NSData *> *)getDataAsyncForKey:(NSString *)key;
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask *)removeAllDataAsync;
 
 ///--------------------------------------
-/// @name Access
+#pragma mark - Access
 ///--------------------------------------
 
 - (BFTask *)beginLockedContentAccessAsyncToDataForKey:(NSString *)key;

--- a/Parse/Internal/Persistence/Group/PFUserDefaultsPersistenceGroup.h
+++ b/Parse/Internal/Persistence/Group/PFUserDefaultsPersistenceGroup.h
@@ -17,7 +17,7 @@
 @property (nonatomic, strong, readonly) NSUserDefaults *userDefaults;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Parse/Internal/Persistence/PFPersistenceController.h
+++ b/Parse/Internal/Persistence/PFPersistenceController.h
@@ -18,7 +18,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 ///--------------------------------------
-/// @name Controller
+#pragma mark - Controller
 ///--------------------------------------
 
 typedef BFTask<NSNumber *> *__nonnull (^PFPersistenceGroupValidationHandler)(id<PFPersistenceGroup> group);
@@ -29,7 +29,7 @@ typedef BFTask<NSNumber *> *__nonnull (^PFPersistenceGroupValidationHandler)(id<
 @property (nullable, nonatomic, copy, readonly) NSString *applicationGroupIdentifier;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -38,7 +38,7 @@ typedef BFTask<NSNumber *> *__nonnull (^PFPersistenceGroupValidationHandler)(id<
                        groupValidationHandler:(PFPersistenceGroupValidationHandler)handler NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------
-/// @name Data Persistence
+#pragma mark - Data Persistence
 ///--------------------------------------
 
 - (BFTask<id<PFPersistenceGroup>> *)getPersistenceGroupAsync;

--- a/Parse/Internal/Purchase/Controller/PFPurchaseController.h
+++ b/Parse/Internal/Purchase/Controller/PFPurchaseController.h
@@ -36,7 +36,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchaseController : NSObje
 @property (nonatomic, assign) Class productsRequestClass;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -47,7 +47,7 @@ PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPurchaseController : NSObje
                                   bundle:(NSBundle *)bundle;
 
 ///--------------------------------------
-/// @name Products
+#pragma mark - Products
 ///--------------------------------------
 
 - (BFTask *)findProductsAsyncWithIdentifiers:(NSSet *)productIdentifiers;

--- a/Parse/Internal/Push/ChannelsController/PFPushChannelsController.h
+++ b/Parse/Internal/Push/ChannelsController/PFPushChannelsController.h
@@ -25,7 +25,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushChannelsController : NSO
 @property (nonatomic, weak, readonly) id<PFCurrentInstallationControllerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -33,13 +33,13 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushChannelsController : NSO
 + (instancetype)controllerWithDataSource:(id<PFCurrentInstallationControllerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Get
+#pragma mark - Get
 ///--------------------------------------
 
 - (BFTask<NSSet<NSString *> *>*)getSubscribedChannelsAsync;
 
 ///--------------------------------------
-/// @name Subscribe
+#pragma mark - Subscribe
 ///--------------------------------------
 
 - (BFTask *)subscribeToChannelAsyncWithName:(NSString *)name;

--- a/Parse/Internal/Push/Controller/PFPushController.h
+++ b/Parse/Internal/Push/Controller/PFPushController.h
@@ -25,7 +25,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushController : NSObject
 @property (nonatomic, strong, readonly) id<PFCommandRunning> commandRunner;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -34,7 +34,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushController : NSObject
 + (instancetype)controllerWithCommandRunner:(id<PFCommandRunning>)commandRunner;
 
 ///--------------------------------------
-/// @name Sending Push
+#pragma mark - Sending Push
 ///--------------------------------------
 
 /**

--- a/Parse/Internal/Push/Manager/PFPushManager.h
+++ b/Parse/Internal/Push/Manager/PFPushManager.h
@@ -31,7 +31,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushManager : NSObject
 @property (null_resettable, nonatomic, strong) PFPushChannelsController *channelsController;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/Parse/Internal/Push/State/PFMutablePushState.h
+++ b/Parse/Internal/Push/State/PFMutablePushState.h
@@ -26,7 +26,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFMutablePushState : PFPushSta
 @property (nullable, nonatomic, copy, readwrite) NSDictionary *payload;
 
 ///--------------------------------------
-/// @name Payload
+#pragma mark - Payload
 ///--------------------------------------
 
 - (void)setPayloadWithMessage:(nullable NSString *)message;

--- a/Parse/Internal/Push/State/PFPushState.h
+++ b/Parse/Internal/Push/State/PFPushState.h
@@ -32,7 +32,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushState : PFBaseState <NSC
 @property (nullable, nonatomic, copy, readonly) NSDictionary *payload;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithState:(nullable PFPushState *)state;

--- a/Parse/Internal/Query/Controller/PFQueryController.h
+++ b/Parse/Internal/Query/Controller/PFQueryController.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFCommandRunnerProvider> commonDataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)controllerWithCommonDataSource:(id<PFCommandRunnerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Find
+#pragma mark - Find
 ///--------------------------------------
 
 /**
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
                                      user:(nullable PFUser *)user; // TODO: (nlutsenko) Pass `PFUserState` instead of user.
 
 ///--------------------------------------
-/// @name Count
+#pragma mark - Count
 ///--------------------------------------
 
 /**
@@ -73,7 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
                                       user:(nullable PFUser *)user; // TODO: (nlutsenko) Pass `PFUserState` instead of user.
 
 ///--------------------------------------
-/// @name Caching
+#pragma mark - Caching
 ///--------------------------------------
 
 - (NSString *)cacheKeyForQueryState:(PFQueryState *)queryState sessionToken:(nullable NSString *)sessionToken;

--- a/Parse/Internal/Query/State/PFMutableQueryState.h
+++ b/Parse/Internal/Query/State/PFMutableQueryState.h
@@ -17,7 +17,7 @@
 @property (nonatomic, assign, readwrite) NSInteger skip;
 
 ///--------------------------------------
-/// @name Remote + Caching Options
+#pragma mark - Remote + Caching Options
 ///--------------------------------------
 
 @property (nonatomic, assign, readwrite) PFCachePolicy cachePolicy;
@@ -26,7 +26,7 @@
 @property (nonatomic, assign, readwrite) BOOL trace;
 
 ///--------------------------------------
-/// @name Local Datastore Options
+#pragma mark - Local Datastore Options
 ///--------------------------------------
 
 @property (nonatomic, assign, readwrite) BOOL shouldIgnoreACLs;
@@ -35,14 +35,14 @@
 @property (nonatomic, copy, readwrite) NSString *localDatastorePinName;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithParseClassName:(NSString *)className;
 + (instancetype)stateWithParseClassName:(NSString *)className;
 
 ///--------------------------------------
-/// @name Conditions
+#pragma mark - Conditions
 ///--------------------------------------
 
 - (void)setConditionType:(NSString *)type withObject:(id)object forKey:(NSString *)key;
@@ -53,7 +53,7 @@
 - (void)removeAllConditions;
 
 ///--------------------------------------
-/// @name Sort
+#pragma mark - Sort
 ///--------------------------------------
 
 - (void)sortByKey:(NSString *)key ascending:(BOOL)ascending;
@@ -61,19 +61,19 @@
 - (void)addSortKeysFromSortDescriptors:(NSArray *)sortDescriptors;
 
 ///--------------------------------------
-/// @name Includes
+#pragma mark - Includes
 ///--------------------------------------
 
 - (void)includeKey:(NSString *)key;
 
 ///--------------------------------------
-/// @name Selected Keys
+#pragma mark - Selected Keys
 ///--------------------------------------
 
 - (void)selectKeys:(NSArray *)keys;
 
 ///--------------------------------------
-/// @name Redirect
+#pragma mark - Redirect
 ///--------------------------------------
 
 - (void)redirectClassNameForKey:(NSString *)key;

--- a/Parse/Internal/Query/State/PFQueryState.h
+++ b/Parse/Internal/Query/State/PFQueryState.h
@@ -30,7 +30,7 @@
 @property (nonatomic, assign, readonly) NSInteger skip;
 
 ///--------------------------------------
-/// @name Remote + Caching Options
+#pragma mark - Remote + Caching Options
 ///--------------------------------------
 
 @property (nonatomic, assign, readonly) PFCachePolicy cachePolicy;
@@ -39,7 +39,7 @@
 @property (nonatomic, assign, readonly) BOOL trace;
 
 ///--------------------------------------
-/// @name Local Datastore Options
+#pragma mark - Local Datastore Options
 ///--------------------------------------
 
 /**
@@ -56,7 +56,7 @@
 @property (nonatomic, copy, readonly) NSString *localDatastorePinName;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithState:(PFQueryState *)state;

--- a/Parse/Internal/Query/State/PFQueryState_Private.h
+++ b/Parse/Internal/Query/State/PFQueryState_Private.h
@@ -41,7 +41,7 @@
 @property (nonatomic, assign, readwrite) NSInteger skip;
 
 ///--------------------------------------
-/// @name Remote + Caching Options
+#pragma mark - Remote + Caching Options
 ///--------------------------------------
 
 @property (nonatomic, assign, readwrite) PFCachePolicy cachePolicy;
@@ -50,7 +50,7 @@
 @property (nonatomic, assign, readwrite) BOOL trace;
 
 ///--------------------------------------
-/// @name Local Datastore Options
+#pragma mark - Local Datastore Options
 ///--------------------------------------
 
 @property (nonatomic, assign, readwrite) BOOL shouldIgnoreACLs;

--- a/Parse/Internal/Query/Utilities/PFQueryUtilities.h
+++ b/Parse/Internal/Query/Utilities/PFQueryUtilities.h
@@ -12,7 +12,7 @@
 @interface PFQueryUtilities : NSObject
 
 ///--------------------------------------
-/// @name Predicate
+#pragma mark - Predicate
 ///--------------------------------------
 
 /**
@@ -21,7 +21,7 @@
 + (NSPredicate *)predicateByNormalizingPredicate:(NSPredicate *)predicate;
 
 ///--------------------------------------
-/// @name Regex
+#pragma mark - Regex
 ///--------------------------------------
 
 /**
@@ -34,7 +34,7 @@
 + (NSString *)regexStringForString:(NSString *)string;
 
 ///--------------------------------------
-/// @name Errors
+#pragma mark - Errors
 ///--------------------------------------
 
 + (NSError *)objectNotFoundError;

--- a/Parse/Internal/Session/Controller/PFSessionController.h
+++ b/Parse/Internal/Session/Controller/PFSessionController.h
@@ -23,14 +23,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFCommandRunnerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource;
 + (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Current Session
+#pragma mark - Current Session
 ///--------------------------------------
 
 - (BFTask *)getCurrentSessionAsyncWithSessionToken:(nullable NSString *)sessionToken;

--- a/Parse/Internal/Session/PFSession_Private.h
+++ b/Parse/Internal/Session/PFSession_Private.h
@@ -16,7 +16,7 @@
 @interface PFSession ()
 
 ///--------------------------------------
-/// @name Session Controller
+#pragma mark - Session Controller
 ///--------------------------------------
 
 + (PFSessionController *)sessionController;

--- a/Parse/Internal/Session/Utilities/PFSessionUtilities.h
+++ b/Parse/Internal/Session/Utilities/PFSessionUtilities.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFSessionUtilities : NSObject
 
 ///--------------------------------------
-/// @name Session Token
+#pragma mark - Session Token
 ///--------------------------------------
 
 + (BOOL)isSessionTokenRevocable:(nullable NSString *)sessionToken;

--- a/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
+++ b/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFCurrentUserControllerProvider, PFUserControllerProvider> dataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)controllerWithDataSource:(id<PFCurrentUserControllerProvider, PFUserControllerProvider>)dataSource;
 
 ///--------------------------------------
-/// @name Authentication Providers
+#pragma mark - Authentication Providers
 ///--------------------------------------
 
 - (void)registerAuthenticationDelegate:(id<PFUserAuthenticationDelegate>)delegate forAuthType:(NSString *)authType;
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id<PFUserAuthenticationDelegate>)authenticationDelegateForAuthType:(NSString *)authType;
 
 ///--------------------------------------
-/// @name Authentication
+#pragma mark - Authentication
 ///--------------------------------------
 
 - (BFTask<NSNumber *> *)restoreAuthenticationAsyncWithAuthData:(nullable NSDictionary<NSString *, NSString *> *)authData
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask<NSNumber *> *)deauthenticateAsyncWithAuthType:(NSString *)authType;
 
 ///--------------------------------------
-/// @name Log In
+#pragma mark - Log In
 ///--------------------------------------
 
 - (BFTask<PFUser *> *)logInUserAsyncWithAuthType:(NSString *)authType

--- a/Parse/Internal/User/Controller/PFUserController.h
+++ b/Parse/Internal/User/Controller/PFUserController.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak, readonly) id<PFCurrentUserControllerProvider> coreDataSource;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 coreDataSource:(id<PFCurrentUserControllerProvider>)coreDataSource;
 
 ///--------------------------------------
-/// @name Log In
+#pragma mark - Log In
 ///--------------------------------------
 
 - (BFTask *)logInCurrentUserAsyncWithSessionToken:(NSString *)sessionToken;
@@ -45,13 +45,13 @@ NS_ASSUME_NONNULL_BEGIN
                              revocableSession:(BOOL)revocableSession;
 
 ///--------------------------------------
-/// @name Reset Password
+#pragma mark - Reset Password
 ///--------------------------------------
 
 - (BFTask *)requestPasswordResetAsyncForEmail:(NSString *)email;
 
 ///--------------------------------------
-/// @name Log Out
+#pragma mark - Log Out
 ///--------------------------------------
 
 - (BFTask *)logOutUserAsyncWithSessionToken:(NSString *)sessionToken;

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
@@ -31,7 +31,7 @@ typedef NS_OPTIONS(NSUInteger, PFCurrentUserLoadingOptions) {
 @property (atomic, assign) BOOL automaticUsersEnabled;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -43,7 +43,7 @@ typedef NS_OPTIONS(NSUInteger, PFCurrentUserLoadingOptions) {
                            coreDataSource:(id<PFObjectFilePersistenceControllerProvider>)coreDataSource;
 
 ///--------------------------------------
-/// @name User
+#pragma mark - User
 ///--------------------------------------
 
 - (BFTask *)getCurrentUserAsyncWithOptions:(PFCurrentUserLoadingOptions)options;
@@ -51,7 +51,7 @@ typedef NS_OPTIONS(NSUInteger, PFCurrentUserLoadingOptions) {
 - (BFTask *)logOutCurrentUserAsync;
 
 ///--------------------------------------
-/// @name Session Token
+#pragma mark - Session Token
 ///--------------------------------------
 
 - (BFTask *)getCurrentUserSessionTokenAsync;

--- a/Parse/Internal/User/PFUserPrivate.h
+++ b/Parse/Internal/User/PFUserPrivate.h
@@ -24,7 +24,7 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 @interface PFUser (Private)
 
 ///--------------------------------------
-/// @name Current User
+#pragma mark - Current User
 ///--------------------------------------
 + (BFTask *)_getCurrentUserSessionTokenAsync;
 + (NSString *)currentSessionToken;
@@ -41,7 +41,7 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 - (void)restoreAnonymity:(id)data;
 
 ///--------------------------------------
-/// @name Revocable Session
+#pragma mark - Revocable Session
 ///--------------------------------------
 + (BOOL)_isRevocableSessionEnabled;
 + (void)_setRevocableSessionEnabled:(BOOL)enabled;
@@ -71,7 +71,7 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 - (BFTask *)_logOutAsync;
 
 ///--------------------------------------
-/// @name Third-party Authentication (Private)
+#pragma mark - Third-party Authentication (Private)
 ///--------------------------------------
 
 + (void)_unregisterAuthenticationDelegateForAuthType:(NSString *)authType;

--- a/Parse/Internal/User/State/PFUserState.h
+++ b/Parse/Internal/User/State/PFUserState.h
@@ -21,7 +21,7 @@ typedef void(^PFUserStateMutationBlock)(PFMutableUserState *state);
 @property (nonatomic, assign, readonly) BOOL isNew;
 
 ///--------------------------------------
-/// @name Init
+#pragma mark - Init
 ///--------------------------------------
 
 - (instancetype)initWithState:(PFUserState *)state;
@@ -29,7 +29,7 @@ typedef void(^PFUserStateMutationBlock)(PFMutableUserState *state);
 + (instancetype)stateWithState:(PFUserState *)state;
 
 ///--------------------------------------
-/// @name Mutating
+#pragma mark - Mutating
 ///--------------------------------------
 
 - (PFUserState *)copyByMutatingWithBlock:(PFUserStateMutationBlock)block;

--- a/Parse/PFACL.h
+++ b/Parse/PFACL.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFACL : NSObject <NSCopying, NSCoding>
 
 ///--------------------------------------
-/// @name Creating an ACL
+#pragma mark - Creating an ACL
 ///--------------------------------------
 
 /**
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)ACLWithUser:(PFUser *)user;
 
 ///--------------------------------------
-/// @name Controlling Public Access
+#pragma mark - Controlling Public Access
 ///--------------------------------------
 
 /**
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, getter=getPublicWriteAccess) BOOL publicWriteAccess;
 
 ///--------------------------------------
-/// @name Controlling Access Per-User
+#pragma mark - Controlling Access Per-User
 ///--------------------------------------
 
 /**
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)getWriteAccessForUser:(PFUser *)user;
 
 ///--------------------------------------
-/// @name Controlling Access Per-Role
+#pragma mark - Controlling Access Per-Role
 ///--------------------------------------
 
 /**
@@ -223,7 +223,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setWriteAccess:(BOOL)allowed forRole:(PFRole *)role;
 
 ///--------------------------------------
-/// @name Setting Access Defaults
+#pragma mark - Setting Access Defaults
 ///--------------------------------------
 
 /**

--- a/Parse/PFAnalytics.h
+++ b/Parse/PFAnalytics.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFAnalytics : NSObject
 
 ///--------------------------------------
-/// @name App-Open / Push Analytics
+#pragma mark - App-Open / Push Analytics
 ///--------------------------------------
 
 /**
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                           block:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
-/// @name Custom Analytics
+#pragma mark - Custom Analytics
 ///--------------------------------------
 
 /**

--- a/Parse/PFAnonymousUtils+Deprecated.h
+++ b/Parse/PFAnonymousUtils+Deprecated.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFAnonymousUtils (Deprecated)
 
 ///--------------------------------------
-/// @name Creating an Anonymous User
+#pragma mark - Creating an Anonymous User
 ///--------------------------------------
 
 /**

--- a/Parse/PFAnonymousUtils.h
+++ b/Parse/PFAnonymousUtils.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFAnonymousUtils : NSObject
 
 ///--------------------------------------
-/// @name Creating an Anonymous User
+#pragma mark - Creating an Anonymous User
 ///--------------------------------------
 
 /**
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)logInWithBlock:(nullable PFUserResultBlock)block;
 
 ///--------------------------------------
-/// @name Determining Whether a User is Anonymous
+#pragma mark - Determining Whether a User is Anonymous
 ///--------------------------------------
 
 /**

--- a/Parse/PFConfig+Synchronous.h
+++ b/Parse/PFConfig+Synchronous.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFConfig (Synchronous)
 
 ///--------------------------------------
-/// @name Retrieving Config
+#pragma mark - Retrieving Config
 ///--------------------------------------
 
 /**

--- a/Parse/PFConfig.h
+++ b/Parse/PFConfig.h
@@ -26,7 +26,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 @interface PFConfig : NSObject
 
 ///--------------------------------------
-/// @name Current Config
+#pragma mark - Current Config
 ///--------------------------------------
 
 /**
@@ -39,7 +39,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 + (PFConfig *)currentConfig;
 
 ///--------------------------------------
-/// @name Retrieving Config
+#pragma mark - Retrieving Config
 ///--------------------------------------
 
 /**
@@ -58,7 +58,7 @@ typedef void(^PFConfigResultBlock)(PFConfig *__nullable config, NSError *__nulla
 + (void)getConfigInBackgroundWithBlock:(nullable PFConfigResultBlock)block;
 
 ///--------------------------------------
-/// @name Parameters
+#pragma mark - Parameters
 ///--------------------------------------
 
 /**

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -13,7 +13,7 @@
 @class PFUser;
 
 ///--------------------------------------
-/// @name Version
+#pragma mark - Version
 ///--------------------------------------
 
 #define PARSE_VERSION @"1.11.0"
@@ -21,7 +21,7 @@
 extern NSInteger const PARSE_API_VERSION;
 
 ///--------------------------------------
-/// @name Platform
+#pragma mark - Platform
 ///--------------------------------------
 
 #define PARSE_IOS_ONLY (TARGET_OS_IPHONE)
@@ -30,7 +30,7 @@ extern NSInteger const PARSE_API_VERSION;
 extern NSString *const __nonnull kPFDeviceType;
 
 ///--------------------------------------
-/// @name Cache Policies
+#pragma mark - Cache Policies
 ///--------------------------------------
 
 /**
@@ -78,7 +78,7 @@ typedef NS_ENUM(uint8_t, PFCachePolicy) {
 };
 
 ///--------------------------------------
-/// @name Logging Levels
+#pragma mark - Logging Levels
 ///--------------------------------------
 
 /**
@@ -120,7 +120,7 @@ typedef NS_ENUM(uint8_t, PFLogLevel) {
 };
 
 ///--------------------------------------
-/// @name Errors
+#pragma mark - Errors
 ///--------------------------------------
 
 extern NSString *const __nonnull PFParseErrorDomain;
@@ -356,7 +356,7 @@ typedef NS_ENUM(NSInteger, PFErrorCode) {
 };
 
 ///--------------------------------------
-/// @name Blocks
+#pragma mark - Blocks
 ///--------------------------------------
 
 typedef void (^PFBooleanResultBlock)(BOOL succeeded, NSError *__nullable error);
@@ -373,7 +373,7 @@ typedef void (^PFIdResultBlock)(__nullable id object, NSError *__nullable error)
 typedef void (^PFProgressBlock)(int percentDone);
 
 ///--------------------------------------
-/// @name Network Notifications
+#pragma mark - Network Notifications
 ///--------------------------------------
 
 /**
@@ -406,7 +406,7 @@ extern NSString *const __nonnull PFNetworkNotificationURLResponseBodyUserInfoKey
 
 
 ///--------------------------------------
-/// @name Deprecated Macros
+#pragma mark - Deprecated Macros
 ///--------------------------------------
 
 #ifndef PARSE_DEPRECATED
@@ -422,7 +422,7 @@ extern NSString *const __nonnull PFNetworkNotificationURLResponseBodyUserInfoKey
 #endif
 
 ///--------------------------------------
-/// @name Extensions Macros
+#pragma mark - Extensions Macros
 ///--------------------------------------
 
 #ifndef PF_EXTENSION_UNAVAILABLE
@@ -442,7 +442,7 @@ extern NSString *const __nonnull PFNetworkNotificationURLResponseBodyUserInfoKey
 #endif
 
 ///--------------------------------------
-/// @name Swift Macros
+#pragma mark - Swift Macros
 ///--------------------------------------
 
 #ifndef PF_SWIFT_UNAVAILABLE
@@ -454,7 +454,7 @@ extern NSString *const __nonnull PFNetworkNotificationURLResponseBodyUserInfoKey
 #endif
 
 ///--------------------------------------
-/// @name Platform Availability Defines
+#pragma mark - Platform Availability Defines
 ///--------------------------------------
 
 #ifndef TARGET_OS_IOS
@@ -472,7 +472,7 @@ extern NSString *const __nonnull PFNetworkNotificationURLResponseBodyUserInfoKey
 #endif
 
 ///--------------------------------------
-/// @name Avaiability Macros
+#pragma mark - Avaiability Macros
 ///--------------------------------------
 
 #ifndef PF_IOS_UNAVAILABLE

--- a/Parse/PFFile+Deprecated.h
+++ b/Parse/PFFile+Deprecated.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFFile (Deprecated)
 
 ///--------------------------------------
-/// @name Saving Files
+#pragma mark - Saving Files
 ///--------------------------------------
 
 /**
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
                           selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFFile.-saveInBackgroundWithBlock:` instead.");
 
 ///--------------------------------------
-/// @name Getting Files
+#pragma mark - Getting Files
 ///--------------------------------------
 
 /**

--- a/Parse/PFFile+Synchronous.h
+++ b/Parse/PFFile+Synchronous.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFFile (Synchronous)
 
 ///--------------------------------------
-/// @name Storing Data with Parse
+#pragma mark - Storing Data with Parse
 ///--------------------------------------
 
 /**
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)save:(NSError **)error;
 
 ///--------------------------------------
-/// @name Getting Data from Parse
+#pragma mark - Getting Data from Parse
 ///--------------------------------------
 
 /**

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFFile : NSObject
 
 ///--------------------------------------
-/// @name Creating a PFFile
+#pragma mark - Creating a PFFile
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)fileWithData:(NSData *)data contentType:(nullable NSString *)contentType;
 
 ///--------------------------------------
-/// @name File Properties
+#pragma mark - File Properties
 ///--------------------------------------
 
 /**
@@ -148,7 +148,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly, getter=isDirty) BOOL dirty;
 
 ///--------------------------------------
-/// @name Storing Data with Parse
+#pragma mark - Storing Data with Parse
 ///--------------------------------------
 
 /**
@@ -187,7 +187,7 @@ NS_ASSUME_NONNULL_BEGIN
                     progressBlock:(nullable PFProgressBlock)progressBlock;
 
 ///--------------------------------------
-/// @name Getting Data from Parse
+#pragma mark - Getting Data from Parse
 ///--------------------------------------
 
 /**
@@ -358,7 +358,7 @@ NS_ASSUME_NONNULL_BEGIN
                            progressBlock:(nullable PFProgressBlock)progressBlock;
 
 ///--------------------------------------
-/// @name Interrupting a Transfer
+#pragma mark - Interrupting a Transfer
 ///--------------------------------------
 
 /**

--- a/Parse/PFGeoPoint.h
+++ b/Parse/PFGeoPoint.h
@@ -25,7 +25,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 @interface PFGeoPoint : NSObject <NSCopying, NSCoding>
 
 ///--------------------------------------
-/// @name Creating a Geo Point
+#pragma mark - Creating a Geo Point
 ///--------------------------------------
 
 /**
@@ -63,7 +63,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 + (void)geoPointForCurrentLocationInBackground:(nullable PFGeoPointResultBlock)resultBlock;
 
 ///--------------------------------------
-/// @name Controlling Position
+#pragma mark - Controlling Position
 ///--------------------------------------
 
 /**
@@ -77,7 +77,7 @@ typedef void(^PFGeoPointResultBlock)(PFGeoPoint *__nullable geoPoint, NSError *_
 @property (nonatomic, assign) double longitude;
 
 ///--------------------------------------
-/// @name Calculating Distance
+#pragma mark - Calculating Distance
 ///--------------------------------------
 
 /**

--- a/Parse/PFInstallation.h
+++ b/Parse/PFInstallation.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSubclassing>
 
 ///--------------------------------------
-/// @name Accessing the Current Installation
+#pragma mark - Accessing the Current Installation
 ///--------------------------------------
 
 /**
@@ -53,7 +53,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 + (instancetype)currentInstallation;
 
 ///--------------------------------------
-/// @name Installation Properties
+#pragma mark - Installation Properties
 ///--------------------------------------
 
 /**
@@ -94,7 +94,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
 - (void)setDeviceTokenFromData:(nullable NSData *)deviceTokenData;
 
 ///--------------------------------------
-/// @name Querying for Installations
+#pragma mark - Querying for Installations
 ///--------------------------------------
 
 /**

--- a/Parse/PFObject+Deprecated.h
+++ b/Parse/PFObject+Deprecated.h
@@ -16,7 +16,7 @@
 @interface PFObject (Deprecated)
 
 ///--------------------------------------
-/// @name Saving Objects
+#pragma mark - Saving Objects
 ///--------------------------------------
 
 /**
@@ -34,7 +34,7 @@
                           selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.-saveInBackgroundWithBlock:` instead.");
 
 ///--------------------------------------
-/// @name Saving Many Objects
+#pragma mark - Saving Many Objects
 ///--------------------------------------
 
 /**
@@ -54,7 +54,7 @@
                    selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.+saveAllInBackground:block:` instead.");
 
 ///--------------------------------------
-/// @name Getting an Object
+#pragma mark - Getting an Object
 ///--------------------------------------
 
 /**
@@ -100,7 +100,7 @@
                                    selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.-fetchIfNeededInBackgroundWithBlock:` instead.");
 
 ///--------------------------------------
-/// @name Getting Many Objects
+#pragma mark - Getting Many Objects
 ///--------------------------------------
 
 /**
@@ -138,7 +138,7 @@
                             selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.+fetchAllIfNeededInBackground:block:` instead.");
 
 ///--------------------------------------
-/// @name Deleting an Object
+#pragma mark - Deleting an Object
 ///--------------------------------------
 
 /**
@@ -156,7 +156,7 @@
                             selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFObject.-deleteInBackgroundWithBlock:` instead.");
 
 ///--------------------------------------
-/// @name Deleting Many Objects
+#pragma mark - Deleting Many Objects
 ///--------------------------------------
 
 /**

--- a/Parse/PFObject+Subclass.h
+++ b/Parse/PFObject+Subclass.h
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFObject (Subclass)
 
 ///--------------------------------------
-/// @name Methods for Subclasses
+#pragma mark - Methods for Subclasses
 ///--------------------------------------
 
 /**

--- a/Parse/PFObject+Synchronous.h
+++ b/Parse/PFObject+Synchronous.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFObject (Synchronous)
 
 ///--------------------------------------
-/// @name Saving Objects
+#pragma mark - Saving Objects
 ///--------------------------------------
 
 /**
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)save:(NSError **)error;
 
 ///--------------------------------------
-/// @name Saving Many Objects
+#pragma mark - Saving Many Objects
 ///--------------------------------------
 
 /**
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)saveAll:(nullable NSArray<PFObject *> *)objects error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Getting an Object
+#pragma mark - Getting an Object
 ///--------------------------------------
 
 /**
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)fetchIfNeeded:(NSError **)error;
 
 ///--------------------------------------
-/// @name Getting Many Objects
+#pragma mark - Getting Many Objects
 ///--------------------------------------
 
 /**
@@ -127,7 +127,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                       error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Fetching From Local Datastore
+#pragma mark - Fetching From Local Datastore
 ///--------------------------------------
 
 /**
@@ -148,7 +148,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)fetchFromLocalDatastore:(NSError **)error;
 
 ///--------------------------------------
-/// @name Deleting an Object
+#pragma mark - Deleting an Object
 ///--------------------------------------
 
 /**
@@ -168,7 +168,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)delete:(NSError **)error;
 
 ///--------------------------------------
-/// @name Deleting Many Objects
+#pragma mark - Deleting Many Objects
 ///--------------------------------------
 
 /**
@@ -191,7 +191,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)deleteAll:(nullable NSArray<PFObject *> *)objects error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Pinning
+#pragma mark - Pinning
 ///--------------------------------------
 
 /**
@@ -262,7 +262,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)pinWithName:(NSString *)name error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Pinning Many Objects
+#pragma mark - Pinning Many Objects
 ///--------------------------------------
 
 /**
@@ -338,7 +338,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)pinAll:(nullable NSArray<PFObject *> *)objects withName:(NSString *)name error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Unpinning
+#pragma mark - Unpinning
 ///--------------------------------------
 
 /**
@@ -389,7 +389,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)unpinWithName:(NSString *)name error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Unpinning Many Objects
+#pragma mark - Unpinning Many Objects
 ///--------------------------------------
 
 /**

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -32,7 +32,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 @interface PFObject : NSObject
 
 ///--------------------------------------
-/// @name Creating a PFObject
+#pragma mark - Creating a PFObject
 ///--------------------------------------
 
 /**
@@ -80,7 +80,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 + (instancetype)objectWithoutDataWithClassName:(NSString *)className objectId:(nullable NSString *)objectId;
 
 ///--------------------------------------
-/// @name Managing Object Properties
+#pragma mark - Managing Object Properties
 ///--------------------------------------
 
 /**
@@ -117,7 +117,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 @property (nonatomic, copy, readonly) NSArray<NSString *> *allKeys;
 
 ///--------------------------------------
-/// @name Accessors
+#pragma mark - Accessors
 ///--------------------------------------
 
 /**
@@ -207,7 +207,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)revertObjectForKey:(NSString *)key;
 
 ///--------------------------------------
-/// @name Array Accessors
+#pragma mark - Array Accessors
 ///--------------------------------------
 
 /**
@@ -264,7 +264,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)removeObjectsInArray:(NSArray *)objects forKey:(NSString *)key;
 
 ///--------------------------------------
-/// @name Increment
+#pragma mark - Increment
 ///--------------------------------------
 
 /**
@@ -283,7 +283,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)incrementKey:(NSString *)key byAmount:(NSNumber *)amount;
 
 ///--------------------------------------
-/// @name Saving Objects
+#pragma mark - Saving Objects
 ///--------------------------------------
 
 /**
@@ -340,7 +340,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)saveEventually:(nullable PFBooleanResultBlock)callback PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE;
 
 ///--------------------------------------
-/// @name Saving Many Objects
+#pragma mark - Saving Many Objects
 ///--------------------------------------
 
 /**
@@ -363,7 +363,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                       block:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
-/// @name Deleting Many Objects
+#pragma mark - Deleting Many Objects
 ///--------------------------------------
 
 /**
@@ -384,7 +384,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                         block:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
-/// @name Getting an Object
+#pragma mark - Getting an Object
 ///--------------------------------------
 
 /**
@@ -456,7 +456,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)fetchIfNeededInBackgroundWithBlock:(nullable PFObjectResultBlock)block;
 
 ///--------------------------------------
-/// @name Getting Many Objects
+#pragma mark - Getting Many Objects
 ///--------------------------------------
 
 /**
@@ -500,7 +500,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                                block:(nullable PFArrayResultBlock)block;
 
 ///--------------------------------------
-/// @name Fetching From Local Datastore
+#pragma mark - Fetching From Local Datastore
 ///--------------------------------------
 
 /**
@@ -521,7 +521,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)fetchFromLocalDatastoreInBackgroundWithBlock:(nullable PFObjectResultBlock)block;
 
 ///--------------------------------------
-/// @name Deleting an Object
+#pragma mark - Deleting an Object
 ///--------------------------------------
 
 /**
@@ -559,7 +559,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BFTask<NSNumber *> *)deleteEventually PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE;
 
 ///--------------------------------------
-/// @name Dirtiness
+#pragma mark - Dirtiness
 ///--------------------------------------
 
 /**
@@ -580,7 +580,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (BOOL)isDirtyForKey:(NSString *)key;
 
 ///--------------------------------------
-/// @name Pinning
+#pragma mark - Pinning
 ///--------------------------------------
 
 /**
@@ -649,7 +649,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)pinInBackgroundWithName:(NSString *)name block:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
-/// @name Pinning Many Objects
+#pragma mark - Pinning Many Objects
 ///--------------------------------------
 
 /**
@@ -725,7 +725,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
                      block:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
-/// @name Unpinning
+#pragma mark - Unpinning
 ///--------------------------------------
 
 /**
@@ -774,7 +774,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 - (void)unpinInBackgroundWithName:(NSString *)name block:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
-/// @name Unpinning Many Objects
+#pragma mark - Unpinning Many Objects
 ///--------------------------------------
 
 /**

--- a/Parse/PFProduct.h
+++ b/Parse/PFProduct.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 PF_OSX_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFProduct : PFObject<PFSubclassing>
 
 ///--------------------------------------
-/// @name Product-specific Properties
+#pragma mark - Product-specific Properties
 ///--------------------------------------
 
 /**

--- a/Parse/PFPush+Deprecated.h
+++ b/Parse/PFPush+Deprecated.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFPush (Deprecated)
 
 ///--------------------------------------
-/// @name Sending Push Notifications
+#pragma mark - Sending Push Notifications
 ///--------------------------------------
 
 /**
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
                                  selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFPush.+sendPushDataToChannelInBackground:withData:block:` instead.");
 
 ///--------------------------------------
-/// @name Managing Channel Subscriptions
+#pragma mark - Managing Channel Subscriptions
 ///--------------------------------------
 
 /**

--- a/Parse/PFPush+Synchronous.h
+++ b/Parse/PFPush+Synchronous.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFPush (Synchronous)
 
 ///--------------------------------------
-/// @name Sending Push Notifications
+#pragma mark - Sending Push Notifications
 ///--------------------------------------
 
 /**
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)sendPushDataToQuery:(PFQuery<PFInstallation *> *)query withData:(NSDictionary *)data error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Managing Channel Subscriptions
+#pragma mark - Managing Channel Subscriptions
 ///--------------------------------------
 
 /**

--- a/Parse/PFPush.h
+++ b/Parse/PFPush.h
@@ -30,13 +30,13 @@ NS_ASSUME_NONNULL_BEGIN
 PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject<NSCopying>
 
 ///--------------------------------------
-/// @name Creating a Push Notification
+#pragma mark - Creating a Push Notification
 ///--------------------------------------
 
 + (instancetype)push;
 
 ///--------------------------------------
-/// @name Configuring a Push Notification
+#pragma mark - Configuring a Push Notification
 ///--------------------------------------
 
 /**
@@ -144,7 +144,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject<NSCopying>
 @property (nullable, nonatomic, strong) NSDate *pushDate;
 
 ///--------------------------------------
-/// @name Sending Push Notifications
+#pragma mark - Sending Push Notifications
 ///--------------------------------------
 
 /**
@@ -265,7 +265,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject<NSCopying>
                                   block:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
-/// @name Handling Notifications
+#pragma mark - Handling Notifications
 ///--------------------------------------
 
 /**
@@ -283,7 +283,7 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPush : NSObject<NSCopying>
 + (void)handlePush:(nullable NSDictionary *)userInfo NS_AVAILABLE_IOS(3_0) PF_EXTENSION_UNAVAILABLE("");
 
 ///--------------------------------------
-/// @name Managing Channel Subscriptions
+#pragma mark - Managing Channel Subscriptions
 ///--------------------------------------
 
 /**

--- a/Parse/PFQuery+Deprecated.h
+++ b/Parse/PFQuery+Deprecated.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFQuery (Deprecated)
 
 ///--------------------------------------
-/// @name Getting Objects by ID
+#pragma mark - Getting Objects by ID
 ///--------------------------------------
 
 /**
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
                            selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFQuery.-getObjectInBackgroundWithId:block:` instead.");
 
 ///--------------------------------------
-/// @name Getting all Matches for a Query
+#pragma mark - Getting all Matches for a Query
 ///--------------------------------------
 
 /**
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
                                  selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFQuery.-findObjectsInBackgroundWithBlock:` instead.");
 
 ///--------------------------------------
-/// @name Getting the First Match in a Query
+#pragma mark - Getting the First Match in a Query
 ///--------------------------------------
 
 /**
@@ -76,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
                                     selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFQuery.-getFirstObjectInBackgroundWithBlock:` instead.");
 
 ///--------------------------------------
-/// @name Counting the Matches in a Query
+#pragma mark - Counting the Matches in a Query
 ///--------------------------------------
 
 /**

--- a/Parse/PFQuery+Synchronous.h
+++ b/Parse/PFQuery+Synchronous.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFQuery<PFGenericObject : PFObject *> (Synchronous)
 
 ///--------------------------------------
-/// @name Getting Objects by ID
+#pragma mark - Getting Objects by ID
 ///--------------------------------------
 
 /**
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable PFGenericObject)getObjectWithId:(NSString *)objectId error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Getting User Objects
+#pragma mark - Getting User Objects
 ///--------------------------------------
 
 /**
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable PFUser *)getUserObjectWithId:(NSString *)objectId error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Getting all Matches for a Query
+#pragma mark - Getting all Matches for a Query
 ///--------------------------------------
 
 /**
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSArray<PFGenericObject> *)findObjects:(NSError **)error;
 
 ///--------------------------------------
-/// @name Getting the First Match in a Query
+#pragma mark - Getting the First Match in a Query
 ///--------------------------------------
 
 /**
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable PFGenericObject)getFirstObject:(NSError **)error;
 
 ///--------------------------------------
-/// @name Counting the Matches in a Query
+#pragma mark - Counting the Matches in a Query
 ///--------------------------------------
 
 /**

--- a/Parse/PFQuery.h
+++ b/Parse/PFQuery.h
@@ -24,13 +24,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFQuery<PFGenericObject : PFObject *> : NSObject<NSCopying>
 
 ///--------------------------------------
-/// @name Blocks
+#pragma mark - Blocks
 ///--------------------------------------
 
 typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable objects, NSError * __nullable error);
 
 ///--------------------------------------
-/// @name Creating a Query for a Class
+#pragma mark - Creating a Query for a Class
 ///--------------------------------------
 
 /**
@@ -79,7 +79,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 @property (nonatomic, strong) NSString *parseClassName;
 
 ///--------------------------------------
-/// @name Adding Basic Constraints
+#pragma mark - Adding Basic Constraints
 ///--------------------------------------
 
 /**
@@ -221,7 +221,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (instancetype)whereKey:(NSString *)key containsAllObjectsInArray:(NSArray *)array;
 
 ///--------------------------------------
-/// @name Adding Location Constraints
+#pragma mark - Adding Location Constraints
 ///--------------------------------------
 
 /**
@@ -300,7 +300,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (instancetype)whereKey:(NSString *)key withinGeoBoxFromSouthwest:(PFGeoPoint *)southwest toNortheast:(PFGeoPoint *)northeast;
 
 ///--------------------------------------
-/// @name Adding String Constraints
+#pragma mark - Adding String Constraints
 ///--------------------------------------
 
 /**
@@ -369,7 +369,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (instancetype)whereKey:(NSString *)key hasSuffix:(nullable NSString *)suffix;
 
 ///--------------------------------------
-/// @name Adding Subqueries
+#pragma mark - Adding Subqueries
 ///--------------------------------------
 
 /**
@@ -434,7 +434,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (instancetype)whereKey:(NSString *)key doesNotMatchQuery:(PFQuery *)query;
 
 ///--------------------------------------
-/// @name Sorting
+#pragma mark - Sorting
 ///--------------------------------------
 
 /**
@@ -496,7 +496,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (instancetype)orderBySortDescriptors:(nullable NSArray<NSSortDescriptor *> *)sortDescriptors;
 
 ///--------------------------------------
-/// @name Getting Objects by ID
+#pragma mark - Getting Objects by ID
 ///--------------------------------------
 
 /**
@@ -525,7 +525,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
                               block:(nullable void (^)(PFGenericObject __nullable object, NSError *__nullable error))block;
 
 ///--------------------------------------
-/// @name Getting User Objects
+#pragma mark - Getting User Objects
 ///--------------------------------------
 
 /**
@@ -534,7 +534,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 + (instancetype)queryForUser PARSE_DEPRECATED("Use [PFUser query] instead.");
 
 ///--------------------------------------
-/// @name Getting all Matches for a Query
+#pragma mark - Getting all Matches for a Query
 ///--------------------------------------
 
 /**
@@ -553,7 +553,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (void)findObjectsInBackgroundWithBlock:(nullable PFQueryArrayResultBlock)block;
 
 ///--------------------------------------
-/// @name Getting the First Match in a Query
+#pragma mark - Getting the First Match in a Query
 ///--------------------------------------
 
 /**
@@ -578,7 +578,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (void)getFirstObjectInBackgroundWithBlock:(nullable void (^)(PFGenericObject __nullable object, NSError *__nullable error))block;
 
 ///--------------------------------------
-/// @name Counting the Matches in a Query
+#pragma mark - Counting the Matches in a Query
 ///--------------------------------------
 
 /**
@@ -597,7 +597,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (void)countObjectsInBackgroundWithBlock:(nullable PFIntegerResultBlock)block;
 
 ///--------------------------------------
-/// @name Cancelling a Query
+#pragma mark - Cancelling a Query
 ///--------------------------------------
 
 /**
@@ -606,7 +606,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (void)cancel;
 
 ///--------------------------------------
-/// @name Paginating Results
+#pragma mark - Paginating Results
 ///--------------------------------------
 
 /**
@@ -623,7 +623,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 @property (nonatomic, assign) NSInteger skip;
 
 ///--------------------------------------
-/// @name Controlling Caching Behavior
+#pragma mark - Controlling Caching Behavior
 ///--------------------------------------
 
 /**
@@ -660,7 +660,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 + (void)clearAllCachedResults;
 
 ///--------------------------------------
-/// @name Query Source
+#pragma mark - Query Source
 ///--------------------------------------
 
 /**
@@ -712,7 +712,7 @@ typedef void (^PFQueryArrayResultBlock)(NSArray<PFGenericObject> *__nullable obj
 - (instancetype)ignoreACLs;
 
 ///--------------------------------------
-/// @name Advanced Settings
+#pragma mark - Advanced Settings
 ///--------------------------------------
 
 /**

--- a/Parse/PFRelation.h
+++ b/Parse/PFRelation.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy) NSString *targetClass;
 
 ///--------------------------------------
-/// @name Accessing Objects
+#pragma mark - Accessing Objects
 ///--------------------------------------
 
 /**
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (PFQuery *)query;
 
 ///--------------------------------------
-/// @name Modifying Relations
+#pragma mark - Modifying Relations
 ///--------------------------------------
 
 /**

--- a/Parse/PFRole.h
+++ b/Parse/PFRole.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFRole : PFObject <PFSubclassing>
 
 ///--------------------------------------
-/// @name Creating a New Role
+#pragma mark - Creating a New Role
 ///--------------------------------------
 
 /**
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)roleWithName:(NSString *)name acl:(nullable PFACL *)acl;
 
 ///--------------------------------------
-/// @name Role-specific Properties
+#pragma mark - Role-specific Properties
 ///--------------------------------------
 
 /**

--- a/Parse/PFUser+Deprecated.h
+++ b/Parse/PFUser+Deprecated.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFUser (Deprecated)
 
 ///--------------------------------------
-/// @name Creating a New User
+#pragma mark - Creating a New User
 ///--------------------------------------
 
 /**
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
                             selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFUser.-signUpInBackgroundWithBlock:` instead.");
 
 ///--------------------------------------
-/// @name Logging In
+#pragma mark - Logging In
 ///--------------------------------------
 
 /**
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
                              selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFUser.+logInWithUsernameInBackground:password:block:` instead.");
 
 ///--------------------------------------
-/// @name Becoming a User
+#pragma mark - Becoming a User
 ///--------------------------------------
 
 /**
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
                   selector:(nullable SEL)selector PARSE_DEPRECATED("Please use `PFUser.+becomeInBackground:block:` instead.");
 
 ///--------------------------------------
-/// @name Requesting a Password Reset
+#pragma mark - Requesting a Password Reset
 ///--------------------------------------
 
 /**

--- a/Parse/PFUser+Synchronous.h
+++ b/Parse/PFUser+Synchronous.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFUser (Synchronous)
 
 ///--------------------------------------
-/// @name Creating a New User
+#pragma mark - Creating a New User
 ///--------------------------------------
 
 /**
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)signUp:(NSError **)error;
 
 ///--------------------------------------
-/// @name Logging In
+#pragma mark - Logging In
 ///--------------------------------------
 
 /**
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)logInWithUsername:(NSString *)username password:(NSString *)password error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Becoming a User
+#pragma mark - Becoming a User
 ///--------------------------------------
 
 /**
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)become:(NSString *)sessionToken error:(NSError **)error;
 
 ///--------------------------------------
-/// @name Logging Out
+#pragma mark - Logging Out
 ///--------------------------------------
 
 /**
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)logOut;
 
 ///--------------------------------------
-/// @name Requesting a Password Reset
+#pragma mark - Requesting a Password Reset
 ///--------------------------------------
 
 /**

--- a/Parse/PFUser.h
+++ b/Parse/PFUser.h
@@ -35,7 +35,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 @interface PFUser : PFObject <PFSubclassing>
 
 ///--------------------------------------
-/// @name Accessing the Current User
+#pragma mark - Accessing the Current User
 ///--------------------------------------
 
 /**
@@ -68,7 +68,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 @property (nonatomic, assign, readonly, getter=isAuthenticated) BOOL authenticated;
 
 ///--------------------------------------
-/// @name Creating a New User
+#pragma mark - Creating a New User
 ///--------------------------------------
 
 /**
@@ -132,7 +132,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 - (void)signUpInBackgroundWithBlock:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
-/// @name Logging In
+#pragma mark - Logging In
 ///--------------------------------------
 
 /**
@@ -162,7 +162,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (void)logInWithUsernameInBackground:(NSString *)username password:(NSString *)password block:(nullable PFUserResultBlock)block;
 
 ///--------------------------------------
-/// @name Becoming a User
+#pragma mark - Becoming a User
 ///--------------------------------------
 
 /**
@@ -190,7 +190,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (void)becomeInBackground:(NSString *)sessionToken block:(nullable PFUserResultBlock)block;
 
 ///--------------------------------------
-/// @name Revocable Session
+#pragma mark - Revocable Session
 ///--------------------------------------
 
 /**
@@ -217,7 +217,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (void)enableRevocableSessionInBackgroundWithBlock:(nullable PFUserSessionUpgradeResultBlock)block;
 
 ///--------------------------------------
-/// @name Logging Out
+#pragma mark - Logging Out
 ///--------------------------------------
 
 /**
@@ -243,7 +243,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (void)logOutInBackgroundWithBlock:(nullable PFUserLogoutResultBlock)block;
 
 ///--------------------------------------
-/// @name Requesting a Password Reset
+#pragma mark - Requesting a Password Reset
 ///--------------------------------------
 
 /**
@@ -268,7 +268,7 @@ typedef void(^PFUserLogoutResultBlock)(NSError *__nullable error);
 + (void)requestPasswordResetForEmailInBackground:(NSString *)email block:(nullable PFBooleanResultBlock)block;
 
 ///--------------------------------------
-/// @name Third-party Authentication
+#pragma mark - Third-party Authentication
 ///--------------------------------------
 
 /**

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface Parse : NSObject
 
 ///--------------------------------------
-/// @name Connecting to Parse
+#pragma mark - Connecting to Parse
 ///--------------------------------------
 
 /**
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)getClientKey;
 
 ///--------------------------------------
-/// @name Enabling Local Datastore
+#pragma mark - Enabling Local Datastore
 ///--------------------------------------
 
 /**
@@ -127,7 +127,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)isLocalDatastoreEnabled PF_TV_UNAVAILABLE;
 
 ///--------------------------------------
-/// @name Enabling Extensions Data Sharing
+#pragma mark - Enabling Extensions Data Sharing
 ///--------------------------------------
 
 /**
@@ -174,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if PARSE_IOS_ONLY
 
 ///--------------------------------------
-/// @name Configuring UI Settings
+#pragma mark - Configuring UI Settings
 ///--------------------------------------
 
 /**
@@ -200,7 +200,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 ///--------------------------------------
-/// @name Logging
+#pragma mark - Logging
 ///--------------------------------------
 
 /**

--- a/Parse/ParseClientConfiguration.h
+++ b/Parse/ParseClientConfiguration.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ParseMutableClientConfiguration <NSObject>
 
 ///--------------------------------------
-/// @name Connecting to Parse
+#pragma mark - Connecting to Parse
 ///--------------------------------------
 
 /**
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy) NSString *clientKey;
 
 ///--------------------------------------
-/// @name Enabling Local Datastore
+#pragma mark - Enabling Local Datastore
 ///--------------------------------------
 
 /**
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, getter=isLocalDatastoreEnabled) BOOL localDatastoreEnabled PF_TV_UNAVAILABLE;
 
 ///--------------------------------------
-/// @name Enabling Extensions Data Sharing
+#pragma mark - Enabling Extensions Data Sharing
 ///--------------------------------------
 
 /**
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy) NSString *containingApplicationBundleIdentifier PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE;
 
 ///--------------------------------------
-/// @name Other Properties
+#pragma mark - Other Properties
 ///--------------------------------------
 
 /**
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ParseClientConfiguration : NSObject <NSCopying>
 
 ///--------------------------------------
-/// @name Connecting to Parse
+#pragma mark - Connecting to Parse
 ///--------------------------------------
 
 /**
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy, readonly) NSString *clientKey;
 
 ///--------------------------------------
-/// @name Enabling Local Datastore
+#pragma mark - Enabling Local Datastore
 ///--------------------------------------
 
 /**
@@ -118,7 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly, getter=isLocalDatastoreEnabled) BOOL localDatastoreEnabled;
 
 ///--------------------------------------
-/// @name Enabling Extensions Data Sharing
+#pragma mark - Enabling Extensions Data Sharing
 ///--------------------------------------
 
 /**
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy, readonly) NSString *containingApplicationBundleIdentifier;
 
 ///--------------------------------------
-/// @name Other Properties
+#pragma mark - Other Properties
 ///--------------------------------------
 
 /**
@@ -146,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) NSUInteger networkRetryAttempts;
 
 ///--------------------------------------
-/// @name Creating a Configuration
+#pragma mark - Creating a Configuration
 ///--------------------------------------
 
 /**

--- a/Tests/Other/TestCases/TestCase/PFTestCase.h
+++ b/Tests/Other/TestCases/TestCase/PFTestCase.h
@@ -14,21 +14,21 @@
 @interface PFTestCase : XCTestCase
 
 ///--------------------------------------
-/// @name XCTestCase
+#pragma mark - XCTestCase
 ///--------------------------------------
 
 - (void)setUp NS_REQUIRES_SUPER;
 - (void)tearDown NS_REQUIRES_SUPER;
 
 ///--------------------------------------
-/// @name Expectations
+#pragma mark - Expectations
 ///--------------------------------------
 
 - (XCTestExpectation *)currentSelectorTestExpectation;
 - (void)waitForTestExpectations;
 
 ///--------------------------------------
-/// @name File Asserts
+#pragma mark - File Asserts
 ///--------------------------------------
 
 - (void)assertFileExists:(NSString *)path;
@@ -41,7 +41,7 @@
 - (void)assertDirectory:(NSString *)directoryPath hasContents:(NSDictionary *)expected only:(BOOL)only;
 
 ///--------------------------------------
-/// @name Mocks
+#pragma mark - Mocks
 ///--------------------------------------
 
 - (void)registerMockObject:(id)mockObject;

--- a/Tests/Other/TestCases/UnitTestCase/PFUnitTestCase.h
+++ b/Tests/Other/TestCases/UnitTestCase/PFUnitTestCase.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *clientKey;
 
 ///--------------------------------------
-/// @name XCTestCase
+#pragma mark - XCTestCase
 ///--------------------------------------
 
 - (void)setUp NS_REQUIRES_SUPER;


### PR DESCRIPTION
We were using `@name` only for documentation generation purposes. 
Since our new doc generation supports pragma marks - use those instead for every header.
Starting from this point - we can finally use pragmas across both headers and implementations.