### PR TITLE
Require clientKey for old SDK initialization API.

### DIFF
--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -54,6 +54,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
 ///--------------------------------------
 
 + (void)setApplicationId:(NSString *)applicationId clientKey:(NSString *)clientKey {
+    PFParameterAssert(clientKey.length, @"`clientKey` should not be nil.");
     currentParseConfiguration_.applicationId = applicationId;
     currentParseConfiguration_.clientKey = clientKey;
     currentParseConfiguration_.server = [PFInternalUtils parseServerURLString]; // TODO: (nlutsenko) Clean this up after tests are updated.

--- a/Tests/Unit/ParseSetupUnitTests.m
+++ b/Tests/Unit/ParseSetupUnitTests.m
@@ -50,10 +50,7 @@
     NSString *yolo = nil;
     PFAssertThrowsInvalidArgumentException([Parse setApplicationId:yolo clientKey:yolo]);
     PFAssertThrowsInvalidArgumentException([Parse setApplicationId:yolo clientKey:@"a"]);
-}
-
-- (void)testInitializeWithoutClientKeyNoThrow {
-    XCTAssertNoThrow([Parse setApplicationId:@"a" clientKey:nil]);
+    PFAssertThrowsInvalidArgumentException([Parse setApplicationId:@"a" clientKey:yolo]);
 }
 
 @end


### PR DESCRIPTION
The old API, since it's using parse.com should still require clientKey.