### PR TITLE
Remove all usages of BFTask.exception APIs.

### DIFF
--- a/Parse/Internal/BFTask+Private.m
+++ b/Parse/Internal/BFTask+Private.m
@@ -65,21 +65,13 @@
     return [self continueWithExecutor:[BFExecutor mainThreadExecutor]
                             withBlock:^id(BFTask *task) {
                                 BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
-
                                 @try {
-                                    if (self.exception) {
-                                        //TODO: (nlutsenko) Add more context, by passing a `_cmd` from the caller method
-                                        PFLogException(self.exception);
-                                        @throw self.exception;
-                                    }
-
                                     if (!self.cancelled || executeIfCancelled) {
                                         resultBlock(self.result, self.error);
                                     }
                                 } @finally {
                                     tcs.result = nil;
                                 }
-
                                 return tcs.task;
                             }];
 }
@@ -121,8 +113,6 @@
     }
     if (self.cancelled) {
         return nil;
-    } else if (self.exception) {
-        @throw self.exception;
     }
     if (self.error && error) {
         *error = self.error;

--- a/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
+++ b/Parse/Internal/LocalDataStore/OfflineStore/PFOfflineStore.m
@@ -272,8 +272,6 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
             [tcs cancel];
         } else if (task.error != nil) {
             [tcs setError:task.error];
-        } else if (task.exception != nil) {
-            [tcs setException:task.exception];
         } else {
             [tcs setResult:object];
         }
