### PR TITLE
Fix Swift 2.2 naming conversion for PFObject.+objectWithoutDataWithClassName:objectId:.

### DIFF
--- a/Parse/PFObject.h
+++ b/Parse/PFObject.h
@@ -77,7 +77,8 @@ NS_REQUIRES_PROPERTY_DEFINITIONS
 
  @return A `PFObject` instance without data.
  */
-+ (instancetype)objectWithoutDataWithClassName:(NSString *)className objectId:(nullable NSString *)objectId;
++ (instancetype)objectWithoutDataWithClassName:(NSString *)className
+                                      objectId:(nullable NSString *)objectId NS_SWIFT_NAME(init(withoutDataWithClassName:objectId:));
 
 ///--------------------------------------
 #pragma mark - Managing Object Properties


### PR DESCRIPTION
Fixes #806.