### PR TITLE
Move PFQueryKey constants to their own file to allow reuse throughout the Parse SDK.

### DIFF
--- a/Parse.xcodeproj/project.pbxproj
+++ b/Parse.xcodeproj/project.pbxproj
@@ -7,6 +7,20 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4030936B1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 403093691C81F0B200CF09F8 /* PFQueryConstants.h */; };
+		4030936C1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 403093691C81F0B200CF09F8 /* PFQueryConstants.h */; };
+		4030936D1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 403093691C81F0B200CF09F8 /* PFQueryConstants.h */; };
+		4030936E1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 403093691C81F0B200CF09F8 /* PFQueryConstants.h */; };
+		4030936F1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 403093691C81F0B200CF09F8 /* PFQueryConstants.h */; };
+		403093701C81F0B200CF09F8 /* PFQueryConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 403093691C81F0B200CF09F8 /* PFQueryConstants.h */; };
+		403093711C81F0B200CF09F8 /* PFQueryConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 403093691C81F0B200CF09F8 /* PFQueryConstants.h */; };
+		403093721C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
+		403093731C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
+		403093741C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
+		403093751C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
+		403093761C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
+		403093771C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
+		403093781C81F0B200CF09F8 /* PFQueryConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */; };
 		7CBC8DA116D594F800AEC66D /* PFTaskQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CF213BB16D41D980065CF1A /* PFTaskQueue.m */; };
 		8101550A1BB3832700D7C7BD /* PFWeakValue.m in Sources */ = {isa = PBXBuildFile; fileRef = 81C1EE481AE1EF960031C438 /* PFWeakValue.m */; };
 		8101550B1BB3832700D7C7BD /* PFUserState.m in Sources */ = {isa = PBXBuildFile; fileRef = 814BCDF01B4DF63600007B7F /* PFUserState.m */; };
