### PR TITLE
Remove redundant serverURL property from ParseManager.

### DIFF
--- a/Parse/Internal/PFReachability.m
+++ b/Parse/Internal/PFReachability.m
@@ -99,7 +99,8 @@ static void _reachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReac
     static PFReachability *reachability;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        reachability = [[self alloc] initWithURL:[Parse _currentManager].serverURL];
+        NSURL *url = [NSURL URLWithString:[Parse _currentManager].configuration.server];
+        reachability = [[self alloc] initWithURL:url];
     });
     return reachability;
 }

--- a/Parse/Internal/ParseManager.h
+++ b/Parse/Internal/ParseManager.h
@@ -34,7 +34,6 @@ PFKeyValueCacheProvider,
 PFInstallationIdentifierStoreProvider>
 
 @property (nonatomic, copy, readonly) ParseClientConfiguration *configuration;
-@property (nonatomic, strong, readonly) NSURL *serverURL;
 
 @property (nonatomic, strong, readonly) PFCoreManager *coreManager;
 
@@ -59,11 +58,10 @@ PFInstallationIdentifierStoreProvider>
  Initializes an instance of ParseManager class.
 
  @param configuration Configuration of parse app.
- @param url           Parse API Server URL.
 
  @return `ParseManager` instance.
  */
-- (instancetype)initWithConfiguration:(ParseClientConfiguration *)configuration serverURL:(NSURL *)url NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConfiguration:(ParseClientConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
 /**
  Begins all necessary operations for this manager to become active.

--- a/Parse/Internal/ParseManager.m
+++ b/Parse/Internal/ParseManager.m
@@ -86,7 +86,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
 #pragma mark - Init
 ///--------------------------------------
 
-- (instancetype)initWithConfiguration:(ParseClientConfiguration *)configuration serverURL:(NSURL *)url {
+- (instancetype)initWithConfiguration:(ParseClientConfiguration *)configuration {
     self = [super init];
     if (!self) return nil;
 
@@ -105,7 +105,6 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
     _preloadQueue = dispatch_queue_create("com.parse.preload", DISPATCH_QUEUE_SERIAL);
 
     _configuration = [configuration copy];
-    _serverURL = url;
 
     return self;
 }
@@ -313,7 +312,7 @@ static NSString *const _ParseApplicationIdFileName = @"applicationId";
                                                                       retryAttempts:self.configuration.networkRetryAttempts
                                                                       applicationId:self.configuration.applicationId
                                                                           clientKey:self.configuration.clientKey
-                                                                          serverURL:self.serverURL];
+                                                                          serverURL:[NSURL URLWithString:self.configuration.server]];
         }
         runner = _commandRunner;
     });

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -75,8 +75,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
                         configuration.containingApplicationBundleIdentifier != nil,
                         @"'containingApplicationBundleIdentifier' must be non-nil in extension environment");
 
-    ParseManager *manager = [[ParseManager alloc] initWithConfiguration:configuration
-                                                              serverURL:[NSURL URLWithString:configuration.server]];
+    ParseManager *manager = [[ParseManager alloc] initWithConfiguration:configuration];
     [manager startManaging];
 
     currentParseManager_ = manager;


### PR DESCRIPTION
This is no longer needed and is somewhat redundant, since we have `server` property on `ParseClientConfiguration`.