### PR TITLE
Convert constant strings to type-safe macros in PFQueryState.

### DIFF
--- a/Parse/Internal/Query/State/PFMutableQueryState.h
+++ b/Parse/Internal/Query/State/PFMutableQueryState.h
@@ -58,7 +58,7 @@
 
 - (void)sortByKey:(NSString *)key ascending:(BOOL)ascending;
 - (void)addSortKey:(NSString *)key ascending:(BOOL)ascending;
-- (void)addSortKeysFromSortDescriptors:(NSArray *)sortDescriptors;
+- (void)addSortKeysFromSortDescriptors:(NSArray<NSSortDescriptor *> *)sortDescriptors;
 
 ///--------------------------------------
 #pragma mark - Includes
@@ -71,7 +71,7 @@
 #pragma mark - Selected Keys
 ///--------------------------------------
 
-- (void)selectKeys:(NSArray *)keys;
+- (void)selectKeys:(NSArray<NSString *> *)keys;
 
 ///--------------------------------------
 #pragma mark - Redirect

--- a/Parse/Internal/Query/State/PFMutableQueryState.m
+++ b/Parse/Internal/Query/State/PFMutableQueryState.m
@@ -13,10 +13,10 @@
 #import "PFQueryState_Private.h"
 
 @interface PFMutableQueryState () {
-    NSMutableDictionary *_conditions;
-    NSMutableArray *_sortKeys;
-    NSMutableSet *_includedKeys;
-    NSMutableDictionary *_extraOptions;
+    NSMutableDictionary<NSString *, id> *_conditions;
+    NSMutableArray<NSString *> *_sortKeys;
+    NSMutableSet<NSString *> *_includedKeys;
+    NSMutableDictionary<NSString *, NSString *> *_extraOptions;
 }
 
 @end
@@ -133,7 +133,7 @@
     }
 }
 