@@ -2946,6 +2960,8 @@
 		09EEA12E1434FB1F00E3A3FA /* Parse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Parse.m; sourceTree = "<group>"; };
 		09EEA1351435143500E3A3FA /* ParseInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParseInternal.h; sourceTree = "<group>"; };
 		2FE3E9E9147B383200445083 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		403093691C81F0B200CF09F8 /* PFQueryConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFQueryConstants.h; sourceTree = "<group>"; };
+		4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFQueryConstants.m; sourceTree = "<group>"; };
 		44B78E11157D21B000A5E97F /* PFInstallation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PFInstallation.h; sourceTree = "<group>"; };
 		44B78E12157D21B000A5E97F /* PFInstallation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PFInstallation.m; sourceTree = "<group>"; };
 		498C29FE1551DC450034BB80 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
@@ -4625,6 +4641,8 @@
 		81A207C31AEB0AA0008A5F1A /* Query */ = {
 			isa = PBXGroup;
 			children = (
+				403093691C81F0B200CF09F8 /* PFQueryConstants.h */,
+				4030936A1C81F0B200CF09F8 /* PFQueryConstants.m */,
 				8166FC961B50381B003841A2 /* PFQueryPrivate.h */,
 				812B7AB51AF2FA3F00D15FF5 /* Controller */,
 				81C7F4A61AF42BD9007B5418 /* State */,
@@ -5333,6 +5351,7 @@
 				810156271BB3832700D7C7BD /* PFSQLiteDatabase.h in Headers */,
 				8101562A1BB3832700D7C7BD /* PFKeyValueCache.h in Headers */,
 				8101562C1BB3832700D7C7BD /* PFSessionController.h in Headers */,
+				403093701C81F0B200CF09F8 /* PFQueryConstants.h in Headers */,
 				8101562D1BB3832700D7C7BD /* PFRole.h in Headers */,
 				810156301BB3832700D7C7BD /* PFSession.h in Headers */,
 				810156311BB3832700D7C7BD /* PFEventuallyPin.h in Headers */,
@@ -5418,6 +5437,7 @@
 				815F23621BD04D150054659F /* PFCategoryLoader.h in Headers */,
 				815F23631BD04D150054659F /* PFThreadsafety.h in Headers */,
 				815F23641BD04D150054659F /* PFRelationState_Private.h in Headers */,
+				4030936E1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */,
 				815F23651BD04D150054659F /* ParseInternal.h in Headers */,
 				815F23671BD04D150054659F /* PFCoreDataProvider.h in Headers */,
 				815F23681BD04D150054659F /* ParseModule.h in Headers */,
@@ -5784,6 +5804,7 @@
 				8166FC9D1B503847003841A2 /* PFUserPrivate.h in Headers */,
 				81C7F4991AF42187007B5418 /* PFFileState.h in Headers */,
 				818AAA7219D36B1C00FC1B3C /* PFAnonymousUtils.h in Headers */,
+				4030936B1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */,
 				818D6F141B3C8D1900F94C82 /* PFObjectLocalIdStore.h in Headers */,
 				814881551B795CAC008763BF /* PFPropertyInfo_Runtime.h in Headers */,
 				8166FC891B503794003841A2 /* PFInstallationPrivate.h in Headers */,
@@ -6006,6 +6027,7 @@
 				81C584361C3B0A98000063C6 /* PFUserPrivate.h in Headers */,
 				81C584371C3B0A98000063C6 /* PFFileState.h in Headers */,
 				81C584381C3B0A98000063C6 /* PFAnonymousUtils.h in Headers */,
+				4030936C1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */,
 				81C584391C3B0A98000063C6 /* PFObjectLocalIdStore.h in Headers */,
 				81C5843A1C3B0A98000063C6 /* PFPropertyInfo_Runtime.h in Headers */,
 				81C5843B1C3B0A98000063C6 /* PFInstallationPrivate.h in Headers */,
@@ -6068,6 +6090,7 @@
 				81C585081C3B0AA1000063C6 /* PFCategoryLoader.h in Headers */,
 				81C585091C3B0AA1000063C6 /* PFThreadsafety.h in Headers */,
 				81C5850A1C3B0AA1000063C6 /* PFRelationState_Private.h in Headers */,
+				4030936F1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */,
 				81C5850B1C3B0AA1000063C6 /* ParseInternal.h in Headers */,
 				81C5850C1C3B0AA1000063C6 /* PFCoreDataProvider.h in Headers */,
 				81C5850D1C3B0AA1000063C6 /* ParseModule.h in Headers */,
@@ -6384,6 +6407,7 @@
 				81C586D11C3B0AA9000063C6 /* PFSQLiteDatabase.h in Headers */,
 				81C586D21C3B0AA9000063C6 /* PFKeyValueCache.h in Headers */,
 				81C586D31C3B0AA9000063C6 /* PFSessionController.h in Headers */,
+				403093711C81F0B200CF09F8 /* PFQueryConstants.h in Headers */,
 				81C586D41C3B0AA9000063C6 /* PFRole.h in Headers */,
 				81C586D51C3B0AA9000063C6 /* PFSession.h in Headers */,
 				81C586D61C3B0AA9000063C6 /* PFEventuallyPin.h in Headers */,
@@ -6599,6 +6623,7 @@
 				815EE91E19F987910076FE5D /* PFRESTCloudCommand.h in Headers */,
 				81146C7F1A785203001F8473 /* PFRESTObjectCommand.h in Headers */,
 				8124C8741B26B9E700758E00 /* PFPinningObjectStore.h in Headers */,
+				4030936D1C81F0B200CF09F8 /* PFQueryConstants.h in Headers */,
 				81EB6635198A7FA600851598 /* PFConfig.h in Headers */,
 				81F0E89C19E6F83E00812A88 /* PFObject+Subclass.h in Headers */,
 				815EE8F619F976D50076FE5D /* PFRESTCommand.h in Headers */,
@@ -7258,6 +7283,7 @@
 				810155511BB3832700D7C7BD /* PFACLState.m in Sources */,
 				810155521BB3832700D7C7BD /* PFRESTConfigCommand.m in Sources */,
 				810155531BB3832700D7C7BD /* PFQueryUtilities.m in Sources */,
+				403093771C81F0B200CF09F8 /* PFQueryConstants.m in Sources */,
 				810155561BB3832700D7C7BD /* PFOfflineObjectController.m in Sources */,
 				810155571BB3832700D7C7BD /* PFKeychainStore.m in Sources */,
 				810155591BB3832700D7C7BD /* PFQueryState.m in Sources */,
@@ -7344,6 +7370,7 @@
 				815F22BF1BD04D150054659F /* PFCommandRunningConstants.m in Sources */,
 				815F22C01BD04D150054659F /* PFDevice.m in Sources */,
 				815F22C11BD04D150054659F /* PFSQLiteStatement.m in Sources */,
+				403093751C81F0B200CF09F8 /* PFQueryConstants.m in Sources */,
 				815F22C21BD04D150054659F /* ParseModule.m in Sources */,
 				815F22C31BD04D150054659F /* PFACL.m in Sources */,
 				815F22C41BD04D150054659F /* PFUserController.m in Sources */,
@@ -7808,6 +7835,7 @@
 				81E7A2271B6042BD006CB680 /* PFObjectFileCodingLogic.m in Sources */,
 				8124C88C1B276B8800758E00 /* PFObjectFilePersistenceController.m in Sources */,
 				818D586C1B5D9F4B00813989 /* PFURLSessionCommandRunner.m in Sources */,
+				403093721C81F0B200CF09F8 /* PFQueryConstants.m in Sources */,
 				815619021A1F79AC0076504A /* PFDateFormatter.m in Sources */,
 				8124C8751B26B9E700758E00 /* PFPinningObjectStore.m in Sources */,
 				81C7F49B1AF42187007B5418 /* PFFileState.m in Sources */,
@@ -7967,6 +7995,7 @@
 				81C583421C3B0A98000063C6 /* PFObjectFileCodingLogic.m in Sources */,
 				81C583431C3B0A98000063C6 /* PFObjectFilePersistenceController.m in Sources */,
 				81C583441C3B0A98000063C6 /* PFURLSessionCommandRunner.m in Sources */,
+				403093731C81F0B200CF09F8 /* PFQueryConstants.m in Sources */,
 				81C583451C3B0A98000063C6 /* PFDateFormatter.m in Sources */,
 				81C583461C3B0A98000063C6 /* PFPinningObjectStore.m in Sources */,
 				81C583471C3B0A98000063C6 /* PFFileState.m in Sources */,
@@ -8047,6 +8076,7 @@
 				81C584711C3B0AA1000063C6 /* PFCommandRunningConstants.m in Sources */,
 				81C584721C3B0AA1000063C6 /* PFDevice.m in Sources */,
 				81C584731C3B0AA1000063C6 /* PFSQLiteStatement.m in Sources */,
+				403093761C81F0B200CF09F8 /* PFQueryConstants.m in Sources */,
 				81C584741C3B0AA1000063C6 /* ParseModule.m in Sources */,
 				81C584751C3B0AA1000063C6 /* PFACL.m in Sources */,
 				81C584761C3B0AA1000063C6 /* PFUserController.m in Sources */,
@@ -8248,6 +8278,7 @@
 				81C586091C3B0AA9000063C6 /* PFACLState.m in Sources */,
 				81C5860A1C3B0AA9000063C6 /* PFRESTConfigCommand.m in Sources */,
 				81C5860B1C3B0AA9000063C6 /* PFQueryUtilities.m in Sources */,
+				403093781C81F0B200CF09F8 /* PFQueryConstants.m in Sources */,
 				81C5860C1C3B0AA9000063C6 /* PFOfflineObjectController.m in Sources */,
 				81C5860D1C3B0AA9000063C6 /* PFKeychainStore.m in Sources */,
 				81C5860E1C3B0AA9000063C6 /* PFQueryState.m in Sources */,
@@ -8421,6 +8452,7 @@
 				812B7ABB1AF2FA4800D15FF5 /* PFQueryController.m in Sources */,
 				812145801AA4A808000B23F5 /* PFRESTSessionCommand.m in Sources */,
 				81EEE1B31B446D600087AC4D /* PFCurrentUserController.m in Sources */,
+				403093741C81F0B200CF09F8 /* PFQueryConstants.m in Sources */,
 				814BCDF41B4DF63600007B7F /* PFUserState.m in Sources */,
 				818D6F231B3DCB5A00F94C82 /* PFObjectEstimatedData.m in Sources */,
 				81C7F49C1AF42187007B5418 /* PFFileState.m in Sources */,

--- a/Parse/Internal/Commands/PFRESTQueryCommand.m
+++ b/Parse/Internal/Commands/PFRESTQueryCommand.m
@@ -14,6 +14,7 @@
 #import "PFHTTPRequest.h"
 #import "PFQueryPrivate.h"
 #import "PFQueryState.h"
+#import "PFQueryConstants.h"
 
 @implementation PFRESTQueryCommand
 
@@ -133,7 +134,7 @@
     if (conditions.count > 0) {
         NSMutableDictionary *whereData = [[NSMutableDictionary alloc] init];
         [conditions enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-            if ([key isEqualToString:@"$or"]) {
+            if ([key isEqualToString:PFQueryKeyOr]) {
                 NSArray *array = (NSArray *)obj;
                 NSMutableArray *newArray = [NSMutableArray array];
                 for (PFQuery *subquery in array) {

--- a/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
+++ b/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
@@ -24,6 +24,7 @@
 #import "PFQueryPrivate.h"
 #import "PFRelation.h"
 #import "PFRelationPrivate.h"
+#import "PFQueryConstants.h"
 
 typedef BOOL (^PFComparatorDeciderBlock)(id value, id constraint);
 typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);

--- a/Parse/Internal/Query/Controller/PFOfflineQueryController.m
+++ b/Parse/Internal/Query/Controller/PFOfflineQueryController.m
@@ -19,6 +19,7 @@
 #import "PFQueryState.h"
 #import "PFRESTCommand.h"
 #import "PFRelationPrivate.h"
+#import "PFQueryConstants.h"
 
 @interface PFOfflineQueryController () {
     PFOfflineStore *_offlineStore; // TODO: (nlutsenko) Lazy-load this via self.dataSource.
@@ -63,7 +64,7 @@
                                                                  user:user];
     }
 
-    NSDictionary *relationCondition = queryState.conditions[@"$relatedTo"];
+    NSDictionary *relationCondition = queryState.conditions[PFQueryKeyRelatedTo];
     if (relationCondition) {
         PFObject *object = relationCondition[@"object"];
         NSString *key = relationCondition[@"key"];

--- a/Parse/Internal/Query/PFQueryConstants.h
+++ b/Parse/Internal/Query/PFQueryConstants.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const PFQueryKeyNotEqualTo;
+extern NSString *const PFQueryKeyLessThan;
+extern NSString *const PFQueryKeyLessThanEqualTo;
+extern NSString *const PFQueryKeyGreaterThan;
+extern NSString *const PFQueryKeyGreaterThanOrEqualTo;
+extern NSString *const PFQueryKeyContainedIn;
+extern NSString *const PFQueryKeyNotContainedIn;
+extern NSString *const PFQueryKeyContainsAll;
+extern NSString *const PFQueryKeyNearSphere;
+extern NSString *const PFQueryKeyWithin;
+extern NSString *const PFQueryKeyRegex;
+extern NSString *const PFQueryKeyExists;
+extern NSString *const PFQueryKeyInQuery;
+extern NSString *const PFQueryKeyNotInQuery;
+extern NSString *const PFQueryKeySelect;
+extern NSString *const PFQueryKeyDontSelect;
+extern NSString *const PFQueryKeyRelatedTo;
+extern NSString *const PFQueryKeyOr;
+extern NSString *const PFQueryKeyQuery;
+extern NSString *const PFQueryKeyKey;
+extern NSString *const PFQueryKeyObject;
+
+extern NSString *const PFQueryOptionKeyMaxDistance;
+extern NSString *const PFQueryOptionKeyBox;
+extern NSString *const PFQueryOptionKeyRegexOptions;
+
+NS_ASSUME_NONNULL_END

--- a/Parse/Internal/Query/PFQueryConstants.m
+++ b/Parse/Internal/Query/PFQueryConstants.m
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "PFQueryConstants.h"
+
+NSString *const PFQueryKeyNotEqualTo = @"$ne";
+NSString *const PFQueryKeyLessThan = @"$lt";
+NSString *const PFQueryKeyLessThanEqualTo = @"$lte";
+NSString *const PFQueryKeyGreaterThan = @"$gt";
+NSString *const PFQueryKeyGreaterThanOrEqualTo = @"$gte";
+NSString *const PFQueryKeyContainedIn = @"$in";
+NSString *const PFQueryKeyNotContainedIn = @"$nin";
+NSString *const PFQueryKeyContainsAll = @"$all";
+NSString *const PFQueryKeyNearSphere = @"$nearSphere";
+NSString *const PFQueryKeyWithin = @"$within";
+NSString *const PFQueryKeyRegex = @"$regex";
+NSString *const PFQueryKeyExists = @"$exists";
+NSString *const PFQueryKeyInQuery = @"$inQuery";
+NSString *const PFQueryKeyNotInQuery = @"$notInQuery";
+NSString *const PFQueryKeySelect = @"$select";
+NSString *const PFQueryKeyDontSelect = @"$dontSelect";
+NSString *const PFQueryKeyRelatedTo = @"$relatedTo";
+NSString *const PFQueryKeyOr = @"$or";
+NSString *const PFQueryKeyQuery = @"query";
+NSString *const PFQueryKeyKey = @"key";
+NSString *const PFQueryKeyObject = @"object";
+
+NSString *const PFQueryOptionKeyMaxDistance = @"$maxDistance";
+NSString *const PFQueryOptionKeyBox = @"$box";
+NSString *const PFQueryOptionKeyRegexOptions = @"$options";

--- a/Parse/Internal/Query/PFQueryPrivate.h
+++ b/Parse/Internal/Query/PFQueryPrivate.h
@@ -13,32 +13,6 @@
 
 #import "PFQueryState.h"
 
-extern NSString *const PFQueryKeyNotEqualTo;
-extern NSString *const PFQueryKeyLessThan;
-extern NSString *const PFQueryKeyLessThanEqualTo;
-extern NSString *const PFQueryKeyGreaterThan;
-extern NSString *const PFQueryKeyGreaterThanOrEqualTo;
-extern NSString *const PFQueryKeyContainedIn;
-extern NSString *const PFQueryKeyNotContainedIn;
-extern NSString *const PFQueryKeyContainsAll;
-extern NSString *const PFQueryKeyNearSphere;
-extern NSString *const PFQueryKeyWithin;
-extern NSString *const PFQueryKeyRegex;
-extern NSString *const PFQueryKeyExists;
-extern NSString *const PFQueryKeyInQuery;
-extern NSString *const PFQueryKeyNotInQuery;
-extern NSString *const PFQueryKeySelect;
-extern NSString *const PFQueryKeyDontSelect;
-extern NSString *const PFQueryKeyRelatedTo;
-extern NSString *const PFQueryKeyOr;
-extern NSString *const PFQueryKeyQuery;
-extern NSString *const PFQueryKeyKey;
-extern NSString *const PFQueryKeyObject;
-
-extern NSString *const PFQueryOptionKeyMaxDistance;
-extern NSString *const PFQueryOptionKeyBox;
-extern NSString *const PFQueryOptionKeyRegexOptions;
-
 @class BFTask<__covariant BFGenericType>;
 @class PFObject;
 

--- a/Parse/Internal/Query/State/PFMutableQueryState.m
+++ b/Parse/Internal/Query/State/PFMutableQueryState.m
@@ -8,6 +8,7 @@
  */
 
 #import "PFMutableQueryState.h"
+#import "PFQueryConstants.h"
 
 #import "PFQueryState_Private.h"
 
@@ -103,7 +104,7 @@
     NSMutableDictionary *condition = [NSMutableDictionary dictionaryWithCapacity:2];
     condition[@"object"] = object;
     condition[@"key"] = key;
-    [self setEqualityConditionWithObject:condition forKey:@"$relatedTo"];
+    [self setEqualityConditionWithObject:condition forKey:PFQueryKeyRelatedTo];
 }
 
 - (void)removeAllConditions {

--- a/Parse/PFQuery.m
+++ b/Parse/PFQuery.m
@@ -34,32 +34,7 @@
 #import "PFUserPrivate.h"
 #import "ParseInternal.h"
 #import "Parse_Private.h"
-
-NSString *const PFQueryKeyNotEqualTo = @"$ne";
-NSString *const PFQueryKeyLessThan = @"$lt";
-NSString *const PFQueryKeyLessThanEqualTo = @"$lte";
-NSString *const PFQueryKeyGreaterThan = @"$gt";
-NSString *const PFQueryKeyGreaterThanOrEqualTo = @"$gte";
-NSString *const PFQueryKeyContainedIn = @"$in";
-NSString *const PFQueryKeyNotContainedIn = @"$nin";
-NSString *const PFQueryKeyContainsAll = @"$all";
-NSString *const PFQueryKeyNearSphere = @"$nearSphere";
-NSString *const PFQueryKeyWithin = @"$within";
-NSString *const PFQueryKeyRegex = @"$regex";
-NSString *const PFQueryKeyExists = @"$exists";
-NSString *const PFQueryKeyInQuery = @"$inQuery";
-NSString *const PFQueryKeyNotInQuery = @"$notInQuery";
-NSString *const PFQueryKeySelect = @"$select";
-NSString *const PFQueryKeyDontSelect = @"$dontSelect";
-NSString *const PFQueryKeyRelatedTo = @"$relatedTo";
-NSString *const PFQueryKeyOr = @"$or";
-NSString *const PFQueryKeyQuery = @"query";
-NSString *const PFQueryKeyKey = @"key";
-NSString *const PFQueryKeyObject = @"object";
-
-NSString *const PFQueryOptionKeyMaxDistance = @"$maxDistance";
-NSString *const PFQueryOptionKeyBox = @"$box";
-NSString *const PFQueryOptionKeyRegexOptions = @"$options";
+#import "PFQueryConstants.h"
 
 /**
  Checks if an object can be used as value for query equality clauses.


### PR DESCRIPTION
I wasn't sure if it would make sense to use the constants in the unit tests, and I left them alone. I'd be happy to update the PR to use the constants in the unit tests, if so desired.

This change is cosmetic, and as such, I didn't add any unit tests.

I wasn't able to run the unit tests due to this build error:

![screenshot at feb 26 10-06-11](https://cloud.githubusercontent.com/assets/768997/13357562/9865a2da-dc70-11e5-92a4-9f21d7fd9eea.png)

I suspect the error is due to my inexperience with Carthage.