### PR TITLE
Add failure/safety checks for PFInstallation.+currentInstallation.

### DIFF
--- a/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.m
+++ b/Parse/Internal/Installation/CurrentInstallationController/PFCurrentInstallationController.m
@@ -102,7 +102,7 @@ NSString *const PFCurrentInstallationPinName = @"_currentInstallation";
             @strongify(self);
 
             __block PFInstallation *installation = task.result;
-            return [[self.installationIdentifierStore getInstallationIdentifierAsync] continueWithBlock:^id _Nullable(BFTask<NSString *> * _Nonnull task) {
+            return [[self.installationIdentifierStore getInstallationIdentifierAsync] continueWithSuccessBlock:^id _Nullable(BFTask<NSString *> * _Nonnull task) {
                 NSString *installationId = task.result.lowercaseString;
                 if (!installation || ![installationId isEqualToString:installation.installationId]) {
                     // If there's no installation object, or the object's installation

--- a/Parse/PFInstallation.h
+++ b/Parse/PFInstallation.h
@@ -47,9 +47,9 @@ PF_TV_UNAVAILABLE PF_WATCH_UNAVAILABLE @interface PFInstallation : PFObject<PFSu
  If this installation is not stored on disk this method will create a new `PFInstallation`
  with `deviceType` and `installationId` fields set to those of the current installation.
 
- @result Returns a `PFInstallation` that represents the currently-running installation.
+ @result Returns a `PFInstallation` that represents the currently-running installation if it could be loaded from disk, otherwise - `nil`.
  */
-+ (instancetype)currentInstallation;
++ (nullable instancetype)currentInstallation;
 
 /**
  *Asynchronously* loads the currently-running installation from disk and returns an instance of it.

--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
@@ -47,8 +47,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func application(application: NSApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: NSData) {
         let installation = PFInstallation.currentInstallation()
-        installation.setDeviceTokenFromData(deviceToken)
-        installation.saveInBackground()
+        installation?.setDeviceTokenFromData(deviceToken)
+        installation?.saveInBackground()
 
         PFPush.subscribeToChannelInBackground("") { (succeeded: Bool, error: NSError?) in
             if succeeded {

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
@@ -76,8 +76,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: NSData) {
         let installation = PFInstallation.currentInstallation()
-        installation.setDeviceTokenFromData(deviceToken)
-        installation.saveInBackground()
+        installation?.setDeviceTokenFromData(deviceToken)
+        installation?.saveInBackground()
 
         PFPush.subscribeToChannelInBackground("") { (succeeded: Bool, error: NSError?) in
             if succeeded {

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
@@ -81,8 +81,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: NSData) {
         let installation = PFInstallation.currentInstallation()
-        installation.setDeviceTokenFromData(deviceToken)
-        installation.saveInBackground()
+        installation?.setDeviceTokenFromData(deviceToken)
+        installation?.saveInBackground()
 
         PFPush.subscribeToChannelInBackground("") { (succeeded: Bool, error: NSError?) in
             if succeeded {


### PR DESCRIPTION
If reading installationId from disk failed - it will crash the app on setting the installationId.
If loading of `currentInstallation` failed, because disk failed or `installationId` wasn't loaded - we should not crash Swift runtime, but rather force everyone unwrap `currentInstallation`.

Closes #817.