### PR TITLE
Unify all platform conditional macros.

### DIFF
--- a/Parse/Internal/Object/PFObjectPrivate.h
+++ b/Parse/Internal/Object/PFObjectPrivate.h
@@ -97,7 +97,7 @@
 
 - (PFObjectEstimatedData *)_estimatedData;
 
-#if PARSE_OSX_ONLY
+#if PF_TARGET_OS_OSX
 // Not available publicly, but available for testing
 
 - (instancetype)refresh;

--- a/Parse/Internal/PFApplication.m
+++ b/Parse/Internal/PFApplication.m
@@ -35,7 +35,7 @@
 ///--------------------------------------
 
 - (BOOL)isAppStoreEnvironment {
-#if TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_IOS && !TARGET_IPHONE_SIMULATOR
     return ([[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"] == nil);
 #endif
 

--- a/Parse/Internal/PFDevice.m
+++ b/Parse/Internal/PFDevice.m
@@ -133,7 +133,7 @@ static NSString *PFDeviceSysctlByName(NSString *name) {
 
 - (BOOL)isJailbroken {
     BOOL jailbroken = NO;
-#if TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_IOS && !TARGET_IPHONE_SIMULATOR
     DIR *dir = opendir("/");
     if (dir != NULL) {
         jailbroken = YES;

--- a/Parse/Internal/PFFileManager.m
+++ b/Parse/Internal/PFFileManager.m
@@ -246,7 +246,12 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
 - (NSString *)parseDefaultDataDirectoryPath {
     // NSHomeDirectory: Returns the path to either the user's or application's
     // home directory, depending on the platform. Sandboxed by default on iOS.
-#if PARSE_IOS_ONLY
+#if PF_TARGET_OS_OSX
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+    NSString *directoryPath = [paths firstObject];
+    directoryPath = [directoryPath stringByAppendingPathComponent:_PFFileManagerParseDirectoryName];
+    directoryPath = [directoryPath stringByAppendingPathComponent:self.applicationIdentifier];
+#else
     NSString *directoryPath = nil;
     if (self.applicationGroupIdentifier) {
         NSURL *containerPath = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:self.applicationGroupIdentifier];
@@ -255,11 +260,6 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
     } else {
         return [self parseLocalSandboxDataDirectoryPath];
     }
-#else
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
-    NSString *directoryPath = [paths firstObject];
-    directoryPath = [directoryPath stringByAppendingPathComponent:_PFFileManagerParseDirectoryName];
-    directoryPath = [directoryPath stringByAppendingPathComponent:self.applicationIdentifier];
 #endif
 
     BFTask *createDirectoryTask = [[self class] createDirectoryIfNeededAsyncAtPath:directoryPath

--- a/Parse/Internal/PFFileManager.m
+++ b/Parse/Internal/PFFileManager.m
@@ -19,7 +19,7 @@
 static NSString *const _PFFileManagerParseDirectoryName = @"Parse";
 
 static NSDictionary *_PFFileManagerDefaultDirectoryFileAttributes() {
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+#if !PF_TARGET_OS_OSX
     return @{ NSFileProtectionKey : NSFileProtectionCompleteUntilFirstUserAuthentication };
 #else
     return nil;
@@ -28,7 +28,7 @@ static NSDictionary *_PFFileManagerDefaultDirectoryFileAttributes() {
 
 static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
     NSDataWritingOptions options = NSDataWritingAtomic;
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+#if !PF_TARGET_OS_OSX
     options |= NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication;
 #endif
     return options;
@@ -92,7 +92,7 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
             }
         }
 
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_IOS || TARGET_OS_WATCH // No backups for Apple TV, since everything is cache.
         if (options & PFFileManagerOptionSkipBackup) {
             [self _skipBackupOnPath:path];
         }
@@ -271,7 +271,9 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
 }
 
 - (NSString *)parseLocalSandboxDataDirectoryPath {
-#if TARGET_OS_IPHONE
+#if PF_TARGET_OS_OSX
+    return [self parseDefaultDataDirectoryPath];
+#else
     NSString *library = [NSHomeDirectory() stringByAppendingPathComponent:@"Library"];
     NSString *privateDocuments = [library stringByAppendingPathComponent:@"Private Documents"];
     NSString *directoryPath = [privateDocuments stringByAppendingPathComponent:_PFFileManagerParseDirectoryName];
@@ -281,8 +283,6 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
     [createDirectoryTask waitForResult:nil withMainThreadWarning:NO];
 
     return directoryPath;
-#else
-    return [self parseDefaultDataDirectoryPath];
 #endif
 }
 
@@ -294,7 +294,7 @@ static NSDataWritingOptions _PFFileManagerDefaultDataWritingOptions() {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
     NSString *folderPath = paths.firstObject;
     folderPath = [folderPath stringByAppendingPathComponent:_PFFileManagerParseDirectoryName];
-#if !TARGET_OS_IPHONE
+#if PF_TARGET_OS_OSX
     // We append the applicationId in case the OS X application isn't sandboxed,
     // to avoid collisions in the generic ~/Library/Caches/Parse/------ dir.
     folderPath = [folderPath stringByAppendingPathComponent:self.applicationIdentifier];

--- a/Parse/Internal/PFLocationManager.h
+++ b/Parse/Internal/PFLocationManager.h
@@ -9,10 +9,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Parse/PFConstants.h>
+
 @class CLLocation;
 @class CLLocationManager;
 
-#if TARGET_OS_IPHONE
+#if !PF_TARGET_OS_OSX
 
 @class UIApplication;
 
@@ -39,7 +41,7 @@ typedef void(^PFLocationManagerLocationUpdateBlock)(CLLocation *location, NSErro
 
 - (instancetype)initWithSystemLocationManager:(CLLocationManager *)manager;
 
-#if TARGET_OS_IPHONE
+#if !PF_TARGET_OS_OSX
 
 - (instancetype)initWithSystemLocationManager:(CLLocationManager *)manager
                                   application:(UIApplication *)application

--- a/Parse/Internal/PFReachability.m
+++ b/Parse/Internal/PFReachability.m
@@ -66,7 +66,7 @@ static void _reachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReac
         }
     }
 
-#if TARGET_OS_IPHONE
+#if !PF_TARGET_OS_OSX
     if (((flags & kSCNetworkReachabilityFlagsIsWWAN) == kSCNetworkReachabilityFlagsIsWWAN) &&
         ((flags & kSCNetworkReachabilityFlagsConnectionRequired) == 0)) {
         // ... but WWAN connections are OK if the calling application

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -465,7 +465,7 @@ extern NSString *const _Nonnull PFNetworkNotificationURLResponseBodyUserInfoKey;
 #endif
 
 #ifndef PF_TARGET_OS_OSX
-#  define PF_TARGET_OS_OSX TARGET_OS_MAC && !TARGET_OS_IOS && !TARGET_OS_WATCH && !TARGET_OS_TV
+#  define PF_TARGET_OS_OSX (TARGET_OS_MAC && !TARGET_OS_IOS && !TARGET_OS_WATCH && !TARGET_OS_TV)
 #endif
 
 ///--------------------------------------

--- a/Parse/PFConstants.h
+++ b/Parse/PFConstants.h
@@ -24,9 +24,6 @@ extern NSInteger const PARSE_API_VERSION;
 #pragma mark - Platform
 ///--------------------------------------
 
-#define PARSE_IOS_ONLY (TARGET_OS_IPHONE)
-#define PARSE_OSX_ONLY (TARGET_OS_MAC && !(TARGET_OS_IPHONE))
-
 extern NSString *const _Nonnull kPFDeviceType;
 
 ///--------------------------------------

--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -394,7 +394,7 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
  */
 @property (nonatomic, assign, readonly, getter=isDataAvailable) BOOL dataAvailable;
 
-#if PARSE_IOS_ONLY
+#if TARGET_OS_IOS
 
 /**
  Refreshes the PFObject with the current data from the server.

--- a/Parse/PFPush.m
+++ b/Parse/PFPush.m
@@ -28,6 +28,7 @@
 #import "PFQueryPrivate.h"
 #import "PFUserPrivate.h"
 #import "Parse_Private.h"
+#import "PFApplication.h"
 
 static Class _pushInternalUtilClass = nil;
 
@@ -286,9 +287,9 @@ static Class _pushInternalUtilClass = nil;
 #pragma mark - Handling Notifications
 ///--------------------------------------
 
-#if PARSE_IOS_ONLY
+#if TARGET_OS_IOS
 + (void)handlePush:(NSDictionary *)userInfo {
-    UIApplication *application = [UIApplication sharedApplication];
+    UIApplication *application = [PFApplication currentApplication].systemApplication;
     if (application.applicationState != UIApplicationStateActive) {
         return;
     }

--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSString *)containingApplicationBundleIdentifierForDataSharing PF_WATCH_UNAVAILABLE PF_TV_UNAVAILABLE;
 
-#if PARSE_IOS_ONLY
+#if TARGET_OS_IOS
 
 ///--------------------------------------
 #pragma mark - Configuring UI Settings

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -186,7 +186,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
 #pragma mark - User Interface
 ///--------------------------------------
 
-#if PARSE_IOS_ONLY
+#if TARGET_OS_IOS
 
 + (void)offlineMessagesEnabled:(BOOL)enabled {
     // Deprecated method - shouldn't do anything.

--- a/Tests/Other/ExtensionDataSharing/PFExtensionDataSharingTestHelper.m
+++ b/Tests/Other/ExtensionDataSharing/PFExtensionDataSharingTestHelper.m
@@ -32,11 +32,11 @@
 }
 
 + (NSString *)sharedTestDirectoryPathForGroupIdentifier:(NSString *)groupIdentifier {
-#if TARGET_OS_IPHONE
-    return [[PFExtensionDataSharingTestHelper sharedTestDirectoryPath] stringByAppendingPathComponent:groupIdentifier];
-#else
+#if PF_TARGET_OS_OSX
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
     return [paths firstObject];
+#else
+    return [[PFExtensionDataSharingTestHelper sharedTestDirectoryPath] stringByAppendingPathComponent:groupIdentifier];
 #endif
 }
 

--- a/Tests/Other/LocationManager/CLLocationManager+TestAdditions.m
+++ b/Tests/Other/LocationManager/CLLocationManager+TestAdditions.m
@@ -9,6 +9,8 @@
 
 #import "CLLocationManager+TestAdditions.h"
 
+#import <Parse/PFConstants.h>
+
 #import "PFTestSwizzlingUtilities.h"
 
 @interface CLLocationManager ()
@@ -31,7 +33,7 @@ static BOOL mockingEnabled = NO;
 
 + (void)setMockingEnabled:(BOOL)enabled {
     // There is no ability to use real CLLocationManager on Mac, due to permission requests
-#if PARSE_OSX_ONLY
+#if PF_TARGET_OS_OSX
     if (!enabled) {
         return;
     }


### PR DESCRIPTION
- Replace custom, old, Parse-specific macros.
- Replace vague `TARGET_OS_IPHONE`.