### PR TITLE
Allow clientKey to be nil, as it's not explicitly required for Open Parse Server.

### DIFF
--- a/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
+++ b/Parse/Internal/Commands/CommandRunner/PFCommandRunning.h
@@ -43,11 +43,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                      applicationId:(NSString *)applicationId
-                         clientKey:(NSString *)clientKey
+                         clientKey:(nullable NSString *)clientKey
                          serverURL:(NSURL *)serverURL;
 + (instancetype)commandRunnerWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                               applicationId:(NSString *)applicationId
-                                  clientKey:(NSString *)clientKey
+                                  clientKey:(nullable NSString *)clientKey
                                   serverURL:(NSURL *)serverURL;
 
 ///--------------------------------------

--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.h
@@ -16,6 +16,8 @@
 @class BFTask<__covariant BFGenericType>;
 @class PFRESTCommand;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PFCommandURLRequestConstructor : NSObject
 
 @property (nonatomic, weak, readonly) id<PFInstallationIdentifierStoreProvider> dataSource;
@@ -49,7 +51,9 @@
 ///--------------------------------------
 
 + (NSDictionary *)defaultURLRequestHeadersForApplicationId:(NSString *)applicationId
-                                                 clientKey:(NSString *)clientKey
+                                                 clientKey:(nullable NSString *)clientKey
                                                     bundle:(NSBundle *)bundle;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
+++ b/Parse/Internal/Commands/CommandRunner/URLRequestConstructor/PFCommandURLRequestConstructor.m
@@ -115,7 +115,7 @@
 ///--------------------------------------
 
 + (NSDictionary *)defaultURLRequestHeadersForApplicationId:(NSString *)applicationId
-                                                 clientKey:(NSString *)clientKey
+                                                 clientKey:(nullable NSString *)clientKey
                                                     bundle:(NSBundle *)bundle {
 #if TARGET_OS_IOS
     NSString *versionPrefix = @"i";
@@ -130,7 +130,9 @@
     NSMutableDictionary *mutableHeaders = [NSMutableDictionary dictionary];
 
     mutableHeaders[PFCommandHeaderNameApplicationId] = applicationId;
-    mutableHeaders[PFCommandHeaderNameClientKey] = clientKey;
+    if (clientKey) {
+        mutableHeaders[PFCommandHeaderNameClientKey] = clientKey;
+    }
 
     mutableHeaders[PFCommandHeaderNameClientVersion] = [versionPrefix stringByAppendingString:PARSE_VERSION];
     mutableHeaders[PFCommandHeaderNameOSVersion] = [PFDevice currentDevice].operatingSystemFullVersion;

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.h
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)commandRunnerWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                               retryAttempts:(NSUInteger)retryAttempts
                               applicationId:(NSString *)applicationId
-                                  clientKey:(NSString *)clientKey
+                                  clientKey:(nullable NSString *)clientKey
                                   serverURL:(NSURL *)serverURL;
 
 @end

