### PR TITLE
Add ability to get/change server url used by the SDK.

### DIFF
--- a/Parse/Internal/PFInternalUtils.m
+++ b/Parse/Internal/PFInternalUtils.m
@@ -34,6 +34,7 @@
 #import "PFMultiProcessFileLockController.h"
 #import "PFHash.h"
 #import "Parse_Private.h"
+#import "ParseClientConfiguration_Private.h"
 
 #if TARGET_OS_IOS
 #import "PFProduct.h"

--- a/Parse/Internal/ParseClientConfiguration_Private.h
+++ b/Parse/Internal/ParseClientConfiguration_Private.h
@@ -11,10 +11,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString *const _ParseDefaultServerURLString;
+
 @interface ParseClientConfiguration ()
 
 @property (nullable, nonatomic, copy, readwrite) NSString *applicationId;
 @property (nullable, nonatomic, copy, readwrite) NSString *clientKey;
+
+@property (nonatomic, copy, readwrite) NSString *server;
 
 @property (nonatomic, assign, readwrite, getter=isLocalDatastoreEnabled) BOOL localDatastoreEnabled;
 

--- a/Parse/Internal/Parse_Private.h
+++ b/Parse/Internal/Parse_Private.h
@@ -13,8 +13,6 @@
 
 #import "ParseManager.h"
 
-extern NSString *const _ParseDefaultServerURLString;
-
 @class PFEventuallyQueue;
 
 @interface Parse ()

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -33,8 +33,6 @@
 
 #import "PFCategoryLoader.h"
 
-NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
-
 @implementation Parse
 
 static ParseManager *currentParseManager_;
@@ -58,6 +56,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
 + (void)setApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey {
     currentParseConfiguration_.applicationId = applicationId;
     currentParseConfiguration_.clientKey = clientKey;
+    currentParseConfiguration_.server = [PFInternalUtils parseServerURLString]; // TODO: (nlutsenko) Clean this up after tests are updated.
 
     [self initializeWithConfiguration:currentParseConfiguration_];
 
@@ -77,7 +76,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
                         @"'containingApplicationBundleIdentifier' must be non-nil in extension environment");
 
     ParseManager *manager = [[ParseManager alloc] initWithConfiguration:configuration
-                                                              serverURL:[NSURL URLWithString:[PFInternalUtils parseServerURLString]]];
+                                                              serverURL:[NSURL URLWithString:configuration.server]];
     [manager startManaging];
 
     currentParseManager_ = manager;

--- a/Parse/ParseClientConfiguration.h
+++ b/Parse/ParseClientConfiguration.h
@@ -41,6 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, nonatomic, copy) NSString *clientKey;
 
+/**
+ The URL of the server that is being used by the SDK.
+ Defaults to `https://api.parse.com/1`.
+
+ @note Setting this property to a non-valid URL or `nil` will throw an `NSInvalidArgumentException`.
+ */
+@property (nonatomic, copy) NSString *server;
+
 ///--------------------------------------
 #pragma mark - Enabling Local Datastore
 ///--------------------------------------
@@ -105,6 +113,12 @@ NS_ASSUME_NONNULL_BEGIN
  The Parse.com client key to configure the SDK with.
  */
 @property (nullable, nonatomic, copy, readonly) NSString *clientKey;
+
+/**
+ The URL of the server that is being used by the SDK.
+ Defaults to `https://api.parse.com/1`
+ */
+@property (nonatomic, copy, readonly) NSString *server;
 
 ///--------------------------------------
 #pragma mark - Enabling Local Datastore

--- a/Parse/ParseClientConfiguration.m
+++ b/Parse/ParseClientConfiguration.m
@@ -17,6 +17,8 @@
 #import "PFHash.h"
 #import "PFObjectUtilities.h"
 
+NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
+
 @implementation ParseClientConfiguration
 
 ///--------------------------------------
@@ -32,6 +34,7 @@
     if (!self) return nil;
 
     _networkRetryAttempts = PFCommandRunningDefaultMaxAttemptsCount;
+    _server = [_ParseDefaultServerURLString copy];
 
     return self;
 }
