### PR TITLE
Disable Carthage builds, since it consistently times out on xcodebuild.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
     - TEST_TYPE=Deployment
     - TEST_TYPE=Starters
     - TEST_TYPE=CocoaPods
-    - TEST_TYPE=Carthage
 git:
   submodules: false
 before_install:


### PR DESCRIPTION
Re-enable issue with more details -> #850 