@@ -431,7 +429,7 @@ static int const PFOfflineStoreMaximumSQLVariablesCount = 999;
                                     user:user
                                      pin:pin
                                  isCount:YES] continueWithSuccessBlock:^id(BFTask *task) {
-        if (!task.cancelled && !task.error && !task.exception) {
+        if (!task.cancelled && !task.faulted) {
             NSArray *result = task.result;
             return @(result.count);
         }

--- a/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.m
+++ b/Parse/Internal/LocalDataStore/SQLite/PFSQLiteDatabaseController.m
@@ -54,8 +54,6 @@
                 NSError *error = task.error;
                 if (error) {
                     [taskCompletionSource trySetError:error];
-                } else {
-                    [taskCompletionSource trySetException:task.exception];
                 }
             } else if (task.cancelled) {
                 [taskCompletionSource trySetCancelled];

--- a/Parse/Internal/PFAsyncTaskQueue.m
+++ b/Parse/Internal/PFAsyncTaskQueue.m
@@ -50,12 +50,7 @@
         _tail = [_tail continueAsyncWithBlock:block];
         [_tail continueAsyncWithBlock:^id(BFTask *task) {
             if (task.faulted) {
-                NSError *error = task.error;
-                if (error) {
-                    [source trySetError:error];
-                } else {
-                    [source trySetException:task.exception];
-                }
+                [source trySetError:task.error];
             } else if (task.cancelled) {
                 [source trySetCancelled];
             } else {

--- a/Parse/Internal/PFEventuallyQueue.m
+++ b/Parse/Internal/PFEventuallyQueue.m
@@ -106,12 +106,10 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
             return [[[self _enqueueCommandInBackground:command
                                                 object:object
                                             identifier:identifier] continueWithBlock:^id(BFTask *task) {
-                if (task.error || task.exception || task.cancelled) {
+                if (task.faulted || task.cancelled) {
                     [self.testHelper notify:PFEventuallyQueueEventCommandNotEnqueued];
                     if (task.error) {
                         taskCompletionSource.error = task.error;
-                    } else if (task.exception) {
-                        taskCompletionSource.exception = task.exception;
                     } else if (task.cancelled) {
                         [taskCompletionSource cancel];
                     }
@@ -305,8 +303,6 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
         // Notify anyone waiting that the operation is completed.
         if (resultTask.error) {
             taskCompletionSource.error = resultTask.error;
-        } else if (resultTask.exception) {
-            taskCompletionSource.exception = resultTask.exception;
         } else if (resultTask.cancelled) {
             [taskCompletionSource cancel];
         } else {
@@ -340,7 +336,7 @@ NSTimeInterval const PFEventuallyQueueDefaultTimeoutRetryInterval = 600.0f;
         [_taskCompletionSources removeObjectForKey:identifier];
     });
 
-    if (resultTask.exception || resultTask.error || resultTask.cancelled) {
+    if (resultTask.faulted || resultTask.cancelled) {
         [self.testHelper notify:PFEventuallyQueueEventCommandFailed];
     } else {
         [self.testHelper notify:PFEventuallyQueueEventCommandSucceded];

--- a/Parse/Internal/PFPinningEventuallyQueue.m
+++ b/Parse/Internal/PFPinningEventuallyQueue.m
@@ -212,7 +212,7 @@
             [_eventuallyPinUUIDQueue removeObject:identifier];
         });
 
-        if (resultTask.cancelled || resultTask.exception || resultTask.error) {
+        if (resultTask.cancelled || resultTask.faulted) {
             return resultTask;
         }
 

--- a/Parse/Internal/Query/Controller/PFCachedQueryController.m
+++ b/Parse/Internal/Query/Controller/PFCachedQueryController.m
@@ -68,8 +68,7 @@
             } cancellationToken:cancellationToken];
         }
             break;
-        case kPFCachePolicyCacheOnly:
-        {
+        case kPFCachePolicyCacheOnly: {
             return [self _runNetworkCommandAsyncFromCache:command
                                     withCancellationToken:cancellationToken
                                             forQueryState:queryState];
@@ -83,9 +82,9 @@
             @weakify(self);
             return [networkTask continueWithBlock:^id(BFTask *task) {
                 @strongify(self);
-                if (task.cancelled || task.exception) {
+                if (task.cancelled) {
                     return task;
-                } else if (task.error) {
+                } else if (task.faulted) {
                     return [self _runNetworkCommandAsyncFromCache:command
                                             withCancellationToken:cancellationToken
                                                     forQueryState:queryState];
@@ -111,11 +110,17 @@
             } cancellationToken:cancellationToken];
         }
             break;
-        case kPFCachePolicyCacheThenNetwork:
-            PFConsistencyAssertionFailure(@"kPFCachePolicyCacheThenNetwork is not implemented as a runner.");
+        case kPFCachePolicyCacheThenNetwork: {
+            NSError *error = [PFErrorUtilities errorWithCode:kPFErrorInvalidQuery
+                                                     message:@"Cache then network is not supported directly in PFCachedQueryController."];
+            return [BFTask taskWithError:error];
+        }
             break;
-        default:
-            PFConsistencyAssertionFailure(@"Unrecognized cache policy: %d", queryState.cachePolicy);
+        default: {
+            NSString *message = [NSString stringWithFormat:@"Unrecognized cache policy: %d", queryState.cachePolicy];
+            NSError *error = [PFErrorUtilities errorWithCode:kPFErrorInvalidQuery message:message];
+            return [BFTask taskWithError:error];
+        }
             break;
     }
     return nil;

--- a/Parse/PFUser.m
+++ b/Parse/PFUser.m
@@ -256,7 +256,7 @@ static BOOL revocableSessionEnabled_;
         BFTask *signUpTask = task;
 
         // Bail-out early, but still make sure that super class handled the result
-        if (task.error || task.cancelled || task.exception) {
+        if (task.faulted || task.cancelled) {
             return [[super handleSaveResultAsync:nil] continueWithBlock:^id(BFTask *task) {
                 return signUpTask;
             }];
@@ -520,7 +520,7 @@ static BOOL revocableSessionEnabled_;
                     [currentUser rebuildEstimatedData];
 
                     return [[[[currentUser saveInBackground] continueWithBlock:^id(BFTask *task) {
-                        if (task.error || task.cancelled || task.exception) {
+                        if (task.faulted || task.cancelled) {
                             @synchronized ([currentUser lock]) {
                                 if (oldUsername) {
                                     currentUser.username = oldUsername;

--- a/Tests/Unit/ConfigControllerTests.m
+++ b/Tests/Unit/ConfigControllerTests.m
@@ -17,12 +17,29 @@
 #import "PFConfig.h"
 #import "PFConfigController.h"
 #import "PFTestCase.h"
+#import "PFPersistenceController.h"
+#import "PFPersistenceGroup.h"
+
+@protocol ConfigControllerDataSource <PFCommandRunnerProvider, PFPersistenceControllerProvider>
+
+@end
 
 @interface ConfigControllerTests : PFTestCase
 
 @end
 
 @implementation ConfigControllerTests
+
+///--------------------------------------
+#pragma mark - Helpers
+///--------------------------------------
+
+- (PFPersistenceController *)mockedPersistenceController {
+    id controller = PFStrictClassMock([PFPersistenceController class]);
+    id group = PFProtocolMock(@protocol(PFPersistenceGroup));
+    OCMStub([controller getPersistenceGroupAsync]).andReturn([BFTask taskWithResult:group]);
+    return controller;
+}
 
 ///--------------------------------------
 #pragma mark - Tests
@@ -50,8 +67,9 @@
               forCommandsPassingTest:^BOOL(id obj) {
                   return YES;
               }];
-    id dataSource = PFStrictProtocolMock(@protocol(PFCommandRunnerProvider));
+    id dataSource = PFStrictProtocolMock(@protocol(ConfigControllerDataSource));
     OCMStub([dataSource commandRunner]).andReturn(commandRunner);
+    OCMStub([dataSource persistenceController]).andReturn([self mockedPersistenceController]);
 
     PFConfigController *configController = [[PFConfigController alloc] initWithDataSource:dataSource];
 

--- a/Tests/Unit/QueryCachedControllerTests.m
+++ b/Tests/Unit/QueryCachedControllerTests.m
@@ -294,7 +294,7 @@
     [[controller findObjectsAsyncForQueryState:state
                          withCancellationToken:nil
                                           user:nil] continueWithBlock:^id(BFTask *task) {
-        XCTAssertNotNil(task.exception);
+        XCTAssertNotNil(task.error);
         [expectation fulfill];
         return nil;
     }];
@@ -310,7 +310,7 @@
     [[controller findObjectsAsyncForQueryState:state
                          withCancellationToken:nil
                                           user:nil] continueWithBlock:^id(BFTask *task) {
-        XCTAssertNotNil(task.exception);
+        XCTAssertNotNil(task.error);
         [expectation fulfill];
         return nil;
     }];

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  ignore:
+    - Tests/.*
+  status:
+    project:
+      default:
+        target: 65
+    patch: false
+    changes: false
+comment: false


### PR DESCRIPTION
This is deprecated as of Bolts 1.8.0, so remove all usages of it.