### PR TITLE
Unify and provide consistent client-side error and exception reporting.

### DIFF
--- a/Parse/Internal/FieldOperation/PFFieldOperation.m
+++ b/Parse/Internal/FieldOperation/PFFieldOperation.m
@@ -25,17 +25,17 @@
 @implementation PFFieldOperation
 
 - (id)encodeWithObjectEncoder:(PFEncoder *)objectEncoder {
-    PFConsistencyAssert(NO, @"Operation is invalid.");
+    PFConsistencyAssertionFailure(@"Operation is invalid.");
     return nil;
 }
 
 - (PFFieldOperation *)mergeWithPrevious:(PFFieldOperation *)previous {
-    PFConsistencyAssert(NO, @"Operation is invalid.");
+    PFConsistencyAssertionFailure(@"Operation is invalid.");
     return nil;
 }
 
 - (id)applyToValue:(id)oldValue forKey:(NSString *)key {
-    PFConsistencyAssert(NO, @"Operation is invalid.");
+    PFConsistencyAssertionFailure(@"Operation is invalid.");
     return nil;
 }
 
@@ -153,7 +153,7 @@
                                               withNumber:((PFIncrementOperation *)previous).amount];
         return [PFIncrementOperation incrementWithAmount:newAmount];
     }
-    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    PFConsistencyAssertionFailure(@"This operation is invalid after previous operation.");
     return nil;
 }
 
@@ -208,7 +208,7 @@
             NSArray *newArray = [oldArray arrayByAddingObjectsFromArray:self.objects];
             return [PFSetOperation setWithValue:newArray];
         } else {
-            [NSException raise:NSInternalInconsistencyException format:@"You can't add an item to a non-array."];
+            PFConsistencyAssertionFailure(@"Unable to add an item to a non-array.");
             return nil;
         }
     } else if ([previous isKindOfClass:[PFAddOperation class]]) {
@@ -216,7 +216,7 @@
         [newObjects addObjectsFromArray:self.objects];
         return [[self class] addWithObjects:newObjects];
     }
-    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    PFConsistencyAssertionFailure(@"This operation is invalid after previous operation.");
     return nil;
 }
 
@@ -226,7 +226,7 @@
     } else if ([oldValue isKindOfClass:[NSArray class]]) {
         return [((NSArray *)oldValue)arrayByAddingObjectsFromArray:self.objects];
     }
-    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    PFConsistencyAssertionFailure(@"This operation is invalid after previous operation.");
     return nil;
 }
 
@@ -267,14 +267,14 @@
             NSArray *oldArray = (((PFSetOperation *)previous).value);
             return [PFSetOperation setWithValue:[self applyToValue:oldArray forKey:nil]];
         } else {
-            [NSException raise:NSInternalInconsistencyException format:@"You can't add an item to a non-array."];
+            PFConsistencyAssertionFailure(@"Unable to add an item to a non-array.");
             return nil;
         }
     } else if ([previous isKindOfClass:[PFAddUniqueOperation class]]) {
         NSArray *previousObjects = ((PFAddUniqueOperation *)previous).objects;
         return [[self class] addUniqueWithObjects:[self applyToValue:previousObjects forKey:nil]];
     }
-    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    PFConsistencyAssertionFailure(@"This operation is invalid after previous operation.");
     return nil;
 }
 
@@ -302,7 +302,7 @@
         }
         return newValue;
     }
-    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    PFConsistencyAssertionFailure(@"This operation is invalid after previous operation.");
     return nil;
 }
 
