### PR TITLE
Add assertion that makes it invalid to initialize Parse twice in a single runtime.

### DIFF
--- a/Parse/Parse.h
+++ b/Parse/Parse.h
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The current client key that was used to configure Parse framework.
  */
-+ (NSString *)getClientKey;
++ (nullable NSString *)getClientKey;
 
 ///--------------------------------------
 #pragma mark - Enabling Local Datastore

--- a/Parse/Parse.m
+++ b/Parse/Parse.m
@@ -73,6 +73,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
                         configuration.applicationGroupIdentifier == nil ||
                         configuration.containingApplicationBundleIdentifier != nil,
                         @"'containingApplicationBundleIdentifier' must be non-nil in extension environment");
+    PFConsistencyAssert(![self currentConfiguration], @"Parse is already initialized.");
 
     ParseManager *manager = [[ParseManager alloc] initWithConfiguration:configuration];
     [manager startManaging];
@@ -104,7 +105,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
     [[self parseModulesCollection] parseDidInitializeWithApplicationId:configuration.applicationId clientKey:configuration.clientKey];
 }
 
-+ (ParseClientConfiguration *)currentConfiguration {
++ (nullable ParseClientConfiguration *)currentConfiguration {
     return currentParseManager_.configuration;
 }
 
@@ -114,7 +115,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
     return currentParseManager_.configuration.applicationId;
 }
 
-+ (NSString *)getClientKey {
++ (nullable NSString *)getClientKey {
     PFConsistencyAssert(currentParseManager_,
                         @"You have to call setApplicationId:clientKey: on Parse to configure Parse.");
     return currentParseManager_.configuration.clientKey;

--- a/Tests/Unit/InstallationIdentifierUnitTests.m
+++ b/Tests/Unit/InstallationIdentifierUnitTests.m
@@ -8,34 +8,21 @@
  */
 
 #import "PFInstallationIdentifierStore_Private.h"
-#import "PFTestCase.h"
+#import "PFUnitTestCase.h"
 #import "Parse_Private.h"
 #import "BFTask+Private.h"
 
-@interface InstallationIdentifierUnitTests : PFTestCase
+@interface InstallationIdentifierUnitTests : PFUnitTestCase
 
 @end
 
 @implementation InstallationIdentifierUnitTests
 
 ///--------------------------------------
-#pragma mark - XCTestCase
-///--------------------------------------
-
-- (void)tearDown {
-    [[Parse _currentManager] clearEventuallyQueue];
-    [[[Parse _currentManager].installationIdentifierStore clearInstallationIdentifierAsync] waitForResult:nil];
-    [Parse _clearCurrentManager];
-
-    [super tearDown];
-}
-
-///--------------------------------------
 #pragma mark - Tests
 ///--------------------------------------
 
 - (void)testNewInstallationIdentifierIsLowercase {
-    [Parse setApplicationId:@"b" clientKey:@"c"];
     PFInstallationIdentifierStore *store = [Parse _currentManager].installationIdentifierStore;
 
     XCTestExpectation *expectation = [self currentSelectorTestExpectation];
@@ -51,7 +38,6 @@
 }
 
 - (void)testCachedInstallationId {
-    [Parse setApplicationId:@"b" clientKey:@"c"];
     PFInstallationIdentifierStore *store = [Parse _currentManager].installationIdentifierStore;
 
     [[store _clearCachedInstallationIdentifierAsync] waitForResult:nil];

--- a/Tests/Unit/InstallationUnitTests.m
+++ b/Tests/Unit/InstallationUnitTests.m
@@ -8,20 +8,14 @@
  */
 
 #import "PFInstallation.h"
-#import "PFTestCase.h"
+#import "PFUnitTestCase.h"
 #import "Parse.h"
 
-@interface InstallationUnitTests : PFTestCase
+@interface InstallationUnitTests : PFUnitTestCase
 
 @end
 
 @implementation InstallationUnitTests
-
-+ (void)setUp {
-    [super setUp];
-
-    [Parse setApplicationId:@"a" clientKey:@"a"];
-}
 
 - (void)testInstallationImmutableFieldsCannotBeChanged {
     PFInstallation *installation = [PFInstallation currentInstallation];

--- a/Tests/Unit/SessionUnitTests.m
+++ b/Tests/Unit/SessionUnitTests.m
@@ -15,6 +15,7 @@
 #import "PFSession_Private.h"
 #import "PFUnitTestCase.h"
 #import "Parse_Private.h"
+#import "PFObjectSubclassingController.h"
 
 @interface SessionUnitTests : PFUnitTestCase
 
@@ -44,12 +45,13 @@
 ///--------------------------------------
 
 - (void)testSessionClassIsRegistered {
+    [[Parse _currentManager] clearEventuallyQueue];
+    [Parse _clearCurrentManager];
+    [PFObjectSubclassingController clearDefaultController];
+
     [PFObject unregisterSubclass:[PFSession class]];
     [Parse setApplicationId:@"a" clientKey:@"b"];
     XCTAssertNotNil([PFSession query]);
-
-    [[Parse _currentManager] clearEventuallyQueue];
-    [Parse _clearCurrentManager];
 }
 
 - (void)testConstructorsClassNameValidation {


### PR DESCRIPTION
We might want to introduce a method that teardowns Parse completely at a later point as well.
What do you think would be a good name for that method? `resetConfiguration`? `deinitialize`?

Also, needed to cleanup these tests, since the setup/teardown logic was inconsistent.