### PR TITLE
Load bundle before resgistering subclasses

### DIFF
--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
@@ -128,6 +128,7 @@ static NSNumber *PFNumberCreateSafe(const char *typeEncoding, const void *bytes)
                                                                                             queue:nil
                                                                                        usingBlock:^(NSNotification *note) {
                                                                                            @strongify(self);
+                                                                                           [(NSBundle*)note.object load]; // Ensure bundle is completely loaded first
                                                                                            [self _registerSubclassesInBundle:note.object];
                                                                                        }];
     }


### PR DESCRIPTION
Intended to address https://github.com/ParsePlatform/Parse-SDK-iOS-OSX/issues/1006