@@ -336,14 +336,14 @@
     if (!previous) {
         return self;
     } else if ([previous isKindOfClass:[PFDeleteOperation class]]) {
-        [NSException raise:NSInternalInconsistencyException format:@"You can't remove items from a deleted array."];
+        PFConsistencyAssertionFailure(@"Unable to remove items from a deleted array.");
         return nil;
     } else if ([previous isKindOfClass:[PFSetOperation class]]) {
         if ([((PFSetOperation *)previous).value isKindOfClass:[NSArray class]]) {
             NSArray *oldArray = ((PFSetOperation *)previous).value;
             return [PFSetOperation setWithValue:[self applyToValue:oldArray forKey:nil]];
         } else {
-            [NSException raise:NSInternalInconsistencyException format:@"You can't add an item to a non-array."];
+            PFConsistencyAssertionFailure(@"Unable to add an item to a non-array.");
             return nil;
         }
     } else if ([previous isKindOfClass:[PFRemoveOperation class]]) {
@@ -351,7 +351,7 @@
         return [PFRemoveOperation removeWithObjects:newObjects];
     }
 
-    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    PFConsistencyAssertionFailure(@"This operation is invalid after previous operation.");
     return nil;
 }
 
@@ -379,7 +379,7 @@
         }
         return newValue;
     }
-    [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+    PFConsistencyAssertionFailure(@"This operation is invalid after previous operation.");
     return nil;
 }
 
@@ -474,8 +474,7 @@
     if (removeDict) {
         return removeDict;
     }
-
-    [NSException raise:NSInternalInconsistencyException format:@"A PFRelationOperation was created without any data."];
+    PFConsistencyAssertionFailure(@"A PFRelationOperation was created without any data.");
     return nil;
 }
 
@@ -535,7 +534,7 @@
             }
         }
     } else {
-        [NSException raise:NSInternalInconsistencyException format:@"Operation is invalid after previous operation."];
+        PFConsistencyAssertionFailure(@"This operation is invalid after previous operation.");
         return nil;
     }
 

--- a/Parse/Internal/Installation/Controller/PFInstallationController.m
+++ b/Parse/Internal/Installation/Controller/PFInstallationController.m
@@ -83,12 +83,12 @@
 ///--------------------------------------
 
 - (BFTask *)deleteObjectAsync:(PFObject *)object withSessionToken:(nullable NSString *)sessionToken {
-    PFConsistencyAssert(NO, @"Installations cannot be deleted.");
+    PFConsistencyAssertionFailure(@"Installations cannot be deleted.");
     return nil;
 }
 
 - (BFTask *)processDeleteResultAsync:(nullable NSDictionary *)result forObject:(PFObject *)object {
-    PFConsistencyAssert(NO, @"Installations cannot be deleted.");
+    PFConsistencyAssertionFailure(@"Installations cannot be deleted.");
     return nil;
 }
 

--- a/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
+++ b/Parse/Internal/LocalDataStore/OfflineQueryLogic/PFOfflineQueryLogic.m
@@ -126,7 +126,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
                     return [self valueForContainer:restFormat key:rest depth:depth + 1];
                 }
             }
-            [NSException raise:NSInvalidArgumentException format:@"Key %@ is invalid", key];
+            PFParameterAssertionFailure(@"Key %@ is invalid.", key);
         }
         return [self valueForContainer:value key:rest depth:depth + 1];
     }
@@ -152,7 +152,7 @@ typedef BOOL (^PFSubQueryMatcherBlock)(id object, NSArray *results);
     } else if (container == nil) {
         return nil;
     } else {
-        [NSException raise:NSInvalidArgumentException format:@"Bad key %@", key];
+        PFParameterAssertionFailure(@"Bad key %@", key);
         // Shouldn't reach here.
         return nil;
     }
@@ -457,9 +457,7 @@ greaterThanOrEqualTo:(id)constraint {
     } else if ([operator isEqualToString:PFQueryKeyWithin]) {
         return [self matchesValue:value within:constraint];
     }
-
-    [NSException raise:NSInvalidArgumentException
-                format:@"The offline store does not yet support %@ operator.", operator];
+    PFParameterAssertionFailure(@"Local Datastore does not yet support %@ operator.", operator);
     // Shouldn't reach here
     return YES;
 }
