### PR TITLE
Prevent crash by loading the bundle if it's not loaded yet (see: http…

### DIFF
--- a/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
+++ b/Parse/Internal/Object/Subclassing/PFObjectSubclassingController.m
@@ -339,6 +339,11 @@ static NSNumber *PFNumberCreateSafe(const char *typeEncoding, const void *bytes)
 }
 
 - (void)_registerSubclassesInBundle:(NSBundle *)bundle {
+    // Prevent crash by loading the bundle if it's not loaded yet (see: https://github.com/ParsePlatform/Parse-SDK-iOS-OSX/issues/1006 ):
+    NSError *error = nil;
+    if (!bundle.loaded) {
+        [bundle loadAndReturnError:&error];
+    }
     PFConsistencyAssert(bundle.loaded, @"Cannot register subclasses in a bundle that hasn't been loaded!");
 
     const char *executablePath = bundle.executablePath.UTF8String;


### PR DESCRIPTION
…s://github.com/ParsePlatform/Parse-SDK-iOS-OSX/issues/1006 ):

This is the fix from @funnel20. Just opening a PR to speed things along.