--- a/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
+++ b/Parse/Internal/Commands/CommandRunner/URLSession/PFURLSessionCommandRunner.m
@@ -50,8 +50,8 @@
 
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                      applicationId:(NSString *)applicationId
-                         clientKey:(NSString *)clientKey
-                         serverURL:(nonnull NSURL *)serverURL {
+                         clientKey:(nullable NSString *)clientKey
+                         serverURL:(NSURL *)serverURL {
     return [self initWithDataSource:dataSource
                       retryAttempts:PFCommandRunningDefaultMaxAttemptsCount
                       applicationId:applicationId
@@ -62,10 +62,9 @@
 - (instancetype)initWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                      retryAttempts:(NSUInteger)retryAttempts
                      applicationId:(NSString *)applicationId
-                         clientKey:(NSString *)clientKey
+                         clientKey:(nullable NSString *)clientKey
                          serverURL:(NSURL *)serverURL {
-    NSURLSessionConfiguration *configuration = [[self class] _urlSessionConfigurationForApplicationId:applicationId
-                                                                                            clientKey:clientKey];
+    NSURLSessionConfiguration *configuration = [[self class] _urlSessionConfigurationForApplicationId:applicationId clientKey:clientKey];
 
     PFURLSession *session = [PFURLSession sessionWithConfiguration:configuration delegate:self];
     PFCommandURLRequestConstructor *constructor = [PFCommandURLRequestConstructor constructorWithDataSource:dataSource serverURL:serverURL];
@@ -102,7 +101,7 @@
 
 + (instancetype)commandRunnerWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                               applicationId:(NSString *)applicationId
-                                  clientKey:(NSString *)clientKey
+                                  clientKey:(nullable NSString *)clientKey
                                   serverURL:(nonnull NSURL *)serverURL {
     return [[self alloc] initWithDataSource:dataSource applicationId:applicationId clientKey:clientKey serverURL:serverURL];
 }
@@ -110,7 +109,7 @@
 + (instancetype)commandRunnerWithDataSource:(id<PFInstallationIdentifierStoreProvider>)dataSource
                               retryAttempts:(NSUInteger)retryAttempts
                               applicationId:(NSString *)applicationId
-                                  clientKey:(NSString *)clientKey
+                                  clientKey:(nullable NSString *)clientKey
                                   serverURL:(nonnull NSURL *)serverURL {
     return [[self alloc] initWithDataSource:dataSource
                               retryAttempts:retryAttempts
@@ -255,7 +254,7 @@
 ///--------------------------------------
 
 + (NSURLSessionConfiguration *)_urlSessionConfigurationForApplicationId:(NSString *)applicationId
-                                                              clientKey:(NSString *)clientKey {
+                                                              clientKey:(nullable NSString *)clientKey {
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
 
     // No cookies, they are bad for you.

--- a/Parse/Internal/ParseModule.h
+++ b/Parse/Internal/ParseModule.h
@@ -9,9 +9,11 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol ParseModule <NSObject>
 
-- (void)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey;
+- (void)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(nullable NSString *)clientKey;
 
 @end
 
@@ -25,3 +27,5 @@
 - (BOOL)containsModule:(id<ParseModule>)module;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/Internal/ParseModule.m
+++ b/Parse/Internal/ParseModule.m
@@ -9,6 +9,8 @@
 
 #import "ParseModule.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 ///--------------------------------------
 #pragma mark - ParseModuleCollection
 ///--------------------------------------
@@ -30,10 +32,11 @@ typedef void (^ParseModuleEnumerationBlock)(id<ParseModule> module, BOOL *stop, 
 
 - (instancetype)init {
     self = [super init];
-    if (self) {
-        _collectionQueue = dispatch_queue_create("com.parse.ParseModuleCollection", DISPATCH_QUEUE_SERIAL);
-        _modules = [NSPointerArray weakObjectsPointerArray];
-    }
+    if (!self) return self;
+
+    _collectionQueue = dispatch_queue_create("com.parse.ParseModuleCollection", DISPATCH_QUEUE_SERIAL);
+    _modules = [NSPointerArray weakObjectsPointerArray];
+
     return self;
 }
 
@@ -42,20 +45,12 @@ typedef void (^ParseModuleEnumerationBlock)(id<ParseModule> module, BOOL *stop, 
 ///--------------------------------------
 
 - (void)addParseModule:(id<ParseModule>)module {
-    if (module == nil) {
-        return;
-    }
-
     [self performCollectionAccessBlock:^{
         [self.modules addPointer:(__bridge void *)module];
     }];
 }
 
 - (void)removeParseModule:(id<ParseModule>)module {
-    if (module == nil) {
-        return;
-    }
-
     [self enumerateModulesWithBlock:^(id<ParseModule> enumeratedModule, BOOL *stop, BOOL *remove) {
         *remove = (module == enumeratedModule);
     }];
@@ -80,7 +75,7 @@ typedef void (^ParseModuleEnumerationBlock)(id<ParseModule> module, BOOL *stop, 
 #pragma mark - ParseModule
 ///--------------------------------------
 
-- (void)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey {
+- (void)parseDidInitializeWithApplicationId:(NSString *)applicationId clientKey:(nullable NSString *)clientKey {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self enumerateModulesWithBlock:^(id<ParseModule> module, BOOL *stop, BOOL *remove) {
             [module parseDidInitializeWithApplicationId:applicationId clientKey:clientKey];
@@ -132,3 +127,5 @@ typedef void (^ParseModuleEnumerationBlock)(id<ParseModule> module, BOOL *stop, 
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -68,8 +68,6 @@ static ParseClientConfiguration *currentParseConfiguration_;
 + (void)initializeWithConfiguration:(ParseClientConfiguration *)configuration {
     PFConsistencyAssert(configuration.applicationId.length != 0,
                         @"You must set your configuration's `applicationId` before calling %s!", __PRETTY_FUNCTION__);
-    PFConsistencyAssert(configuration.clientKey.length != 0,
-                        @"You must set your configuration's `clientKey` before calling %s!", __PRETTY_FUNCTION__);
     PFConsistencyAssert(![PFApplication currentApplication].extensionEnvironment ||
                         configuration.applicationGroupIdentifier == nil ||
                         configuration.containingApplicationBundleIdentifier != nil,

--- a/Parse/ParseClientConfiguration.m
+++ b/Parse/ParseClientConfiguration.m
@@ -46,7 +46,6 @@ NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
     configurationBlock(self);
 
     PFConsistencyAssert(self.applicationId.length, @"`applicationId` should not be nil.");
-    PFConsistencyAssert(self.clientKey.length, @"`clientKey` should not be nil.");
 
     return self;
 }
@@ -65,7 +64,6 @@ NSString *const _ParseDefaultServerURLString = @"https://api.parse.com/1";
 }
 
 - (void)setClientKey:(NSString *)clientKey {
-    PFParameterAssert(clientKey.length, @"'clientKey' should not be nil.");
     _clientKey = [clientKey copy];
 }
 

--- a/Tests/Unit/ParseModuleUnitTests.m
+++ b/Tests/Unit/ParseModuleUnitTests.m
@@ -36,7 +36,7 @@
     ParseTestModule *module = [[ParseTestModule alloc] init];
     [collection addParseModule:module];
 
-    [collection parseDidInitializeWithApplicationId:nil clientKey:nil];
+    [collection parseDidInitializeWithApplicationId:@"a" clientKey:nil];
 
     // Spin the run loop, as the delegate messages are being called on the main thread
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
@@ -52,7 +52,7 @@
         [collection addParseModule:module];
     }
 
-    [collection parseDidInitializeWithApplicationId:nil clientKey:nil];
+    [collection parseDidInitializeWithApplicationId:@"a" clientKey:nil];
 
     // Run a single runloop tick to trigger the parse initializaiton.
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate distantPast]];
@@ -74,15 +74,6 @@
     XCTAssertTrue([collection containsModule:moduleB]);
     XCTAssertFalse([collection containsModule:moduleA]);
     XCTAssertEqual(collection.modulesCount, 1);
-}
-
-- (void)testNilModule {
-    ParseModuleCollection *collection = [[ParseModuleCollection alloc] init];
-
-    XCTAssertNoThrow([collection addParseModule:nil]);
-    XCTAssertEqual(collection.modulesCount, 0);
-    XCTAssertNoThrow([collection removeParseModule:nil]);
-    XCTAssertEqual(collection.modulesCount, 0);
 }
 
 @end

--- a/Tests/Unit/ParseSetupUnitTests.m
+++ b/Tests/Unit/ParseSetupUnitTests.m
@@ -46,11 +46,14 @@
     PFAssertThrowsInconsistencyException([Parse enableLocalDatastore]);
 }
 
-- (void)testInitializeWithNilApplicationIdNilClientKeyShouldThrowException {
+- (void)testInitializeWithNilApplicationIdShouldThrowException {
     NSString *yolo = nil;
     PFAssertThrowsInvalidArgumentException([Parse setApplicationId:yolo clientKey:yolo]);
     PFAssertThrowsInvalidArgumentException([Parse setApplicationId:yolo clientKey:@"a"]);
-    PFAssertThrowsInvalidArgumentException([Parse setApplicationId:@"a" clientKey:yolo]);
+}
+
+- (void)testInitializeWithoutClientKeyNoThrow {
+    XCTAssertNoThrow([Parse setApplicationId:@"a" clientKey:nil]);
 }
 
 @end


### PR DESCRIPTION
Implements and closes #826.

cc @hramos 