### PR TITLE
Correctly return a secure URL if https was used as the url of a PFFil…

### DIFF
--- a/Parse/Internal/File/State/PFFileState.m
+++ b/Parse/Internal/File/State/PFFileState.m
@@ -78,13 +78,11 @@ static NSString *const _PFFileStateSecureDomain = @"files.parsetfss.com";
     }
 
     NSString *scheme = components.scheme;
-    if (![scheme isEqualToString:@"http"]) {
-        return self.urlString;
+    if ([scheme isEqualToString:@"http"] || [components.host isEqualToString:_PFFileStateSecureDomain]) {
+        components.scheme = @"https";
+        _secureURLString = components.URL.absoluteString;
     }
 
-    if ([components.host isEqualToString:_PFFileStateSecureDomain]) {
-        components.scheme = @"https";
-    }
     _secureURLString = components.URL.absoluteString;
     return _secureURLString;
 }

--- a/Parse/PFFile.m
+++ b/Parse/PFFile.m
@@ -448,6 +448,9 @@
 
 - (NSString *)url {
     __block NSString *url = nil;
+    
+    if (self.state.urlString == nil) return nil;
+    
     [self _performDataAccessBlock:^{
         
         NSURLComponents *components = [NSURLComponents componentsWithString:self.state.urlString];

--- a/Parse/PFFile.m
+++ b/Parse/PFFile.m
@@ -449,7 +449,15 @@
 - (NSString *)url {
     __block NSString *url = nil;
     [self _performDataAccessBlock:^{
-        url = self.state.secureURLString;
+        
+        NSURLComponents *components = [NSURLComponents componentsWithString:self.state.urlString];
+        NSString *scheme = components.scheme;
+        if ([scheme isEqualToString:@"http"]) {
+            url = self.state.urlString;
+        } else {
+            url = self.state.secureURLString;
+        }
+        
     }];
     return url;
 }

--- a/Tests/Unit/DecoderTests.m
+++ b/Tests/Unit/DecoderTests.m
@@ -106,7 +106,7 @@
     XCTAssertTrue([relation _hasKnownObject:object]);
 }
 
-- (void)testDecodingFiles {
+- (void)testDecodingFilesUnsecure {
     PFDecoder *decoder = [[PFDecoder alloc] init];
 
     NSDictionary *decoded = [decoder decodeObject:@{ @"file" : @{@"__type" : @"File",
@@ -121,6 +121,25 @@
     XCTAssertEqualObjects(file.name, @"yolo.png");
     XCTAssertEqualObjects(file.url, @"http://yarr.com/yolo.png");
 }
+
+
+- (void)testDecodingFilesSecure {
+    PFDecoder *decoder = [[PFDecoder alloc] init];
+    
+    NSDictionary *decoded = [decoder decodeObject:@{ @"file" : @{@"__type" : @"File",
+                                                                 @"name" : @"yolo.png",
+                                                                 @"url" : @"https://yarr.com/yolo.png"} }];
+    XCTAssertNotNil(decoded);
+    
+    PFFile *file = decoded[@"file"];
+    XCTAssertNotNil(file);
+    PFAssertIsKindOfClass(file, [PFFile class]);
+    
+    XCTAssertEqualObjects(file.name, @"yolo.png");
+    XCTAssertEqualObjects(file.url, @"https://yarr.com/yolo.png");
+}
+
+
 
 - (void)testDecodingPointers {
     PFDecoder *decoder = [[PFDecoder alloc] init];

--- a/Tests/Unit/FileStateTests.m
+++ b/Tests/Unit/FileStateTests.m
@@ -138,4 +138,26 @@
     XCTAssertNil(state.secureURLString);
 }
 
+- (void)testSecureURLStringUsingS3AdapterHost {
+    PFMutableFileState *state = [[PFMutableFileState alloc] initWithName:@"a"
+                                                               urlString:@"http://s3.amazonaws.com/bucket/yolo.txt"
+                                                                mimeType:nil];
+    XCTAssertEqualObjects(state.urlString, @"http://s3.amazonaws.com/bucket/yolo.txt");
+    XCTAssertEqualObjects(state.secureURLString, @"https://s3.amazonaws.com/bucket/yolo.txt");
+    
+    state.urlString = @"https://s3.amazonaws.com/bucket/yolo.txt";
+    XCTAssertEqualObjects(state.urlString, @"https://s3.amazonaws.com/bucket/yolo.txt");
+    XCTAssertEqualObjects(state.secureURLString, @"https://s3.amazonaws.com/bucket/yolo.txt");
+    
+    state.urlString = @"http://s3.amazonaws.com/bucket/yolo2.txt";
+    XCTAssertEqualObjects(state.urlString, @"http://s3.amazonaws.com/bucket/yolo2.txt");
+    XCTAssertEqualObjects(state.secureURLString, @"https://s3.amazonaws.com/bucket/yolo2.txt");
+    
+    state.urlString = nil;
+    XCTAssertNil(state.urlString);
+    XCTAssertNil(state.secureURLString);
+}
+
+
+
 @end


### PR DESCRIPTION

This is necessary since Apple will no longer accept App Transport Security setting work-arounds in 2017.