@@ -710,10 +708,9 @@ greaterThanOrEqualTo:(id)constraint {
             // throwing an exception.
             return nil;
         }
-        NSException *exception = [NSException exceptionWithName:NSInternalInconsistencyException
-                                                         reason:@"include is invalid"
-                                                       userInfo:nil];
-        return [BFTask taskWithException:exception];
+        NSError *error = [PFErrorUtilities errorWithCode:kPFErrorInvalidNestedKey
+                                                 message:@"include is invalid"];
+        return [BFTask taskWithError:error];
     }] continueWithSuccessBlock:^id(BFTask *task) {
         return [self fetchIncludeAsync:rest container:task.result database:database];
     }];

--- a/Parse/Internal/PFAssert.h
+++ b/Parse/Internal/PFAssert.h
@@ -25,15 +25,24 @@
     } while(0)
 
 /**
+ Raises an `NSInvalidArgumentException`. Use `description` to supply the way to fix the exception.
+ */
+#define PFParameterAssertionFailure(description, ...) \
+do {\
+    [NSException raise:NSInvalidArgumentException \
+                format:description, ##__VA_ARGS__]; \
+} while(0)
+
+/**
  Raises an `NSRangeException` if the `condition` does not pass.
  Use `description` to supply the way to fix the exception.
  */
 #define PFRangeAssert(condition, description, ...) \
-    do {\
-        if (!(condition)) { \
-            [NSException raise:NSRangeException \
-                        format:description, ##__VA_ARGS__]; \
-    } \
+do {\
+    if (!(condition)) { \
+        [NSException raise:NSRangeException \
+                    format:description, ##__VA_ARGS__]; \
+} \
 } while(0)
 
 /**
@@ -41,12 +50,21 @@
  Use `description` to supply the way to fix the exception.
  */
 #define PFConsistencyAssert(condition, description, ...) \
-    do { \
-        if (!(condition)) { \
-            [NSException raise:NSInternalInconsistencyException \
-                        format:description, ##__VA_ARGS__]; \
-        } \
-    } while(0)
+do { \
+    if (!(condition)) { \
+        [NSException raise:NSInternalInconsistencyException \
+                    format:description, ##__VA_ARGS__]; \
+    } \
+} while(0)
+
+/**
+ Raises an `NSInternalInconsistencyException`. Use `description` to supply the way to fix the exception.
+ */
+#define PFConsistencyAssertionFailure(description, ...) \
+do {\
+    [NSException raise:NSInternalInconsistencyException \
+                format:description, ##__VA_ARGS__]; \
+} while(0)
 
 /**
  Always raises `NSInternalInconsistencyException` with details
@@ -54,10 +72,9 @@
  */
 #define PFNotDesignatedInitializer() \
 do { \
-    PFConsistencyAssert(NO, \
-                        @"%@ is not the designated initializer for instances of %@.", \
-                        NSStringFromSelector(_cmd), \
-                        NSStringFromClass([self class])); \
+    PFConsistencyAssertionFailure(@"%@ is not the designated initializer for instances of %@.", \
+                                  NSStringFromSelector(_cmd), \
+                                  NSStringFromClass([self class])); \
     return nil; \
 } while (0)
 

--- a/Parse/Internal/PFEncoder.m
+++ b/Parse/Internal/PFEncoder.m
@@ -55,9 +55,6 @@
             // Returning this empty object is strictly wrong, but we have to have *something*
             // to put into an object's mutable container cache, and this is just about the
             // best we can do right now.
-            //
-            // [NSException raise:NSInternalInconsistencyException
-            //             format:@"Tried to serialize an unsaved file."];
             return @{ @"__type" : @"File" };
         }
         return @{
@@ -122,7 +119,7 @@
 }
 
 - (id)encodeParseObject:(PFObject *)object {
-    [NSException raise:NSInternalInconsistencyException format:@"PFObjects are not allowed here."];
+    PFConsistencyAssertionFailure(@"PFObjects are not allowed here.");
     return nil;
 }
 

--- a/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Internal/PFEventuallyQueue.m
@@ -325,11 +325,10 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
         return [self.dataSource.commandRunner runCommandAsync:(PFRESTCommand *)command withOptions:0];
     }
 
-    NSString *reason = [NSString stringWithFormat:@"Can't find a compatible runner for command %@.", command];
-    NSException *exception = [NSException exceptionWithName:NSInternalInconsistencyException
-                                                     reason:reason
-                                                   userInfo:nil];
-    return [BFTask taskWithException:exception];
+    NSError *error = [PFErrorUtilities errorWithCode:kPFErrorInternalServer
+                                             message:[NSString stringWithFormat:@"Can't find a compatible runner for command %@.", command]
+                                           shouldLog:NO];
+    return [BFTask taskWithError:error];
 }
 
 - (BFTask *)_didFinishRunningCommand:(id<PFNetworkCommand>)command

--- a/Parse/Internal/PFInternalUtils.m
+++ b/Parse/Internal/PFInternalUtils.m
@@ -152,8 +152,7 @@ static NSString *parseServer_;
     } else if ([object isKindOfClass:[NSNull class]]) {
         [self appendNullToString:string];
     } else {
-        [NSException raise:NSInvalidArgumentException
-                    format:@"Couldn't create cache key from %@", object];
+        PFParameterAssertionFailure(@"Couldn't create cache key from %@", object);
     }
 }
 

--- a/Parse/Internal/PFPinningEventuallyQueue.m
+++ b/Parse/Internal/PFPinningEventuallyQueue.m
@@ -281,10 +281,10 @@
         }
     });
     if (uuid == nil) {
-        NSException *exception = [NSException exceptionWithName:NSInternalInconsistencyException
-                                                         reason:@"Either operationSet or eventuallyPin must be set"
-                                                       userInfo:nil];
-        return [BFTask taskWithException:exception];
+        NSError *error = [PFErrorUtilities errorWithCode:kPFErrorIncorrectType
+                                                 message:@"Either operationSet or eventuallyPin must be set"
+                                               shouldLog:NO];
+        return [BFTask taskWithError:error];
     }
     return [BFTask taskWithResult:nil];
 }

