### PR TITLE
Improve designated initializer flow for all classes with custom initializers.

### DIFF
--- a/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
+++ b/Parse/Internal/Analytics/Controller/PFAnalyticsController.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFEventuallyQueueProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)controllerWithDataSource:(id<PFEventuallyQueueProvider>)dataSource;

--- a/Parse/Internal/Analytics/Controller/PFAnalyticsController.m
+++ b/Parse/Internal/Analytics/Controller/PFAnalyticsController.m
@@ -27,10 +27,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFEventuallyQueueProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/CloudCode/PFCloudCodeController.h
+++ b/Parse/Internal/CloudCode/PFCloudCodeController.h
@@ -23,6 +23,8 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider>)dataSource;

--- a/Parse/Internal/CloudCode/PFCloudCodeController.m
+++ b/Parse/Internal/CloudCode/PFCloudCodeController.m
@@ -22,11 +22,7 @@
 
 ///--------------------------------------
 #pragma mark - Init
-///--------------------------------------
-
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
+///--------------------------------------s
 
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource {
     self = [super init];

--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
@@ -26,6 +26,8 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 + (instancetype)constructorWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource serverURL:(NSURL *)serverURL;
 
 ///--------------------------------------

--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
@@ -27,10 +27,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource serverURL:(NSURL *)serverURL {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFURLSessionCommandRunner : NSObject <PFCommandRunning>
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 + (instancetype)commandRunnerWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                               retryAttempts:(NSUInteger)retryAttempts

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -48,10 +48,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                      applicationId:(NSString *)applicationId
                          clientKey:(NSString *)clientKey

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
                              delegate:(id<PFURLSessionDelegate>)delegate NS_DESIGNATED_INITIALIZER;
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/PFURLSession.m
@@ -37,10 +37,6 @@ typedef void (^PFURLSessionTaskCompletionHandler)(NSData *data, NSURLResponse *r
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
                              delegate:(id<PFURLSessionDelegate>)delegate {
     // NOTE: cast to id suppresses warning about designated initializer.

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.h
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy, readonly) NSString *responseString;
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initForDataTask:(NSURLSessionDataTask *)dataTask
           withCancellationToken:(nullable BFCancellationToken *)cancellationToken NS_DESIGNATED_INITIALIZER;
 

--- a/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/Session/TaskDelegate/PFURLSessionDataTaskDelegate.m
@@ -31,10 +31,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initForDataTask:(NSURLSessionDataTask *)dataTask
           withCancellationToken:(BFCancellationToken *)cancellationToken {
     self = [super init];

--- a/Parse/Internal/Config/Controller/PFConfigController.h
+++ b/Parse/Internal/Config/Controller/PFConfigController.h
@@ -28,6 +28,8 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider, PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------

--- a/Parse/Internal/Config/Controller/PFConfigController.m
+++ b/Parse/Internal/Config/Controller/PFConfigController.m
@@ -34,10 +34,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider, PFCommandRunnerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.h
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.h
@@ -25,6 +25,8 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)controllerWithDataSource:(id<PFPersistenceControllerProvider>)dataSource;

--- a/Parse/Internal/Config/Controller/PFCurrentConfigController.m
+++ b/Parse/Internal/Config/Controller/PFCurrentConfigController.m
@@ -34,10 +34,6 @@ static NSString *const PFConfigCurrentConfigFileName_ = @"config";
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/File/Controller/PFFileController.h
+++ b/Parse/Internal/File/Controller/PFFileController.h
@@ -32,6 +32,8 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider, PFFileManagerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider, PFFileManagerProvider>)dataSource;

--- a/Parse/Internal/File/Controller/PFFileController.m
+++ b/Parse/Internal/File/Controller/PFFileController.m
@@ -44,10 +44,6 @@ static NSString *const PFFileControllerCacheDirectoryName_ = @"PFFileCache";
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider, PFFileManagerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/File/Controller/PFFileStagingController.h
+++ b/Parse/Internal/File/Controller/PFFileStagingController.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFFileManagerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)controllerWithDataSource:(id<PFFileManagerProvider>)dataSource;

--- a/Parse/Internal/File/Controller/PFFileStagingController.m
+++ b/Parse/Internal/File/Controller/PFFileStagingController.m
@@ -26,10 +26,6 @@ static NSString *const PFFileStagingControllerDirectoryName_ = @"PFFileStaging";
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFFileManagerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.h
+++ b/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.h
@@ -24,6 +24,8 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 ///--------------------------------------

--- a/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.m
+++ b/Parse/Internal/Installation/InstallationIdentifierStore/PFInstallationIdentifierStore.m
@@ -37,10 +37,6 @@ static NSString *const PFInstallationIdentifierFileName = @"installationId";
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/KeyValueCache/PFKeyValueCache.h
+++ b/Parse/Internal/KeyValueCache/PFKeyValueCache.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithCacheDirectoryPath:(NSString *)path;
 
 ///--------------------------------------

--- a/Parse/Internal/KeyValueCache/PFKeyValueCache.m
+++ b/Parse/Internal/KeyValueCache/PFKeyValueCache.m
@@ -32,10 +32,6 @@ static NSString *const PFKeyValueCacheDiskCachePathKey = @"path";
 
 @implementation PFKeyValueCacheEntry
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithValue:(NSString *)value {
     return [self initWithValue:value creationTime:[NSDate date]];
 }
@@ -72,10 +68,6 @@ static NSString *const PFKeyValueCacheDiskCachePathKey = @"path";
 ///--------------------------------------
 #pragma mark - Init
 ///--------------------------------------
-
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
 
 - (instancetype)initWithCacheDirectoryPath:(NSString *)path {
     return [self initWithCacheDirectoryURL:[NSURL fileURLWithPath:path]

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -93,10 +93,6 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithFileManager:(PFFileManager *)fileManager options:(PFOfflineStoreOptions)options {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.h
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithFileManager:(PFFileManager *)fileManager NS_DESIGNATED_INITIALIZER;
 + (instancetype)controllerWithFileManager:(PFFileManager *)fileManager;
 

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.m
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.m
@@ -25,10 +25,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithFileManager:(PFFileManager *)fileManager {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/MultiProcessLock/PFMultiProcessFileLock.h
+++ b/Parse/Internal/MultiProcessLock/PFMultiProcessFileLock.h
@@ -20,6 +20,8 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initForFileWithPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
 + (instancetype)lockForFileWithPath:(NSString *)path;
 

--- a/Parse/Internal/MultiProcessLock/PFMultiProcessFileLock.m
+++ b/Parse/Internal/MultiProcessLock/PFMultiProcessFileLock.m
@@ -30,10 +30,6 @@ static const NSTimeInterval PFMultiProcessLockAttemptsDelay = 0.001;
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initForFileWithPath:(NSString *)path {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Object/BatchController/PFObjectBatchController.h
+++ b/Parse/Internal/Object/BatchController/PFObjectBatchController.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 + (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider>)dataSource;
 

--- a/Parse/Internal/Object/BatchController/PFObjectBatchController.m
+++ b/Parse/Internal/Object/BatchController/PFObjectBatchController.m
@@ -30,10 +30,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Object/Controller/PFObjectController.h
+++ b/Parse/Internal/Object/Controller/PFObjectController.h
@@ -26,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 + (instancetype)controllerWithDataSource:(id<PFCommandRunnerProvider>)dataSource;
 

--- a/Parse/Internal/Object/Controller/PFObjectController.m
+++ b/Parse/Internal/Object/Controller/PFObjectController.m
@@ -27,10 +27,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
+++ b/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.h
@@ -26,6 +26,8 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 + (instancetype)controllerWithDataSource:(id<PFPersistenceControllerProvider>)dataSource;
 

--- a/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.m
+++ b/Parse/Internal/Object/FilePersistence/PFObjectFilePersistenceController.m
@@ -23,10 +23,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFPersistenceControllerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
+++ b/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.h
@@ -28,6 +28,8 @@
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFFileManagerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 + (instancetype)storeWithDataSource:(id<PFFileManagerProvider>)dataSource;
 

--- a/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
+++ b/Parse/Internal/Object/LocalIdStore/PFObjectLocalIdStore.m
@@ -81,10 +81,6 @@ static NSString *const _PFObjectLocalIdStoreDiskFolderPath = @"LocalId";
 
 @implementation PFObjectLocalIdStore
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 /**
  * Creates a new LocalIdManager with default options.
  */

--- a/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
+++ b/Parse/Internal/Object/PinningStore/PFPinningObjectStore.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFOfflineStoreProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 + (instancetype)storeWithDataSource:(id<PFOfflineStoreProvider>)dataSource;
 

--- a/Parse/Internal/Object/PinningStore/PFPinningObjectStore.m
+++ b/Parse/Internal/Object/PinningStore/PFPinningObjectStore.m
@@ -30,10 +30,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFOfflineStoreProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassInfo.h
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassInfo.h
@@ -16,6 +16,8 @@
 @property (atomic, strong) Class subclass;
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithSubclass:(Class)kls NS_DESIGNATED_INITIALIZER;
 + (instancetype)subclassInfoWithSubclass:(Class)kls;
 

--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassInfo.m
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassInfo.m
@@ -77,10 +77,6 @@ static objc_property_t getAccessorMutatorPair(Class klass, SEL sel, SEL outPair[
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithSubclass:(Class)kls {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/PFCommandResult.h
+++ b/Parse/Internal/PFCommandResult.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithResult:(NSDictionary *)result
                   resultString:(nullable NSString *)resultString
                   httpResponse:(nullable NSHTTPURLResponse *)response NS_DESIGNATED_INITIALIZER;

--- a/Parse/Internal/PFCommandResult.m
+++ b/Parse/Internal/PFCommandResult.m
@@ -17,10 +17,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithResult:(NSDictionary *)result
                   resultString:(NSString *)resultString
                   httpResponse:(NSHTTPURLResponse *)response {

--- a/Parse/Internal/PFCoreManager.h
+++ b/Parse/Internal/PFCoreManager.h
@@ -68,6 +68,8 @@ PFUserControllerProvider
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFCoreManagerDataSource>)dataSource NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)managerWithDataSource:(id<PFCoreManagerDataSource>)dataSource;

--- a/Parse/Internal/PFCoreManager.m
+++ b/Parse/Internal/PFCoreManager.m
@@ -72,10 +72,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFCoreManagerDataSource>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/PFEventuallyQueue.h
+++ b/Parse/Internal/PFEventuallyQueue.h
@@ -47,6 +47,8 @@ extern NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval;
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource
                   maxAttemptsCount:(NSUInteger)attemptsCount
                      retryInterval:(NSTimeInterval)retryInterval NS_DESIGNATED_INITIALIZER;

--- a/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Internal/PFEventuallyQueue.m
@@ -46,10 +46,6 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(id<PFCommandRunnerProvider>)dataSource
                   maxAttemptsCount:(NSUInteger)attemptsCount
                      retryInterval:(NSTimeInterval)retryInterval {

--- a/Parse/Internal/PFFileManager.h
+++ b/Parse/Internal/PFFileManager.h
@@ -52,6 +52,8 @@ typedef NS_OPTIONS(uint8_t, PFFileManagerOptions) {
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithApplicationIdentifier:(NSString *)applicationIdentifier
                    applicationGroupIdentifier:(NSString *)applicationGroupIdentifier NS_DESIGNATED_INITIALIZER;
 

--- a/Parse/Internal/PFFileManager.m
+++ b/Parse/Internal/PFFileManager.m
@@ -230,10 +230,6 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
 
 #pragma mark Init
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithApplicationIdentifier:(NSString *)applicationIdentifier
                    applicationGroupIdentifier:(NSString *)applicationGroupIdentifier {
     self = [super init];

--- a/Parse/Internal/PFKeychainStore.h
+++ b/Parse/Internal/PFKeychainStore.h
@@ -22,6 +22,8 @@ extern NSString *const PFKeychainStoreDefaultService;
 @interface PFKeychainStore : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithService:(NSString *)service NS_DESIGNATED_INITIALIZER;
 
 - (nullable id)objectForKey:(NSString *)key;

--- a/Parse/Internal/PFKeychainStore.m
+++ b/Parse/Internal/PFKeychainStore.m
@@ -52,10 +52,6 @@ NSString *const PFKeychainStoreDefaultService = @"com.parse.sdk";
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithService:(NSString *)service {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/PFReachability.h
+++ b/Parse/Internal/PFReachability.h
@@ -34,6 +34,8 @@ PF_WATCH_UNAVAILABLE @interface PFReachability : NSObject
 @property (nonatomic, assign, readonly) PFReachabilityState currentState;
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithURL:(NSURL *)url NS_DESIGNATED_INITIALIZER;
 
 /*

--- a/Parse/Internal/PFReachability.m
+++ b/Parse/Internal/PFReachability.m
@@ -84,10 +84,6 @@ static void _reachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReac
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithURL:(NSURL *)url {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/ParseManager.h
+++ b/Parse/Internal/ParseManager.h
@@ -53,6 +53,7 @@ PFInstallationIdentifierStoreProvider>
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 /**
  Initializes an instance of ParseManager class.

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -86,10 +86,6 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithConfiguration:(ParseClientConfiguration *)configuration serverURL:(NSURL *)url {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/PropertyInfo/PFPropertyInfo.h
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PFPropertyInfo : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithClass:(Class)kls
                          name:(NSString *)propertyName;
 

--- a/Parse/Internal/PropertyInfo/PFPropertyInfo.m
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo.m
@@ -39,10 +39,6 @@ static inline NSString *stringByCapitalizingFirstCharacter(NSString *string) {
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithClass:(Class)kls name:(NSString *)propertyName {
     return [self initWithClass:kls name:propertyName associationType:_associationType];
 }

--- a/Parse/Internal/Push/ChannelsController/PFPushChannelsController.h
+++ b/Parse/Internal/Push/ChannelsController/PFPushChannelsController.h
@@ -29,6 +29,8 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushChannelsController : NSO
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithDataSource:(id<PFCurrentInstallationControllerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 + (instancetype)controllerWithDataSource:(id<PFCurrentInstallationControllerProvider>)dataSource;
 

--- a/Parse/Internal/Push/ChannelsController/PFPushChannelsController.m
+++ b/Parse/Internal/Push/ChannelsController/PFPushChannelsController.m
@@ -28,10 +28,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithDataSource:(nonnull id<PFCurrentInstallationControllerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Push/Controller/PFPushController.h
+++ b/Parse/Internal/Push/Controller/PFPushController.h
@@ -29,6 +29,8 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushController : NSObject
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithCommandRunner:(id<PFCommandRunning>)commandRunner NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)controllerWithCommandRunner:(id<PFCommandRunning>)commandRunner;

--- a/Parse/Internal/Push/Controller/PFPushController.m
+++ b/Parse/Internal/Push/Controller/PFPushController.m
@@ -21,10 +21,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithCommandRunner:(id<PFCommandRunning>)commandRunner {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/Push/Manager/PFPushManager.h
+++ b/Parse/Internal/Push/Manager/PFPushManager.h
@@ -35,6 +35,8 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFPushManager : NSObject
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithCommonDataSource:(id<PFCommandRunnerProvider>)commonDataSource
                           coreDataSource:(id<PFCurrentInstallationControllerProvider>)coreDataSource NS_DESIGNATED_INITIALIZER;
 

--- a/Parse/Internal/Push/Manager/PFPushManager.m
+++ b/Parse/Internal/Push/Manager/PFPushManager.m
@@ -29,10 +29,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithCommonDataSource:(id<PFCommandRunnerProvider>)commonDataSource
                           coreDataSource:(id<PFCurrentInstallationControllerProvider>)coreDataSource {
     self = [super init];

--- a/Parse/Internal/Query/Controller/PFOfflineQueryController.m
+++ b/Parse/Internal/Query/Controller/PFOfflineQueryController.m
@@ -34,10 +34,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)initWithCommonDataSource:(id<PFCommandRunnerProvider>)dataSource {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithCommonDataSource:(id<PFCommandRunnerProvider, PFOfflineStoreProvider>)dataSource
                           coreDataSource:(id<PFPinningObjectStoreProvider>)coreDataSource {
     self = [super initWithCommonDataSource:dataSource];

--- a/Parse/Internal/Query/Controller/PFQueryController.h
+++ b/Parse/Internal/Query/Controller/PFQueryController.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithCommonDataSource:(id<PFCommandRunnerProvider>)dataSource NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)controllerWithCommonDataSource:(id<PFCommandRunnerProvider>)dataSource;

--- a/Parse/Internal/Query/Controller/PFQueryController.m
+++ b/Parse/Internal/Query/Controller/PFQueryController.m
@@ -33,10 +33,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithCommonDataSource:(id<PFCommandRunnerProvider>)dataSource {
     self = [super init];
     if (!self) return nil;

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.h
@@ -35,6 +35,8 @@ typedef NS_OPTIONS(NSUInteger, PFCurrentUserLoadingOptions) {
 ///--------------------------------------
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
 - (instancetype)initWithStorageType:(PFCurrentObjectStorageType)storageType
                    commonDataSource:(id<PFKeychainStoreProvider>)commonDataSource
                      coreDataSource:(id<PFObjectFilePersistenceControllerProvider>)coreDataSource NS_DESIGNATED_INITIALIZER;

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
@@ -41,10 +41,6 @@
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)init {
-    PFNotDesignatedInitializer();
-}
-
 - (instancetype)initWithStorageType:(PFCurrentObjectStorageType)storageType
                    commonDataSource:(id<PFKeychainStoreProvider>)commonDataSource
                      coreDataSource:(id<PFObjectFilePersistenceControllerProvider>)coreDataSource {

--- a/Tests/Unit/ObjectFilePersistenceControllerTests.m
+++ b/Tests/Unit/ObjectFilePersistenceControllerTests.m
@@ -57,8 +57,6 @@
     controller = [PFObjectFilePersistenceController controllerWithDataSource:dataSource];
     XCTAssertNotNil(controller);
     XCTAssertEqual((id)controller.dataSource, dataSource);
-
-    PFAssertThrowsInconsistencyException([PFObjectFilePersistenceController new]);
 }
 
 - (void)testLoadPersistentObject {

--- a/Tests/Unit/OfflineQueryControllerTests.m
+++ b/Tests/Unit/OfflineQueryControllerTests.m
@@ -54,11 +54,6 @@
     XCTAssertEqual((id)offlineQueryController.coreDataSource, objectStoreProvider);
 }
 
-- (void)testBadConstructor {
-    id<PFCoreManagerDataSource> mockedProvider = PFStrictProtocolMock(@protocol(PFCoreManagerDataSource));
-    XCTAssertThrows([(id)[PFOfflineQueryController alloc] initWithCommonDataSource:mockedProvider]);
-}
-
 - (void)testFindObjectsLDS {
     id<PFCoreManagerDataSource> mockedProvider = PFStrictProtocolMock(@protocol(PFCoreManagerDataSource));
     id<PFPinningObjectStoreProvider> objectStoreProvider = PFStrictProtocolMock(@protocol(PFPinningObjectStoreProvider));

--- a/Tests/Unit/URLSessionCommandRunnerTests.m
+++ b/Tests/Unit/URLSessionCommandRunnerTests.m
@@ -51,8 +51,6 @@
     XCTAssertEqualObjects(@"clientKey", commandRunner.clientKey);
     XCTAssertEqual(commandRunner.initialRetryDelay, PFCommandRunningDefaultRetryDelay);
     XCTAssertEqual(commandRunner.serverURL, url);
-
-    PFAssertThrowsInconsistencyException([PFURLSessionCommandRunner new]);
 }
 
 - (void)testRunCommand {

--- a/Tests/Unit/URLSessionDataTaskDelegateTests.m
+++ b/Tests/Unit/URLSessionDataTaskDelegateTests.m
@@ -37,8 +37,6 @@
     XCTAssertNotNil(delegate);
     XCTAssertEqual(mockedTask, delegate.dataTask);
     XCTAssertNotNil(delegate.resultTask);
-
-    PFAssertThrowsInconsistencyException([PFURLSessionJSONDataTaskDelegate new]);
 }
 
 - (void)testCancel {

--- a/Tests/Unit/URLSessionTests.m
+++ b/Tests/Unit/URLSessionTests.m
@@ -86,8 +86,6 @@
                                          delegate:delegate];
     XCTAssertNotNil(session);
     XCTAssertEqual((id)session.delegate, delegate);
-    
-    PFAssertThrowsInconsistencyException([PFURLSession new]);
 }
 
 - (void)testPerformDataRequestSuccess {

--- a/Tests/Unit/URLSessionUploadTaskDelegateTests.m
+++ b/Tests/Unit/URLSessionUploadTaskDelegateTests.m
@@ -54,8 +54,6 @@
     XCTAssertNotNil(delegate);
     XCTAssertEqual(delegate.dataTask, mockedTask);
     XCTAssertNotNil(delegate.resultTask);
-
-    PFAssertThrowsInconsistencyException([PFURLSessionUploadTaskDelegate new]);
 }
 
 - (void)testCancel {


### PR DESCRIPTION
- Remove no longer needed override for `-init` that throws.
- Mark `+new` as unavailable in classes where `-init` is unavailable.
- Cleanup tests that are no longer relevant.