### PR TITLE
Convert all private ivars of PFUser to properties.

### DIFF
--- a/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
+++ b/Parse/Internal/User/AuthenticationProviders/Controller/PFUserAuthenticationController.m
@@ -118,7 +118,7 @@
     return [[self.dataSource.currentUserController getCurrentUserAsyncWithOptions:0] continueWithSuccessBlock:^id(BFTask<PFUser *> *task) {
         PFUser *currentUser = task.result;
         if (currentUser && [PFAnonymousUtils isLinkedWithUser:currentUser]) {
-            if (currentUser.isLazy) {
+            if (currentUser._lazy) {
                 BFTask *resolveLaziness = nil;
                 NSDictionary *oldAnonymousData = nil;
                 @synchronized(currentUser.lock) {

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
@@ -120,9 +120,9 @@
         return [[[[self _loadCurrentUserFromDiskAsync] continueWithSuccessBlock:^id(BFTask *task) {
             PFUser *user = task.result;
             // If the object was not yet saved, but is already linked with AnonymousUtils - it means it is lazy.
-            // So mark it's state as `isLazy` and make it `dirty`
+            // So mark it's state as `lazy` and make it `dirty`
             if (!user.objectId && [PFAnonymousUtils isLinkedWithUser:user]) {
-                user.isLazy = YES;
+                user._lazy = YES;
                 [user _setDirty:YES];
             }
             return user;
@@ -158,7 +158,7 @@
         }
         return [[task continueWithBlock:^id(BFTask *task) {
             @synchronized (user.lock) {
-                [user setIsCurrentUser:YES];
+                user._current = YES;
                 [user synchronizeAllAuthData];
             }
             return [self _saveCurrentUserToDiskAsync:user];
@@ -246,7 +246,7 @@
     }
     return [task continueWithSuccessBlock:^id(BFTask *task) {
         PFUser *user = task.result;
-        [user setIsCurrentUser:YES];
+        user._current = YES;
         return [[self _loadSensitiveUserDataAsync:user
                          fromKeychainItemWithName:PFUserCurrentUserKeychainItemName] continueWithSuccessResult:user];
     }];

--- a/Parse/Internal/User/PFUserPrivate.h
+++ b/Parse/Internal/User/PFUserPrivate.h
@@ -51,20 +51,17 @@ extern NSString *const PFUserCurrentUserKeychainItemName;
 @end
 
 // Private Properties
-@interface PFUser () {
-    BOOL isCurrentUser;
-    NSMutableDictionary *authData;
-    NSMutableSet *linkedServiceNames;
-    BOOL isLazy;
-}
+@interface PFUser ()
 
-// This earmarks the user as being an "identity" user. This will make saves write through
-// to the currentUser singleton and disk object
-@property (nonatomic, assign) BOOL isCurrentUser;
+@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, id> *authData;
+@property (nonatomic, strong, readonly) NSMutableSet<NSString *> *linkedServiceNames;
 
-@property (nonatomic, strong, readonly) NSMutableDictionary *authData;
-@property (nonatomic, strong, readonly) NSMutableSet *linkedServiceNames;
-@property (nonatomic, assign) BOOL isLazy;
+/**
+ This earmarks the user as being an "identity" user.
+ This will make saves write through to the currentUser singleton and disk object
+ */
+@property (nonatomic, assign) BOOL _current;
+@property (nonatomic, assign) BOOL _lazy;
 
 - (BOOL)_isAuthenticatedWithCurrentUser:(PFUser *)currentUser;
 

--- a/Parse/PFACL.m
+++ b/Parse/PFACL.m
@@ -275,7 +275,7 @@ static NSString *const PFACLCodingDataKey_ = @"ACL";
 - (void)setReadAccess:(BOOL)allowed forUser:(PFUser *)user {
     NSString *objectId = user.objectId;
     if (!objectId) {
-        if (user.isLazy) {
+        if (user._lazy) {
             [self setUnresolvedReadAccess:allowed forUser:user];
             return;
         }
@@ -301,7 +301,7 @@ static NSString *const PFACLCodingDataKey_ = @"ACL";
 - (void)setWriteAccess:(BOOL)allowed forUser:(PFUser *)user {
     NSString *objectId = user.objectId;
     if (!objectId) {
-        if (user.isLazy) {
+        if (user._lazy) {
             [self setUnresolvedWriteAccess:allowed forUser:user];
             return;
         }

--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -435,7 +435,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
         // This has to happen separately from everything else because there [PFUser save]
         // is special-cased to work for lazy users, but new users can't be created by
         // PFMultiCommand's regular save.
-        if (currentUser.isLazy && [current containsObject:currentUser]) {
+        if (currentUser._lazy && [current containsObject:currentUser]) {
             task = [task continueAsyncWithSuccessBlock:^id(BFTask *task) {
                 return [currentUser saveInBackground];
             }];
@@ -607,7 +607,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
             // Unfortunately, ACLs with lazy users still cannot be saved, because the ACL does
             // does not get updated after the user save completes.
             // TODO: (nlutsenko) Make the ACL update after the user is saved.
-            if (currentUser.isLazy && [current containsObject:currentUser]) {
+            if (currentUser._lazy && [current containsObject:currentUser]) {
                 [enqueueTasks addObject:[currentUser _enqueueSaveEventuallyWithChildren:NO]];
                 [finished addObject:currentUser];
                 [current removeObject:currentUser];

--- a/Tests/Unit/ACLTests.m
+++ b/Tests/Unit/ACLTests.m
@@ -122,7 +122,7 @@
     OCMStub(lazyUser.objectId).andDo(^(NSInvocation *invocation) {
         [invocation setReturnValue:&userId];
     });
-    OCMStub(lazyUser.isLazy).andReturn(YES);
+    OCMStub(lazyUser._lazy).andReturn(YES);
 
     __block void (^saveListener)(id, NSError *) = nil;
 


### PR DESCRIPTION
Also added generic types to few of them.
Please note - `authData` needs `id` for object type, since we are using `NSNull` for it in few places.