@@ -64,6 +67,12 @@
 - (void)setClientKey:(NSString *)clientKey {
     PFConsistencyAssert(clientKey.length, @"'clientKey' should not be nil.");
     _clientKey = [clientKey copy];
+}
+
+- (void)setServer:(NSString *)server {
+    PFParameterAssert(server.length, @"Server should not be `nil`.");
+    PFParameterAssert([NSURL URLWithString:server], @"Server should be a valid URL.");
+    _server = [server copy];
 }
 
 - (void)setApplicationGroupIdentifier:(NSString *)applicationGroupIdentifier {
@@ -104,6 +113,7 @@
     ParseClientConfiguration *other = object;
     return ([PFObjectUtilities isObject:self.applicationId equalToObject:other.applicationId] &&
             [PFObjectUtilities isObject:self.clientKey equalToObject:other.clientKey] &&
+            [self.server isEqualToString:other.server] &&
             self.localDatastoreEnabled == other.localDatastoreEnabled &&
             [PFObjectUtilities isObject:self.applicationGroupIdentifier equalToObject:other.applicationGroupIdentifier] &&
             [PFObjectUtilities isObject:self.containingApplicationBundleIdentifier equalToObject:other.containingApplicationBundleIdentifier] &&
@@ -119,6 +129,7 @@
         // Use direct assignment to skip over all of the assertions that may fail if we're not fully initialized yet.
         configuration->_applicationId = [self->_applicationId copy];
         configuration->_clientKey = [self->_clientKey copy];
+        configuration->_server = [self.server copy];
         configuration->_localDatastoreEnabled = self->_localDatastoreEnabled;
         configuration->_applicationGroupIdentifier = [self->_applicationGroupIdentifier copy];
         configuration->_containingApplicationBundleIdentifier = [self->_containingApplicationBundleIdentifier copy];

--- a/Parse/ParseClientConfiguration.m
+++ b/Parse/ParseClientConfiguration.m
@@ -60,12 +60,12 @@ NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
 ///--------------------------------------
 
 - (void)setApplicationId:(NSString *)applicationId {
-    PFConsistencyAssert(applicationId.length, @"'applicationId' should not be nil.");
+    PFParameterAssert(applicationId.length, @"'applicationId' should not be nil.");
     _applicationId = [applicationId copy];
 }
 
 - (void)setClientKey:(NSString *)clientKey {
-    PFConsistencyAssert(clientKey.length, @"'clientKey' should not be nil.");
+    PFParameterAssert(clientKey.length, @"'clientKey' should not be nil.");
     _clientKey = [clientKey copy];
 }
 
@@ -76,18 +76,18 @@ NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
 }
 
 - (void)setApplicationGroupIdentifier:(NSString *)applicationGroupIdentifier {
-    PFConsistencyAssert(applicationGroupIdentifier == nil ||
-                        [PFFileManager isApplicationGroupContainerReachableForGroupIdentifier:applicationGroupIdentifier],
-                        @"ApplicationGroupContainer is unreachable. Please double check your Xcode project settings.");
+    PFParameterAssert(applicationGroupIdentifier == nil ||
+                      [PFFileManager isApplicationGroupContainerReachableForGroupIdentifier:applicationGroupIdentifier],
+                      @"ApplicationGroupContainer is unreachable. Please double check your Xcode project settings.");
 
     _applicationGroupIdentifier = [applicationGroupIdentifier copy];
 }
 
 - (void)setContainingApplicationBundleIdentifier:(NSString *)containingApplicationBundleIdentifier {
-    PFConsistencyAssert([PFApplication currentApplication].extensionEnvironment,
-                        @"'containingApplicationBundleIdentifier' cannot be set in non-extension environment");
-    PFConsistencyAssert(containingApplicationBundleIdentifier.length,
-                        @"'containingApplicationBundleIdentifier' should not be nil.");
+    PFParameterAssert([PFApplication currentApplication].extensionEnvironment,
+                      @"'containingApplicationBundleIdentifier' cannot be set in non-extension environment");
+    PFParameterAssert(containingApplicationBundleIdentifier.length,
+                      @"'containingApplicationBundleIdentifier' should not be nil.");
 
     _containingApplicationBundleIdentifier = containingApplicationBundleIdentifier;
 }

--- a/Tests/Unit/CommandUnitTests.m
+++ b/Tests/Unit/CommandUnitTests.m
@@ -15,6 +15,7 @@
 #import "PFURLSessionCommandRunner.h"
 #import "PFUnitTestCase.h"
 #import "Parse_Private.h"
+#import "ParseClientConfiguration_Private.h"
 
 @interface CommandUnitTests : PFUnitTestCase
 

--- a/Tests/Unit/ParseClientConfigurationTests.m
+++ b/Tests/Unit/ParseClientConfigurationTests.m
@@ -37,19 +37,21 @@
     ParseClientConfiguration *configuration = [ParseClientConfiguration configurationWithBlock:^(id<ParseMutableClientConfiguration> configuration) {
         configuration.applicationId = @"foo";
         configuration.clientKey = @"bar";
+        configuration.server = @"http://localhost";
         configuration.localDatastoreEnabled = YES;
         configuration.networkRetryAttempts = 1337;
     }];
 
     XCTAssertEqualObjects(configuration.applicationId, @"foo");
     XCTAssertEqualObjects(configuration.clientKey, @"bar");
+    XCTAssertEqualObjects(configuration.server, @"http://localhost");
     XCTAssertTrue(configuration.localDatastoreEnabled);
     XCTAssertEqual(configuration.networkRetryAttempts, 1337);
 }
 
 - (void)testEqual {
-    ParseClientConfiguration *configurationA = [(id)[ParseClientConfiguration alloc] init];
-    ParseClientConfiguration *configurationB = [(id)[ParseClientConfiguration alloc] init];
+    ParseClientConfiguration *configurationA = [ParseClientConfiguration emptyConfiguration];
+    ParseClientConfiguration *configurationB = [ParseClientConfiguration emptyConfiguration];
     XCTAssertEqualObjects(configurationA, configurationB);
     XCTAssertEqual(configurationA.hash, configurationB.hash);
 
@@ -66,6 +68,13 @@
     configurationB.clientKey = @"test";
     XCTAssertNotEqualObjects(configurationA, configurationB);
     configurationB.clientKey = configurationA.clientKey;
+
+    configurationA.server = configurationB.server = @"http://localhost";
+    XCTAssertEqualObjects(configurationA, configurationB);
+    XCTAssertEqual(configurationA.hash, configurationB.hash);
+    configurationB.server = @"http://api.parse.com";
+    XCTAssertNotEqualObjects(configurationA, configurationB);
+    configurationB.server = configurationA.server;
 
     configurationA.localDatastoreEnabled = configurationB.localDatastoreEnabled = YES;
     XCTAssertEqualObjects(configurationA, configurationB);
@@ -85,6 +94,7 @@
     ParseClientConfiguration *configurationA = [ParseClientConfiguration configurationWithBlock:^(id<ParseMutableClientConfiguration> configuration) {
         configuration.applicationId = @"foo";
         configuration.clientKey = @"bar";
+        configuration.server = @"http://localhost";
         configuration.localDatastoreEnabled = YES;
         configuration.networkRetryAttempts = 1337;
     }];
@@ -100,6 +110,7 @@
 
     XCTAssertEqualObjects(configurationB.applicationId, @"foo");
     XCTAssertEqualObjects(configurationB.clientKey, @"bar");
+    XCTAssertEqualObjects(configurationB.server, @"http://localhost");
     XCTAssertTrue(configurationB.localDatastoreEnabled);
     XCTAssertEqual(configurationB.networkRetryAttempts, 1337);
 }
