### PR TITLE
swift AppDelegate - noPushPayload variable is wrong

### DIFF
--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
@@ -56,7 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let oldPushHandlerOnly = !self.respondsToSelector("application:didReceiveRemoteNotification:fetchCompletionHandler:")
             var noPushPayload = false;
             if let options = launchOptions {
-                noPushPayload = options[UIApplicationLaunchOptionsRemoteNotificationKey] != nil;
+                noPushPayload = options[UIApplicationLaunchOptionsRemoteNotificationKey] == nil;
             }
             if (preBackgroundPush || oldPushHandlerOnly || noPushPayload) {
                 PFAnalytics.trackAppOpenedWithLaunchOptions(launchOptions)


### PR DESCRIPTION
Line 59, the variable noPushPayload is wrong. The variable is true when there is in fact push pay load. You should compare to nil like this:

noPushPayload = options[UIApplicationLaunchOptionsRemoteNotificationKey] == nil;

If options[UIApplicationLaunchOptionsRemoteNotificationKey]  is nil, then there is no payload...

Thanks,