-- (void)addSortKeysFromSortDescriptors:(NSArray *)sortDescriptors {
+- (void)addSortKeysFromSortDescriptors:(NSArray<NSSortDescriptor *> *)sortDescriptors {
     [_sortKeys removeAllObjects];
     for (NSSortDescriptor *sortDescriptor in sortDescriptors) {
         [self addSortKey:sortDescriptor.key ascending:sortDescriptor.ascending];
@@ -164,7 +164,7 @@
 #pragma mark - Selected Keys
 ///--------------------------------------
 
-- (void)selectKeys:(NSArray *)keys {
+- (void)selectKeys:(NSArray<NSString *> *)keys {
     if (keys) {
         _selectedKeys = (_selectedKeys ? [_selectedKeys setByAddingObjectsFromArray:keys] : [NSSet setWithArray:keys]);
     } else {

--- a/Parse/Internal/Query/State/PFMutableQueryState.m
+++ b/Parse/Internal/Query/State/PFMutableQueryState.m
@@ -11,6 +11,7 @@
 #import "PFQueryConstants.h"
 
 #import "PFQueryState_Private.h"
+#import "PFMacros.h"
 
 @interface PFMutableQueryState () {
     NSMutableDictionary<NSString *, id> *_conditions;
@@ -47,10 +48,10 @@
 + (NSDictionary *)propertyAttributes {
     NSMutableDictionary *attributes = [[super propertyAttributes] mutableCopy];
 
-    attributes[@"conditions"] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
-    attributes[@"sortKeys"] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
-    attributes[@"includedKeys"] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
-    attributes[@"extraOptions"] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
+    attributes[PFQueryStatePropertyName(conditions)] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
+    attributes[PFQueryStatePropertyName(sortKeys)] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
+    attributes[PFQueryStatePropertyName(includedKeys)] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
+    attributes[PFQueryStatePropertyName(extraOptions)] = [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeMutableCopy];
 
     return attributes;
 }

--- a/Parse/Internal/Query/State/PFQueryState.h
+++ b/Parse/Internal/Query/State/PFQueryState.h
@@ -17,14 +17,14 @@
 
 @property (nonatomic, copy, readonly) NSString *parseClassName;
 
-@property (nonatomic, copy, readonly) NSDictionary *conditions;
+@property (nonatomic, copy, readonly) NSDictionary<NSString *, id> *conditions;
 
-@property (nonatomic, copy, readonly) NSArray *sortKeys;
+@property (nonatomic, copy, readonly) NSArray<NSString *> *sortKeys;
 @property (nonatomic, copy, readonly) NSString *sortOrderString;
 
-@property (nonatomic, copy, readonly) NSSet *includedKeys;
-@property (nonatomic, copy, readonly) NSSet *selectedKeys;
-@property (nonatomic, copy, readonly) NSDictionary *extraOptions;
+@property (nonatomic, copy, readonly) NSSet<NSString *> *includedKeys;
+@property (nonatomic, copy, readonly) NSSet<NSString *> *selectedKeys;
+@property (nonatomic, copy, readonly) NSDictionary<NSString *, NSString *> *extraOptions;
 
 @property (nonatomic, assign, readonly) NSInteger limit;
 @property (nonatomic, assign, readonly) NSInteger skip;

--- a/Parse/Internal/Query/State/PFQueryState.m
+++ b/Parse/Internal/Query/State/PFQueryState.m
@@ -12,6 +12,7 @@
 
 #import "PFMutableQueryState.h"
 #import "PFPropertyInfo.h"
+#import "PFMacros.h"
 
 @implementation PFQueryState
 
@@ -21,24 +22,24 @@
 
 + (NSDictionary *)propertyAttributes {
     return @{
-        @"parseClassName": [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
-        @"conditions": [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
-        @"sortKeys": [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
-        @"includedKeys": [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
-        @"selectedKeys": [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
-        @"extraOptions": [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
+        PFQueryStatePropertyName(parseClassName): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
+        PFQueryStatePropertyName(conditions): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
+        PFQueryStatePropertyName(sortKeys): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
+        PFQueryStatePropertyName(includedKeys): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
+        PFQueryStatePropertyName(selectedKeys): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
+        PFQueryStatePropertyName(extraOptions): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy],
 
-        @"limit": [PFPropertyAttributes attributes],
-        @"skip": [PFPropertyAttributes attributes],
-        @"cachePolicy": [PFPropertyAttributes attributes],
-        @"maxCacheAge": [PFPropertyAttributes attributes],
+        PFQueryStatePropertyName(limit): [PFPropertyAttributes attributes],
+        PFQueryStatePropertyName(skip): [PFPropertyAttributes attributes],
+        PFQueryStatePropertyName(cachePolicy): [PFPropertyAttributes attributes],
+        PFQueryStatePropertyName(maxCacheAge): [PFPropertyAttributes attributes],
 
-        @"trace": [PFPropertyAttributes attributes],
-        @"shouldIgnoreACLs": [PFPropertyAttributes attributes],
-        @"shouldIncludeDeletingEventually": [PFPropertyAttributes attributes],
-        @"queriesLocalDatastore": [PFPropertyAttributes attributes],
+        PFQueryStatePropertyName(trace): [PFPropertyAttributes attributes],
+        PFQueryStatePropertyName(shouldIgnoreACLs): [PFPropertyAttributes attributes],
+        PFQueryStatePropertyName(shouldIncludeDeletingEventually): [PFPropertyAttributes attributes],
+        PFQueryStatePropertyName(queriesLocalDatastore): [PFPropertyAttributes attributes],
 
-        @"localDatastorePinName": [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy]
+        PFQueryStatePropertyName(localDatastorePinName): [PFPropertyAttributes attributesWithAssociationType:PFPropertyInfoAssociationTypeCopy]
     };
 }
 

--- a/Parse/Internal/Query/State/PFQueryState_Private.h
+++ b/Parse/Internal/Query/State/PFQueryState_Private.h
@@ -9,6 +9,17 @@
 
 #import "PFQueryState.h"
 
+#import "PFMacros.h"
+
+/**
+ Returns NSString representation of a property on PFQueryState.
+
+ @param NAME The name of the property.
+
+ @return NSString representaiton of a given property.
+ */
+#define PFQueryStatePropertyName(NAME) @keypath(PFQueryState, NAME)
+
 @interface PFQueryState () {
 @protected
     NSString *_parseClassName;

--- a/Parse/Internal/Query/State/PFQueryState_Private.h
+++ b/Parse/Internal/Query/State/PFQueryState_Private.h
@@ -13,13 +13,13 @@
 @protected
     NSString *_parseClassName;
 
-    NSDictionary *_conditions;
+    NSDictionary<NSString *, id> *_conditions;
 
-    NSArray *_sortKeys;
+    NSArray<NSString *> *_sortKeys;
 
-    NSSet *_includedKeys;
-    NSSet *_selectedKeys;
-    NSDictionary *_extraOptions;
+    NSSet<NSString *> *_includedKeys;
+    NSSet<NSString *> *_selectedKeys;
+    NSDictionary<NSString *, NSString *> *_extraOptions;
 
     NSInteger _limit;
     NSInteger _skip;

--- a/Tests/Unit/QueryStateUnitTests.m
+++ b/Tests/Unit/QueryStateUnitTests.m
@@ -200,6 +200,15 @@
     XCTAssertEqualObjects(state.includedKeys, includedKeys);
 }
 
+- (void)testIncludeMultipleKeys {
+    PFMutableQueryState *state = [[PFMutableQueryState alloc] initWithParseClassName:@"Yarr"];
+    [state includeKeys:@[ @"a", @"b", @"c" ]];
+    [state includeKey:@"a"];
+
+    NSSet *includedKeys = PF_SET(@"a", @"b", @"c");
+    XCTAssertEqualObjects(state.includedKeys, includedKeys);
+}
+
 - (void)testSelectKeys {
     PFMutableQueryState *state = [[PFMutableQueryState alloc] initWithParseClassName:@"Yarr"];
 


### PR DESCRIPTION
Also adds a tad of tests :)