### PR TITLE
Add ability to clear PFFile cache.

### DIFF
--- a/Parse/Internal/File/Controller/PFFileController.h
+++ b/Parse/Internal/File/Controller/PFFileController.h
@@ -94,7 +94,8 @@
 #pragma mark - Cache
 ///--------------------------------------
 
-- (BFTask<PFVoid> *)clearFileCacheAsync;
+- (BFTask<PFVoid> *)clearFileCacheAsyncForFileWithState:(PFFileState *)fileState;
+- (BFTask<PFVoid> *)clearAllFileCacheAsync;
 
 - (NSString *)cachedFilePathForFileState:(PFFileState *)fileState;
 

--- a/Parse/Internal/File/Controller/PFFileController.m
+++ b/Parse/Internal/File/Controller/PFFileController.m
@@ -259,7 +259,18 @@ static NSString *const PFFileControllerCacheDirectoryName_ = @"PFFileCache";
     return [self.dataSource.fileManager parseCacheItemPathForPathComponent:PFFileControllerCacheDirectoryName_];
 }
 
-- (BFTask<PFVoid> *)clearFileCacheAsync {
+- (BFTask<PFVoid> *)clearFileCacheAsyncForFileWithState:(PFFileState *)fileState {
+    return [BFTask taskFromExecutor:[BFExecutor defaultExecutor] withBlock:^id{
+        NSString *filePath = [self cachedFilePathForFileState:fileState];
+        if (!filePath) {
+            return nil;
+        }
+        // No need to lock on this, since we are removing from a cache directory.
+        return [PFFileManager removeItemAtPathAsync:filePath withFileLock:NO];
+    }];
+}
+
+- (BFTask<PFVoid> *)clearAllFileCacheAsync {
     return [BFTask taskFromExecutor:[BFExecutor defaultExecutor] withBlock:^id{
         NSString *path = self.cacheFilesDirectoryPath;
         if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {

--- a/Parse/PFFile.h
+++ b/Parse/PFFile.h
@@ -366,6 +366,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)cancel;
 
+///--------------------------------------
+#pragma mark - Cache
+///--------------------------------------
+
+/**
+ Clears all cached data for this file.
+
+ @return The task, with the result set to `nil` if the operation succeeds.
+ */
+- (BFTask *)clearCachedDataInBackground;
+
+/**
+ Clears all cached data for all downloaded files.
+
+ @return The task, with the result set to `nil` if the operation succeeds.
+ */
++ (BFTask *)clearAllCachedDataInBackground;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Parse/PFFile.m
+++ b/Parse/PFFile.m
@@ -217,6 +217,20 @@
     }];
 }
 
+#pragma mark Cache
+
+- (BFTask *)clearCachedDataInBackground {
+    @weakify(self);
+    return [self.taskQueue enqueue:^id(BFTask *_) {
+        @strongify(self);
+        return [[[[self class] fileController] clearFileCacheAsyncForFileWithState:self.state] continueWithSuccessResult:nil];
+    }];
+}
+
++ (BFTask *)clearAllCachedDataInBackground {
+    return [[[self fileController] clearAllFileCacheAsync] continueWithSuccessResult:nil];
+}
+
 ///--------------------------------------
 #pragma mark - Private
 ///--------------------------------------

--- a/Tests/Unit/FileUnitTests.m
+++ b/Tests/Unit/FileUnitTests.m
@@ -508,4 +508,40 @@ static NSData *dataFromInputStream(NSInputStream *inputStream) {
     [self waitForTestExpectations];
 }
 
+- (void)testClearCachedData {
+    id mockedFileController = [Parse _currentManager].coreManager.fileController;
+
+    PFFile *file = [PFFile fileWithName:@"a" data:[NSData data]];
+    OCMExpect([mockedFileController clearFileCacheAsyncForFileWithState:file.state]).andReturn([BFTask taskWithResult:nil]);
+
+    XCTestExpectation *expectation = [self currentSelectorTestExpectation];
+    [[file clearCachedDataInBackground] continueWithBlock:^id _Nullable(BFTask * _Nonnull task) {
+        XCTAssertNil(task.result);
+        XCTAssertFalse(task.faulted);
+        XCTAssertFalse(task.cancelled);
+        [expectation fulfill];
+        return nil;
+    }];
+    [self waitForTestExpectations];
+
+    OCMVerifyAll(mockedFileController);
+}
+
+- (void)testClearAllCachedData {
+    id mockedFileController = [Parse _currentManager].coreManager.fileController;
+    OCMExpect([mockedFileController clearAllFileCacheAsync]).andReturn([BFTask taskWithResult:nil]);
+
+    XCTestExpectation *expectation = [self currentSelectorTestExpectation];
+    [[PFFile clearAllCachedDataInBackground] continueWithBlock:^id _Nullable(BFTask * _Nonnull task) {
+        XCTAssertNil(task.result);
+        XCTAssertFalse(task.faulted);
+        XCTAssertFalse(task.cancelled);
+        [expectation fulfill];
+        return nil;
+    }];
+    [self waitForTestExpectations];
+
+    OCMVerifyAll(mockedFileController);
+}
+
 @end


### PR DESCRIPTION
Adds 2 new methods for clearing cache for a single file or all of them at once.
Fixes #488