### PR TITLE
Added object class check to current user controller's cache

### DIFF
--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
@@ -106,7 +106,7 @@
 		if (currentUser) {
 			// Verify that the current user matches our expected registered subclass
 			Class expectedClass = [[PFObjectSubclassingController defaultController] subclassForParseClassName:@"_User"];
-			if(expectedClass == [currentUser class]){
+			if([currentUser isKindOfClass:expectedClass]){
 				return currentUser;
 			} else {
 				matchesDisk = NO;

--- a/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
+++ b/Parse/Internal/User/CurrentUserController/PFCurrentUserController.m
@@ -22,6 +22,7 @@
 #import "PFQuery.h"
 #import "PFUserConstants.h"
 #import "PFUserPrivate.h"
+#import "PFObjectSubclassingController.h"
 
 @interface PFCurrentUserController () {
     dispatch_queue_t _dataQueue;
@@ -102,9 +103,16 @@
             matchesDisk = _currentUserMatchesDisk;
             currentUser = _currentUser;
         });
-        if (currentUser) {
-            return currentUser;
-        }
+		if (currentUser) {
+			// Verify that the current user matches our expected registered subclass
+			Class expectedClass = [[PFObjectSubclassingController defaultController] subclassForParseClassName:@"_User"];
+			if(expectedClass == [currentUser class]){
+				return currentUser;
+			} else {
+				matchesDisk = NO;
+				currentUser = nil;
+			}
+		}
 
         if (matchesDisk) {
             if (options & PFCurrentUserLoadingOptionCreateLazyIfNotAvailable) {


### PR DESCRIPTION
This is a fix for the issue identified in #963.

If the `_currentUser` object is set early on before a custom user subclass has been registered, it will never be updated with the subclassed user. As the current user loading is asynchronous this can create a race condition, and for some app launches `currentUser()` will return a PFUser and other times it will return your custom subclass.

This adds a check to verify that the cached user object is of the class that we expect to get. If it isn't, it continues with user loading which will create the correct class.

This all means that `currentUser()` will return a PFUser before the user subclass is registered, and a `MYUser` custom subclass after the registration completes. This seems like expected behavior and should prevent hard to track down bugs, especially in Swift projects where the + load method isn't available.

As an aside, it seems this issue may also be fixed by the merging of #5. That has been sitting around for a long time, and this PR should get us by until that old PR can be evaluated and merged.