### PR TITLE
fix: `Parse.server` doesn't return server url

### DIFF
--- a/Parse/Parse/Source/Parse.m
+++ b/Parse/Parse/Source/Parse.m
@@ -135,7 +135,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
 + (nullable NSString *)server {
     ParseClientConfiguration *config = currentParseManager_ ? currentParseManager_.configuration
                                                             : currentParseConfiguration_;
-    return currentParseManager_.configuration.server;
+    return config.server;
 }
 
 ///--------------------------------------

--- a/Parse/Parse/Source/Parse.m
+++ b/Parse/Parse/Source/Parse.m
@@ -84,6 +84,7 @@ static ParseClientConfiguration *currentParseConfiguration_;
     [manager startManaging];
 
     currentParseManager_ = manager;
+    currentParseConfiguration_ = configuration;
 
 #if TARGET_OS_IOS
     [PFNetworkActivityIndicatorManager sharedManager].enabled = YES;

--- a/Parse/Tests/Unit/ParseClientConfigurationTests.m
+++ b/Parse/Tests/Unit/ParseClientConfigurationTests.m
@@ -10,6 +10,7 @@
 @import Foundation;
 
 #import "PFTestCase.h"
+#import "Parse_Private.h"
 #import "ParseClientConfiguration.h"
 #import "ParseClientConfiguration_Private.h"
 #import "PFExtensionDataSharingTestHelper.h"
@@ -143,6 +144,28 @@
         PFAssertThrowsInvalidArgumentException(configuration.server = @"");
         PFAssertThrowsInvalidArgumentException(configuration.server = @"Yolo Yarr");
     }];
+}
+
+- (void)testSetServerURL {
+    ParseClientConfiguration *config = [ParseClientConfiguration configurationWithBlock:^(id<ParseMutableClientConfiguration> configuration) {
+        configuration.applicationId = @"foo";
+        configuration.clientKey = @"bar";
+        configuration.server = @"http://localhost";
+        configuration.localDatastoreEnabled = YES;
+        configuration.networkRetryAttempts = 1337;
+    }];
+
+    [Parse initializeWithConfiguration:config];
+
+    XCTAssertEqualObjects(config.server, @"http://localhost");
+    XCTAssertEqualObjects(config.server, [Parse server]);
+
+    [Parse setServer:@"http://example.org"];
+    XCTAssertEqualObjects([Parse server], @"http://example.org");
+    
+    // Should get server from current config instead of manager
+    [Parse _clearCurrentManager];
+    XCTAssertEqualObjects([Parse server], @"http://example.org");
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-iOS-OSX/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-iOS-OSX/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
ParseClientConfiguration *config is never used, when the current parse manager isn't set no url is returned.

### Approach
<!-- Add a description of the approach in this PR. -->
* Get server URL from proper configuration
