### PR TITLE
Fix potentially not saved objects if they are not initially dirty.

### DIFF
--- a/Parse/PFObject.m
+++ b/Parse/PFObject.m
@@ -1402,7 +1402,7 @@ static void PFObjectAssertValueIsKindOfValidClass(id object) {
                 [self startSave];
                 BFTask *childrenTask = [self _saveChildrenInBackgroundWithCurrentUser:currentUser
                                                                          sessionToken:sessionToken];
-                if (!dirty && changes.count != 0) {
+                if (!dirty && changes.count == 0) {
                     return childrenTask;
                 }
                 return [[childrenTask continueWithSuccessBlock:^id(BFTask *task) {


### PR DESCRIPTION
Regression caused by change in #689.
Old code:
```objc
if (!dirty && ![changes count]) {
```
Broken code:
```objc
if (!dirty && change.count != 0) {
```
Fixed code:
```objc
if (!dirty && change.count == 0) {
```

Boolean logic is my weakness.