@@ -123,6 +134,16 @@
 
     // In extension environment this should succeed.
     XCTAssertNoThrow(configuration.containingApplicationBundleIdentifier = @"someContainer");
+}
+
+- (void)testServerValidation {
+    [ParseClientConfiguration configurationWithBlock:^(id<ParseMutableClientConfiguration>  _Nonnull configuration) {
+        configuration.applicationId = @"a";
+        configuration.clientKey = @"b";
+
+        PFAssertThrowsInvalidArgumentException(configuration.server = @"");
+        PFAssertThrowsInvalidArgumentException(configuration.server = @"Yolo Yarr");
+    }];
 }
 
 @end

--- a/Tests/Unit/ParseSetupUnitTests.m
+++ b/Tests/Unit/ParseSetupUnitTests.m
@@ -48,9 +48,9 @@
 
 - (void)testInitializeWithNilApplicationIdNilClientKeyShouldThrowException {
     NSString *yolo = nil;
-    PFAssertThrowsInconsistencyException([Parse setApplicationId:yolo clientKey:yolo]);
-    PFAssertThrowsInconsistencyException([Parse setApplicationId:yolo clientKey:@"a"]);
-    PFAssertThrowsInconsistencyException([Parse setApplicationId:@"a" clientKey:yolo]);
+    PFAssertThrowsInvalidArgumentException([Parse setApplicationId:yolo clientKey:yolo]);
+    PFAssertThrowsInvalidArgumentException([Parse setApplicationId:yolo clientKey:@"a"]);
+    PFAssertThrowsInvalidArgumentException([Parse setApplicationId:@"a" clientKey:yolo]);
 }
 
 @end


### PR DESCRIPTION
- New property with tests and documentation
- Using new property (please note we are still using the getter from `PFInternalUtils` for legacy test reasons)
- Also improved assertion types on properties of `ParseClientConfiguration` (in a separate commit, though not worth creating a separate PR)