### PR TITLE
ci: Replace third-party GitHub Actions with trusted alternatives

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -50,6 +50,13 @@ jobs:
     needs: release
     if: needs.release.outputs.current_tag != ''
     runs-on: macos-15
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -66,8 +73,12 @@ jobs:
           ./Scripts/jazzy.sh
         env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_16 }}
-      - name: Deploy Jazzy Docs
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          path: ./docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -12,6 +12,13 @@ jobs:
   publish-docs:
     if: github.event.inputs.tag != ''
     runs-on: macos-15
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,8 +36,12 @@ jobs:
           ./Scripts/jazzy.sh
         env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_16 }}
-      - name: Deploy Jazzy Docs
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          path: ./docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Replace untrusted third-party GitHub Actions with official alternatives to reduce supply chain attack surface.

## Changes
- Replace `peaceiris/actions-gh-pages` with official `actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages` pipeline

## Note
The repository Pages source setting must be changed to "GitHub Actions" in Settings > Pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation deployment workflow configuration to utilize official GitHub Pages Actions for deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->