### PR TITLE
Update starter projects to use configuration-based initialization API.

### DIFF
--- a/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject-Swift/ParseOSXStarterProject/AppDelegate.swift
@@ -17,14 +17,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var window: NSWindow?
 
     func applicationDidFinishLaunching(aNotification: NSNotification) {
-        // Enable storing and querying data from Local Datastore.
-        // Remove this line if you don't want to use Local Datastore features or want to use cachePolicy.
-        Parse.enableLocalDatastore()
+        // ****************************************************************************
+        // Initialize Parse SDK
+        // ****************************************************************************
 
-        // ****************************************************************************
-        // Uncomment and fill in with your Parse credentials:
-        // Parse.setApplicationId("your_application_id", clientKey: "your_client_key")
-        // ****************************************************************************
+        let configuration = ParseClientConfiguration {
+            // Add your Parse applicationId:
+            $0.applicationId = "your_application_id"
+            // Uncomment and add your clientKey (it's not required if you are using Parse Server):
+            $0.clientKey = "your_client_key"
+
+            // Uncomment the following line and change to your Parse Server address;
+            $0.server = "https://YOUR_PARSE_SERVER/parse"
+
+            // Enable storing and querying data from Local Datastore.
+            // Remove this line if you don't want to use Local Datastore features or want to use cachePolicy.
+            $0.localDatastoreEnabled = true
+        }
+        Parse.initializeWithConfiguration(configuration)
 
         PFUser.enableAutomaticUser()
 

--- a/ParseStarterProject/OSX/ParseOSXStarterProject/ParseOSXStarterProject/AppDelegate.m
+++ b/ParseStarterProject/OSX/ParseOSXStarterProject/ParseOSXStarterProject/AppDelegate.m
@@ -17,14 +17,24 @@
 #pragma mark NSApplicationDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
-    // Enable storing and querying data from Local Datastore.
-    // Remove this line if you don't want to use Local Datastore features or want to use cachePolicy.
-    [Parse enableLocalDatastore];
+    // ****************************************************************************
+    // Initialize Parse SDK
+    // ****************************************************************************
 
-    // ****************************************************************************
-    // Uncomment and fill in with your Parse credentials:
-    // [Parse setApplicationId:@"your_application_id" clientKey:@"your_client_key"];
-    // ****************************************************************************
+    [Parse initializeWithConfiguration:[ParseClientConfiguration configurationWithBlock:^(id<ParseMutableClientConfiguration>  _Nonnull configuration) {
+        // Add your Parse applicationId:
+        configuration.applicationId = @"your_application_id";
+
+        // Uncomment and add your clientKey (it's not required if you are using Parse Server):
+        // configuration.clientKey = @"your_client_key";
+
+        // Uncomment the following line and change to your Parse Server address;
+        // configuration.server = @"https://YOUR_PARSE_SERVER/parse";
+
+        // Enable storing and querying data from Local Datastore. Remove this line if you don't want to
+        // use Local Datastore features or want to use cachePolicy.
+        configuration.localDatastoreEnabled = YES;
+    }]];
 
     [PFUser enableAutomaticUser];
 

--- a/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/iOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
@@ -24,14 +24,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     //--------------------------------------
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        // Enable storing and querying data from Local Datastore.
-        // Remove this line if you don't want to use Local Datastore features or want to use cachePolicy.
-        Parse.enableLocalDatastore()
+        // ****************************************************************************
+        // Initialize Parse SDK
+        // ****************************************************************************
+
+        let configuration = ParseClientConfiguration {
+            // Add your Parse applicationId:
+            $0.applicationId = "your_application_id"
+            // Uncomment and add your clientKey (it's not required if you are using Parse Server):
+            $0.clientKey = "your_client_key"
+
+            // Uncomment the following line and change to your Parse Server address;
+            $0.server = "https://YOUR_PARSE_SERVER/parse"
+
+            // Enable storing and querying data from Local Datastore.
+            // Remove this line if you don't want to use Local Datastore features or want to use cachePolicy.
+            $0.localDatastoreEnabled = true
+        }
+        Parse.initializeWithConfiguration(configuration)
 
         // ****************************************************************************
-        // Uncomment and fill in with your Parse credentials:
-        // Parse.setApplicationId("your_application_id", clientKey: "your_client_key")
-        //
         // If you are using Facebook, uncomment and add your FacebookAppID to your bundle's plist as
         // described here: https://developers.facebook.com/docs/getting-started/facebook-sdk-for-ios/
         // Uncomment the line inside ParseStartProject-Bridging-Header and the following line here:

--- a/ParseStarterProject/iOS/ParseStarterProject/ParseStarterProject/ParseStarterProjectAppDelegate.m
+++ b/ParseStarterProject/iOS/ParseStarterProject/ParseStarterProject/ParseStarterProjectAppDelegate.m
@@ -24,14 +24,26 @@
 #pragma mark UIApplicationDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // Enable storing and querying data from Local Datastore. Remove this line if you don't want to
-    // use Local Datastore features or want to use cachePolicy.
-    [Parse enableLocalDatastore];
+    // ****************************************************************************
+    // Initialize Parse SDK
+    // ****************************************************************************
+
+    [Parse initializeWithConfiguration:[ParseClientConfiguration configurationWithBlock:^(id<ParseMutableClientConfiguration>  _Nonnull configuration) {
+        // Add your Parse applicationId:
+        configuration.applicationId = @"your_application_id";
+
+        // Uncomment and add your clientKey (it's not required if you are using Parse Server):
+        // configuration.clientKey = @"your_client_key";
+
+        // Uncomment the following line and change to your Parse Server address;
+        // configuration.server = @"https://YOUR_PARSE_SERVER/parse";
+
+        // Enable storing and querying data from Local Datastore. Remove this line if you don't want to
+        // use Local Datastore features or want to use cachePolicy.
+        configuration.localDatastoreEnabled = YES;
+    }]];
 
     // ****************************************************************************
-    // Uncomment and fill in with your Parse credentials:
-    // [Parse setApplicationId:@"your_application_id" clientKey:@"your_client_key"];
-    //
     // If you are using Facebook, uncomment and add your FacebookAppID to your bundle's plist as
     // described here: https://developers.facebook.com/docs/getting-started/facebook-sdk-for-ios/
     // [PFFacebookUtils initializeFacebook];

--- a/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/AppDelegate.swift
+++ b/ParseStarterProject/tvOS/ParseStarterProject-Swift/ParseStarter/AppDelegate.swift
@@ -22,11 +22,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // ****************************************************************************
-        //
-        // Uncomment and fill in with your Parse credentials:
-        // Parse.setApplicationId("your_application_id", clientKey: "your_client_key")
-        //
+        // Initialize Parse SDK
         // ****************************************************************************
+
+        let configuration = ParseClientConfiguration {
+            // Add your Parse applicationId:
+            $0.applicationId = "your_application_id"
+            // Uncomment and add your clientKey (it's not required if you are using Parse Server):
+            $0.clientKey = "your_client_key"
+
+            // Uncomment the following line and change to your Parse Server address;
+            $0.server = "https://YOUR_PARSE_SERVER/parse"
+        }
+        Parse.initializeWithConfiguration(configuration)
 
         PFUser.enableAutomaticUser()
 

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/ExtensionDelegate.swift
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarter Extension/ExtensionDelegate.swift
@@ -13,12 +13,24 @@ import Parse
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
 
     func applicationDidFinishLaunching() {
-        // Enable storing and querying data from Local Datastore.
-        // Remove this line if you don't want to use Local Datastore features or want to use cachePolicy.
-        Parse.enableLocalDatastore()
+        // ****************************************************************************
+        // Initialize Parse SDK
+        // ****************************************************************************
 
-        // Make sure to replace with your Parse app credentials:
-        Parse.setApplicationId("your_application_id", clientKey: "your_client_key")
+        let configuration = ParseClientConfiguration {
+            // Add your Parse applicationId:
+            $0.applicationId = "your_application_id"
+            // Uncomment and add your clientKey (it's not required if you are using Parse Server):
+            $0.clientKey = "your_client_key"
+
+            // Uncomment the following line and change to your Parse Server address;
+            $0.server = "https://YOUR_PARSE_SERVER/parse"
+
+            // Enable storing and querying data from Local Datastore.
+            // Remove this line if you don't want to use Local Datastore features or want to use cachePolicy.
+            $0.localDatastoreEnabled = true
+        }
+        Parse.initializeWithConfiguration(configuration)
 
         // Track application opened event in Analytics
         PFAnalytics.trackAppOpenedWithLaunchOptions(nil)

--- a/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
+++ b/ParseStarterProject/watchOS/ParseStarterProject-Swift/ParseStarterProject/AppDelegate.swift
@@ -24,19 +24,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     //--------------------------------------
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        // Enable storing and querying data from Local Datastore.
-        // Remove this line if you don't want to use Local Datastore features or want to use cachePolicy.
-        Parse.enableLocalDatastore()
+        // ****************************************************************************
+        // Initialize Parse SDK
+        // ****************************************************************************
 
-        // ****************************************************************************
-        // Uncomment and fill in with your Parse credentials:
-        // Parse.setApplicationId("your_application_id", clientKey: "your_client_key")
-        //
-        // If you are using Facebook, uncomment and add your FacebookAppID to your bundle's plist as
-        // described here: https://developers.facebook.com/docs/getting-started/facebook-sdk-for-ios/
-        // Uncomment the line inside ParseStartProject-Bridging-Header and the following line here:
-        // PFFacebookUtils.initializeFacebook()
-        // ****************************************************************************
+        let configuration = ParseClientConfiguration {
+            // Add your Parse applicationId:
+            $0.applicationId = "your_application_id"
+            // Uncomment and add your clientKey (it's not required if you are using Parse Server):
+            $0.clientKey = "your_client_key"
+
+            // Uncomment the following line and change to your Parse Server address;
+            $0.server = "https://YOUR_PARSE_SERVER/parse"
+
+            // Enable storing and querying data from Local Datastore.
+            // Remove this line if you don't want to use Local Datastore features or want to use cachePolicy.
+            $0.localDatastoreEnabled = true
+        }
+        Parse.initializeWithConfiguration(configuration)
 
         PFUser.enableAutomaticUser()
 


### PR DESCRIPTION
Superseds #943.
Closes #943.
Fixes #929.