--- a/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.m
+++ b/Parse/Internal/PropertyInfo/PFPropertyInfo_Runtime.m
@@ -12,6 +12,8 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
+#import "PFAssert.h"
+
 /**
  This macro is really interesting. Because ARC will insert implicit retains, releases and other memory managment code
  that we don't want here, we have to basically trick ARC into treating the functions we want as functions with type
@@ -45,7 +47,7 @@ void object_getIvarValue_safe(__unsafe_unretained id obj, Ivar ivar, void *toMem
 
     switch (associationType) {
         case PFPropertyInfoAssociationTypeDefault:
-            [NSException raise:NSInvalidArgumentException format:@"Invalid association type Default!"];
+            PFParameterAssertionFailure(@"Invalid association type `Default`.");
             break;
 
         case PFPropertyInfoAssociationTypeAssign: {
@@ -86,7 +88,7 @@ void object_setIvarValue_safe(__unsafe_unretained id obj, Ivar ivar, void *fromM
 
     switch (associationType) {
         case PFPropertyInfoAssociationTypeDefault:
-            [NSException raise:NSInvalidArgumentException format:@"Invalid association type Default!"];
+            PFParameterAssertionFailure(@"Invalid association type `Default`.");
             return;
 
         case PFPropertyInfoAssociationTypeAssign: {

--- a/Parse/Internal/Query/Controller/PFCachedQueryController.m
+++ b/Parse/Internal/Query/Controller/PFCachedQueryController.m
@@ -112,10 +112,10 @@
         }
             break;
         case kPFCachePolicyCacheThenNetwork:
-            PFConsistencyAssert(NO, @"kPFCachePolicyCacheThenNetwork is not implemented as a runner.");
+            PFConsistencyAssertionFailure(@"kPFCachePolicyCacheThenNetwork is not implemented as a runner.");
             break;
         default:
-            PFConsistencyAssert(NO, @"Unrecognized cache policy: %d", queryState.cachePolicy);
+            PFConsistencyAssertionFailure(@"Unrecognized cache policy: %d", queryState.cachePolicy);
             break;
     }
     return nil;

--- a/Parse/Internal/Query/Utilities/PFQueryUtilities.m
+++ b/Parse/Internal/Query/Utilities/PFQueryUtilities.m
@@ -47,7 +47,6 @@
             return [[NSCompoundPredicate alloc] initWithType:type subpredicates:newSubpredicates];
         }
     }
-
     if ([predicate isKindOfClass:[NSComparisonPredicate class]]) {
         if (comparisonBlock) {
             return comparisonBlock((NSComparisonPredicate *)predicate);
@@ -55,8 +54,7 @@
             return predicate;
         }
     }
-
-    [NSException raise:NSInternalInconsistencyException format:@"NSExpression predicates are not supported."];
+    PFConsistencyAssertionFailure(@"NSExpression predicates are not supported.");
     return nil;
 }
 
@@ -87,9 +85,8 @@
                              return [NSCompoundPredicate andPredicateWithSubpredicates:newSubpredicates];
                          }
                          default: {
-                             [NSException raise:NSInternalInconsistencyException
-                                         format:@"This compound predicate cannot be negated. (%zd)",
-                              compound.compoundPredicateType];
+                             PFConsistencyAssertionFailure(@"This compound predicate cannot be negated. (%zd)",
+                                                           compound.compoundPredicateType);
                              return nil;
                          }
                      }
@@ -129,8 +126,7 @@
                              break;
                          }
                          case NSBetweenPredicateOperatorType: {
-                             [NSException raise:NSInternalInconsistencyException
-                                         format:@"A BETWEEN predicate was found after they should have been removed."];
+                             PFConsistencyAssertionFailure(@"A BETWEEN predicate was found after they should have been removed.");
                          }
                          case NSMatchesPredicateOperatorType:
                          case NSLikePredicateOperatorType:
@@ -139,8 +135,7 @@
                          case NSContainsPredicateOperatorType:
                          case NSCustomSelectorPredicateOperatorType:
                          default: {
-                             [NSException raise:NSInternalInconsistencyException
-                                         format:@"This comparison predicate cannot be negated. (%@)", comparison];
+                             PFConsistencyAssertionFailure(@"This comparison predicate cannot be negated. (%@)", comparison);
                              return nil;
                          }
                      }
@@ -358,8 +353,7 @@
                     }
 
                 } else {
-                    [NSException raise:NSInternalInconsistencyException
-                                format:@"[PFQuery asOrOfAnds:] found a compound query that wasn't OR or AND."];
+                    PFConsistencyAssertionFailure(@"[PFQuery asOrOfAnds:] found a compound query that wasn't OR or AND.");
                 }
             } else {
                 // Just add this condition to all the conjunctions in progress.
@@ -388,10 +382,7 @@
             return [NSCompoundPredicate orPredicateWithSubpredicates:andPredicates];
         }
     }
-
-    [NSException raise:NSInternalInconsistencyException
-                format:@"[PFQuery asOrOfAnds:] was passed a compound query that wasn't OR or AND."];
-
+    PFConsistencyAssertionFailure(@"[PFQuery asOrOfAnds:] was passed a compound query that wasn't OR or AND.");
     return nil;
 }
 


### PR DESCRIPTION
No more random NSException construction.
Replaced with - `PFParameterAssert`/`PFParameterAssertionFailure` or `PFConsistencyAssert`/`PFConsistencyAssertionFailure`.
Closes #6.